### PR TITLE
chore(release): brand artifacts and links as TERRA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,15 +19,15 @@ jobs:
           - name: macOS (universal)
             os: macos-latest
             platform: darwin/universal
-            artifact: geosense-macOS-universal.zip
+            artifact: TERRA-macOS-universal.zip
           - name: Windows (amd64)
             os: windows-latest
             platform: windows/amd64
-            artifact: geosense-Windows-amd64.zip
+            artifact: TERRA-Windows-amd64.zip
           - name: Linux (amd64)
             os: ubuntu-latest
             platform: linux/amd64
-            artifact: geosense-Linux-amd64.zip
+            artifact: TERRA-Linux-amd64.zip
 
     steps:
       - uses: actions/checkout@v4
@@ -116,7 +116,7 @@ jobs:
           draft: false
           prerelease: false
           body: |
-            ## geosense-infer ${{ github.ref_name }}
+            ## TERRA ${{ github.ref_name }}
 
             Desktop builds for macOS, Windows, and Linux.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The spectral Random Forest path reproduces the method described in:
 ## Download
 
 Prebuilt desktop bundles for macOS, Windows, and Linux are attached to each
-[release](https://github.com/rexionmars/geosense/releases).
+[release](https://github.com/rexionmars/TERRA/releases).
 
 > **Runtime requirement.** The TERRA bundles include the UI and the trained model but
 > run inference through a local Python 3.12 with `rasterio`, `scikit-learn`,


### PR DESCRIPTION
## Summary
- Update README release link to `rexionmars/TERRA`
- Rename release zip artifacts and notes from geosense to TERRA for the next cut

## Test plan
- [ ] Merge, then tag `v0.2.0` and confirm the Release workflow uploads `TERRA-*.zip`


Made with [Cursor](https://cursor.com)