### PR TITLE
test: add offline Go and Python suite for JOSS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build:
-    name: Build & vet
+    name: Build & test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -45,12 +45,15 @@ jobs:
       - name: Go vet
         run: go vet ./...
 
+      - name: Go test
+        run: go test ./backend/...
+
       # Ubuntu 24.04 ships webkit2gtk 4.1 only; target it via the build tag.
       - name: Go build
         run: go build -tags webkit2_41 ./...
 
   sidecar:
-    name: Sidecar lint
+    name: Sidecar tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -59,6 +62,19 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Install GDAL system libs
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gdal-bin libgdal-dev
+
+      - name: Install Python test deps
+        run: pip install -r requirements-dev.txt
 
       - name: Byte-compile sidecar
-        run: python -m py_compile sidecar/infer.py
+        run: python -m py_compile sidecar/*.py
+
+      - name: Pytest
+        run: pytest sidecar/tests -q

--- a/README.md
+++ b/README.md
@@ -117,6 +117,20 @@ wails dev
 
 Starts Vite with hot reload and the Go backend with the bridge bindings.
 
+## Testing
+
+Automated tests cover the SQLite store, area/model path resolution, vegetation
+indices, phenology, LULC metrics, and a smoke load of the spectral Random Forest
+artifacts. They run offline (no Planetary Computer / network) and are executed
+on every push and pull request to `main` via GitHub Actions.
+
+```bash
+go test ./backend/...
+
+pip install -r requirements-dev.txt
+pytest sidecar/tests -q
+```
+
 ## Build
 
 ```bash

--- a/backend/sidecar_test.go
+++ b/backend/sidecar_test.go
@@ -1,0 +1,108 @@
+package backend
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Dir(filepath.Dir(file))
+}
+
+func TestNewRunnerListAreasAndModelDir(t *testing.T) {
+	root := repoRoot(t)
+	t.Setenv("GEOSENSE_APP_DIR", root)
+	t.Setenv("GEOSENSE_MODEL_DIR", "")
+	t.Setenv("GEOSENSE_PYTHON", "python3")
+	t.Setenv("GEOSENSE_ROOT", filepath.Dir(root))
+
+	r, err := NewRunner(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.ModelDir() != filepath.Join(root, "model") {
+		t.Fatalf("ModelDir=%s want %s", r.ModelDir(), filepath.Join(root, "model"))
+	}
+	if r.PythonPath() != "python3" {
+		t.Fatalf("PythonPath=%s want python3", r.PythonPath())
+	}
+
+	areas := r.ListAreas()
+	if len(areas) != 3 {
+		t.Fatalf("ListAreas len=%d want 3", len(areas))
+	}
+	ids := map[string]bool{}
+	for _, a := range areas {
+		ids[a.ID] = true
+		if a.Geometry.Type != "Polygon" {
+			t.Fatalf("area %s geometry type=%s", a.ID, a.Geometry.Type)
+		}
+		if len(a.Geometry.Coordinates) == 0 || len(a.Geometry.Coordinates[0]) < 4 {
+			t.Fatalf("area %s has incomplete polygon", a.ID)
+		}
+		if a.Bounds.LonMax <= a.Bounds.LonMin || a.Bounds.LatMax <= a.Bounds.LatMin {
+			t.Fatalf("area %s has invalid bounds: %+v", a.ID, a.Bounds)
+		}
+	}
+	for _, id := range []string{"A", "B", "C"} {
+		if !ids[id] {
+			t.Fatalf("missing area %s", id)
+		}
+		if _, ok := r.loadArea(id); !ok {
+			t.Fatalf("loadArea(%s) failed", id)
+		}
+	}
+	if _, ok := r.loadArea("Z"); ok {
+		t.Fatal("loadArea(Z) should fail")
+	}
+}
+
+func TestPngToDataURI(t *testing.T) {
+	// 1x1 transparent PNG
+	raw, err := base64.StdEncoding.DecodeString(
+		"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "pixel.png")
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	uri, err := pngToDataURI(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(uri, "data:image/png;base64,") {
+		t.Fatalf("unexpected URI prefix: %s", uri[:min(40, len(uri))])
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(uri, "data:image/png;base64,"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded) != len(raw) {
+		t.Fatalf("decoded len=%d want %d", len(decoded), len(raw))
+	}
+}
+
+func TestConvertLULCNilSafe(t *testing.T) {
+	if convertLULC(nil) != nil {
+		t.Fatal("expected nil")
+	}
+	out := convertLULC(&lulcSidecarPayload{Year: 2023, Source: "test"})
+	if out == nil || out.Year != 2023 {
+		t.Fatalf("unexpected: %+v", out)
+	}
+	if out.Composition == nil || out.Groups == nil || out.PredVsRef == nil {
+		t.Fatal("nil slices should be normalized to empty")
+	}
+}

--- a/backend/store/store_test.go
+++ b/backend/store/store_test.go
@@ -1,38 +1,111 @@
 package store
 
 import (
-  "fmt"
-  "os"
-  "path/filepath"
-  "testing"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
 )
 
+func openTestStore(t *testing.T) *Store {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+	s, err := Open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
 func TestRegisterLoginPrefsRuns(t *testing.T) {
-  tmp := t.TempDir()
-  // Open uses UserConfigDir; override HOME/XDG for test
-  t.Setenv("HOME", tmp)
-  t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
-  s, err := Open()
-  if err != nil { t.Fatal(err) }
-  defer s.Close()
-  email := fmt.Sprintf("t%d@ex.com", os.Getpid())
-  u, _, err := s.Register(email, "secret12", "Tester")
-  if err != nil { t.Fatal(err) }
-  if u.DisplayName != "Tester" { t.Fatal(u) }
-  _, _, err = s.Login(email, "wrong")
-  if err == nil { t.Fatal("expected bad login") }
-  u2, tok, err := s.Login(email, "secret12")
-  if err != nil { t.Fatal(err) }
-  if tok == "" { t.Fatal("empty token") }
-  p, err := s.GetPreferences(u2.ID)
-  if err != nil { t.Fatal(err) }
-  p.DefaultModel = "prithvi"
-  if err := s.SavePreferences(*p); err != nil { t.Fatal(err) }
-  _, err = s.SaveRun(InferenceRun{
-    UserID: u2.ID, ModelKind: "spectral", PeriodStart: "2024-01-01", PeriodEnd: "2024-12-31",
-    PolygonGeoJSON: "{}", Status: "ok", SummaryJSON: "{}", NDates: 2,
-  })
-  if err != nil { t.Fatal(err) }
-  runs, err := s.ListRuns(u2.ID, 10)
-  if err != nil || len(runs) != 1 { t.Fatalf("runs=%v err=%v", runs, err) }
+	s := openTestStore(t)
+	email := fmt.Sprintf("t%d@ex.com", os.Getpid())
+	u, _, err := s.Register(email, "secret12", "Tester")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.DisplayName != "Tester" {
+		t.Fatal(u)
+	}
+	_, _, err = s.Login(email, "wrong")
+	if err == nil {
+		t.Fatal("expected bad login")
+	}
+	u2, tok, err := s.Login(email, "secret12")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok == "" {
+		t.Fatal("empty token")
+	}
+	p, err := s.GetPreferences(u2.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.DefaultModel = "prithvi"
+	if err := s.SavePreferences(*p); err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.SaveRun(InferenceRun{
+		UserID: u2.ID, ModelKind: "spectral", PeriodStart: "2024-01-01", PeriodEnd: "2024-12-31",
+		PolygonGeoJSON: "{}", Status: "ok", SummaryJSON: "{}", NDates: 2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runs, err := s.ListRuns(u2.ID, 10)
+	if err != nil || len(runs) != 1 {
+		t.Fatalf("runs=%v err=%v", runs, err)
+	}
+}
+
+func TestLogoutAndGetRun(t *testing.T) {
+	s := openTestStore(t)
+	email := fmt.Sprintf("logout%d@ex.com", os.Getpid())
+	_, tok, err := s.Register(email, "secret12", "Logout")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.UserFromSession(tok); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Logout(tok); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.UserFromSession(tok); err == nil {
+		t.Fatal("expected unauthorized after logout")
+	}
+
+	saved, err := s.SaveRun(InferenceRun{
+		UserID: LocalUserID, ModelKind: "spectral", PeriodStart: "2023-01-01", PeriodEnd: "2023-06-30",
+		PolygonGeoJSON: `{"type":"Polygon"}`, Status: "ok", SummaryJSON: `{"n":1}`, NDates: 3, Label: "guest",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetRun("", saved.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Label != "guest" || got.UserID != LocalUserID || got.NDates != 3 {
+		t.Fatalf("GetRun mismatch: %+v", got)
+	}
+	runs, err := s.ListRuns("", 5)
+	if err != nil || len(runs) != 1 {
+		t.Fatalf("guest ListRuns=%v err=%v", runs, err)
+	}
+}
+
+func TestLocalUserExists(t *testing.T) {
+	s := openTestStore(t)
+	u, err := s.GetUser(LocalUserID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.Email != LocalUserEmail {
+		t.Fatalf("local user email=%s", u.Email)
+	}
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,9 @@
+# Dev / CI dependencies for sidecar unit tests (offline; no torch).
+pytest>=8.0
+numpy>=1.26
+scipy>=1.11
+shapely>=2.0
+pyproj>=3.6
+rasterio>=1.3
+joblib>=1.3
+scikit-learn>=1.8,<1.9

--- a/sidecar/tests/conftest.py
+++ b/sidecar/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Make sidecar modules importable as top-level packages (infer, phenology, lulc)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SIDECAR_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = SIDECAR_DIR.parent
+
+if str(SIDECAR_DIR) not in sys.path:
+    sys.path.insert(0, str(SIDECAR_DIR))

--- a/sidecar/tests/test_infer.py
+++ b/sidecar/tests/test_infer.py
@@ -1,0 +1,105 @@
+"""Unit tests for vegetation indices, features, and RF smoke (offline)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import joblib
+import numpy as np
+import pytest
+
+import infer
+
+MODEL_DIR = Path(__file__).resolve().parents[2] / "model"
+
+
+def test_calculate_ndvi_known_values():
+    nir = np.array([[0.8, 0.2]], dtype=float)
+    red = np.array([[0.2, 0.2]], dtype=float)
+    ndvi = infer.calculate_ndvi(nir, red)
+    assert ndvi.shape == (1, 2)
+    assert abs(ndvi[0, 0] - 0.6) < 1e-6
+    assert abs(ndvi[0, 1] - 0.0) < 1e-6
+
+
+def test_calculate_ndvi_zero_denominator():
+    ndvi = infer.calculate_ndvi(np.zeros((2, 2)), np.zeros((2, 2)))
+    assert np.all(ndvi == 0)
+
+
+def test_calculate_evi_and_savi_finite():
+    nir = np.full((3, 3), 0.5)
+    red = np.full((3, 3), 0.2)
+    blue = np.full((3, 3), 0.1)
+    evi = infer.calculate_evi(nir, red, blue)
+    savi = infer.calculate_savi(nir, red)
+    assert np.all(np.isfinite(evi))
+    assert np.all(np.isfinite(savi))
+    assert np.all((-1 <= evi) & (evi <= 1))
+    assert np.all((-1 <= savi) & (savi <= 1))
+
+
+def test_compute_index_features_shape():
+    # 4 pixels × 6 timesteps
+    ts = np.random.default_rng(0).random((4, 6))
+    feat = infer.compute_index_features(ts)
+    assert feat.shape == (4, 14)
+
+
+def test_polygon_from_geojson():
+    geom = {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [-53.54, -25.10],
+                [-53.53, -25.10],
+                [-53.53, -25.09],
+                [-53.54, -25.09],
+                [-53.54, -25.10],
+            ]
+        ],
+    }
+    poly = infer.polygon_from_geojson(geom)
+    assert poly.is_valid
+    assert poly.area > 0
+
+
+def test_class_statistics():
+    cmap = np.array([[39, 39, 3], [21, -1, 3]], dtype=np.int32)
+    stats = infer.class_statistics(cmap)
+    assert stats
+    assert stats[0]["pixels"] >= stats[-1]["pixels"]
+    total_pct = sum(s["pct"] for s in stats)
+    assert abs(total_pct - 100.0) < 0.1
+    ids = {s["class_id"] for s in stats}
+    assert -1 not in ids
+
+
+@pytest.mark.skipif(
+    not (MODEL_DIR / "rf_classifier.joblib").is_file(),
+    reason="trained RF artifacts not present",
+)
+def test_classify_from_features_rf_smoke():
+    model = joblib.load(MODEL_DIR / "rf_classifier.joblib")
+    scaler = joblib.load(MODEL_DIR / "scaler.joblib")
+    label_encoder = joblib.load(MODEL_DIR / "label_encoder.joblib")
+    feature_names = joblib.load(MODEL_DIR / "feature_names.joblib")
+    n_feat = len(feature_names)
+    assert n_feat == 80
+
+    h, w = 4, 5
+    valid = np.ones((h, w), dtype=bool)
+    valid[0, 0] = False
+    n_valid = int(valid.sum())
+    rng = np.random.default_rng(42)
+    # Mild random features in a plausible reflectance/index range
+    X = rng.normal(loc=0.3, scale=0.1, size=(n_valid, n_feat))
+
+    cmap, conf = infer.classify_from_features(X, valid, model, scaler, label_encoder)
+    assert cmap.shape == (h, w)
+    assert conf.shape == (h, w)
+    assert cmap[0, 0] == -1
+    preds = cmap[valid]
+    assert set(preds.tolist()).issubset(set(label_encoder.classes_.tolist()))
+    assert np.all(conf[valid] > 0)
+    assert conf[0, 0] == 0

--- a/sidecar/tests/test_lulc.py
+++ b/sidecar/tests/test_lulc.py
@@ -1,0 +1,68 @@
+"""Unit tests for MapBiomas LULC descriptive helpers (offline)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+import lulc
+
+
+def test_hex_to_rgb():
+    assert lulc.hex_to_rgb("#006d2c") == (0, 109, 44)
+    assert lulc.hex_to_rgb("4292c6") == (66, 146, 198)
+
+
+def test_pixel_area_ha_positive():
+    ha = lulc.pixel_area_ha((0.0001, -0.0001), lat=-25.0)
+    assert ha > 0
+
+
+def test_shannon_and_pielou():
+    h = lulc.shannon_diversity([50.0, 50.0])
+    assert abs(h - np.log(2)) < 1e-6
+    assert abs(lulc.pielou_evenness(h, 2) - 1.0) < 1e-6
+    assert lulc.shannon_diversity([]) == 0.0
+    assert lulc.pielou_evenness(0.5, 1) == 0.0
+
+
+def test_composition_from_array():
+    arr = np.array([[39, 39, 3], [21, 0, 3]], dtype=np.int32)
+    rows = lulc.composition_from_array(arr, px_ha=0.01)
+    assert rows
+    ids = {r["class_id"] for r in rows}
+    assert 0 not in ids  # nodata excluded
+    assert 39 in ids and 3 in ids
+    assert abs(sum(r["pct"] for r in rows) - 100.0) < 0.1
+    assert rows[0]["area_ha"] >= rows[-1]["area_ha"]
+
+
+def test_metrics_from_composition():
+    arr = np.full((10, 10), 39, dtype=np.int32)
+    arr[:3, :] = 3
+    composition = lulc.composition_from_array(arr, px_ha=0.01)
+    metrics = lulc.metrics_from_composition(composition, area_ha=1.0, n_pixels=100)
+    assert metrics["n_classes"] == 2
+    assert metrics["dominant_class"]
+    assert metrics["shannon_h"] > 0
+    assert 0 <= metrics["pielou_j"] <= 1
+    assert metrics["soja_pct"] > 0
+
+
+def test_groups_from_composition():
+    composition = [
+        {
+            "group": "Annual cropland (soybean)",
+            "pct": 60.0,
+            "area_ha": 6.0,
+            "class_id": 39,
+        },
+        {
+            "group": "Natural vegetation",
+            "pct": 40.0,
+            "area_ha": 4.0,
+            "class_id": 3,
+        },
+    ]
+    groups = lulc.groups_from_composition(composition)
+    assert len(groups) == 2
+    assert abs(sum(g["pct"] for g in groups) - 100.0) < 0.01

--- a/sidecar/tests/test_phenology.py
+++ b/sidecar/tests/test_phenology.py
@@ -1,0 +1,63 @@
+"""Unit tests for phenology helpers (synthetic NDVI curves, offline)."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import numpy as np
+
+import phenology
+
+
+def _seasonal_ndvi(n: int = 24) -> tuple[np.ndarray, list[str]]:
+    """Bell-shaped NDVI over one calendar year (soy-like phenology)."""
+    start = date(2023, 1, 1)
+    dates = [(start + timedelta(days=15 * i)).isoformat() for i in range(n)]
+    # Peak around sample 12–14 (≈ mid year)
+    t = np.linspace(0, 2 * np.pi, n)
+    ndvi = 0.15 + 0.55 * (0.5 * (1 - np.cos(t)))
+    return ndvi.astype(float), dates
+
+
+def test_assign_states_short_series():
+    states = phenology.assign_states_from_ndvi(np.array([0.1, 0.2]))
+    assert len(states) == 2
+    assert set(states.tolist()).issubset(set(range(5)))
+
+
+def test_assign_states_seasonal_includes_greenup_and_mature():
+    ndvi, _ = _seasonal_ndvi()
+    states = phenology.assign_states_from_ndvi(ndvi)
+    assert len(states) == len(ndvi)
+    assert phenology.STATE_GREENUP in states or phenology.STATE_MATURE in states
+    assert set(states.tolist()).issubset(set(range(5)))
+
+
+def test_phenology_metrics_coherent_order():
+    ndvi, dates = _seasonal_ndvi()
+    m = phenology.phenology_metrics(ndvi, dates)
+    assert m["peak"] is not None and m["base"] is not None
+    assert m["amplitude"] is not None and m["amplitude"] > 0
+    assert m["sos_doy"] is not None
+    assert m["pos_doy"] is not None
+    assert m["eos_doy"] is not None
+    # Length of season non-negative; peak between SOS and EOS in ordinal sense
+    assert m["los_days"] is not None and m["los_days"] >= 0
+    assert m["peak"] > m["base"]
+
+
+def test_phenology_metrics_too_few_points():
+    m = phenology.phenology_metrics([0.1, 0.2, 0.3], ["2023-01-01", "2023-01-15", "2023-02-01"])
+    assert m["sos_doy"] is None
+    assert m["peak"] is None
+
+
+def test_state_timeline_length_and_fields():
+    ndvi, dates = _seasonal_ndvi(12)
+    timeline = phenology.state_timeline(ndvi, dates)
+    assert len(timeline) == 12
+    for row in timeline:
+        assert "date" in row and "state" in row and "state_name" in row
+        assert row["state"] in phenology.STATE_NAMES
+        assert row["state_name"] == phenology.STATE_NAMES[row["state"]]
+        assert row["color"] == phenology.STATE_COLORS[row["state"]]


### PR DESCRIPTION
## Summary
- Add automated offline tests for the SQLite store, area/model path resolution, vegetation indices, phenology, LULC metrics, and a spectral RF artifact smoke path
- Wire `go test ./backend/...` and `pytest sidecar/tests` into GitHub Actions
- Document how to run the suite in the README (JOSS “Good” testing criterion)

## Test plan
- [ ] CI passes on this PR (`Build & test` + `Sidecar tests`)
- [ ] Locally: `go test ./backend/...`
- [ ] Locally: `pip install -r requirements-dev.txt && pytest sidecar/tests -q`


Made with [Cursor](https://cursor.com)