### PR TITLE
feat(release): LITE and FULL installers with bundled Python

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,24 +10,54 @@ permissions:
 
 jobs:
   build:
-    name: Build ${{ matrix.name }}
+    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: macOS (universal)
+          # LITE — UI + sidecar/areas/model; needs system Python
+          - name: macOS lite (universal)
             os: macos-latest
             platform: darwin/universal
-            artifact: TERRA-macOS-universal.zip
-          - name: Windows (amd64)
+            flavor: lite
+            artifact: TERRA-macOS-universal-lite.zip
+            package_os: darwin
+          - name: Windows lite (amd64)
             os: windows-latest
             platform: windows/amd64
-            artifact: TERRA-Windows-amd64.zip
-          - name: Linux (amd64)
+            flavor: lite
+            artifact: TERRA-Windows-amd64-lite.zip
+            package_os: windows
+          - name: Linux lite (amd64)
             os: ubuntu-latest
             platform: linux/amd64
-            artifact: TERRA-Linux-amd64.zip
+            flavor: lite
+            artifact: TERRA-Linux-amd64-lite.zip
+            package_os: linux
+
+          # FULL — embeds python-build-standalone + requirements.txt (spectral RF)
+          - name: macOS full (arm64)
+            os: macos-latest
+            platform: darwin/arm64
+            flavor: full
+            artifact: TERRA-macOS-arm64-full.zip
+            package_os: darwin
+            arch: aarch64
+          - name: Windows full (amd64)
+            os: windows-latest
+            platform: windows/amd64
+            flavor: full
+            artifact: TERRA-Windows-amd64-full.zip
+            package_os: windows
+            arch: x86_64
+          - name: Linux full (amd64)
+            os: ubuntu-latest
+            platform: linux/amd64
+            flavor: full
+            artifact: TERRA-Linux-amd64-full.zip
+            package_os: linux
+            arch: x86_64
 
     steps:
       - uses: actions/checkout@v4
@@ -49,10 +79,17 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev zip
 
       - name: Install Wails CLI
         run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0
+
+      - name: Cache python-build-standalone
+        if: matrix.flavor == 'full'
+        uses: actions/cache@v4
+        with:
+          path: build/cache
+          key: pbs-20260728-3.12.13-${{ matrix.package_os }}-${{ matrix.arch }}
 
       # Ubuntu 24.04 ships webkit2gtk 4.1 only; tell Wails to target it.
       - name: Build (Linux)
@@ -63,38 +100,29 @@ jobs:
         if: runner.os != 'Linux'
         run: wails build -platform ${{ matrix.platform }} -clean
 
-      # --- package per platform ---
-
-      - name: Package (macOS)
-        if: runner.os == 'macOS'
+      - name: Package (Unix)
+        if: runner.os != 'Windows'
         run: |
-          cd build/bin
-          app=$(ls -d *.app | head -n1)
-          echo "packaging $app"
-          ditto -c -k --keepParent "$app" "../../${{ matrix.artifact }}"
+          chmod +x scripts/package_release.sh
+          args=(--flavor "${{ matrix.flavor }}" --os "${{ matrix.package_os }}" --artifact "${{ matrix.artifact }}")
+          if [ -n "${{ matrix.arch }}" ]; then
+            args+=(--arch "${{ matrix.arch }}")
+          fi
+          scripts/package_release.sh "${args[@]}"
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          $exe = Get-ChildItem build/bin -Filter *.exe | Select-Object -First 1
-          Write-Host "packaging $($exe.Name)"
-          Compress-Archive -Path $exe.FullName -DestinationPath ${{ matrix.artifact }}
-
-      - name: Package (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          cd build/bin
-          bin=$(find . -maxdepth 1 -type f ! -name "*.*" | head -n1)
-          echo "packaging $bin"
-          chmod +x "$bin" || true
-          zip -j "../../${{ matrix.artifact }}" "$bin"
+          $arch = "${{ matrix.arch }}"
+          if ($arch -eq "") { $arch = "x86_64" }
+          ./scripts/package_release.ps1 -Flavor ${{ matrix.flavor }} -Artifact ${{ matrix.artifact }} -Arch $arch
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: ${{ matrix.artifact }}
+          path: dist/${{ matrix.artifact }}
           if-no-files-found: error
 
   release:
@@ -118,14 +146,20 @@ jobs:
           body: |
             ## TERRA ${{ github.ref_name }}
 
-            Desktop builds for macOS, Windows, and Linux.
+            Two install flavors per platform:
 
-            **Runtime requirement.** These builds bundle the UI and the trained
-            model but rely on a local Python 3.12 with the inference
-            dependencies (`rasterio`, `scikit-learn`, `pyproj`, `shapely`,
-            `joblib`, `numpy`, `pystac-client`, `planetary-computer`). Point the
-            app at it with the `GEOSENSE_PYTHON` environment variable if it is
-            not on `PATH`. See the README for details.
+            | Flavor | Assets | What you need |
+            |--------|--------|----------------|
+            | **FULL** | `*-full.zip` | Unzip and run — embeds Python 3.12 + spectral RF deps |
+            | **LITE** | `*-lite.zip` | Smaller; install Python 3.12 + `requirements.txt` yourself |
+
+            **FULL** supports spectral Random Forest (and LULC / phenology) out of the box.
+            Temporal Transformer and Prithvi still need torch (`requirements-prithvi.txt`)
+            via a system/venv install (`GEOSENSE_PYTHON`).
+
+            macOS FULL is **arm64** (Apple Silicon). LITE macOS remains **universal**.
 
             Sentinel-2 imagery is read on demand from the Microsoft Planetary
             Computer STAC catalog; no full product download is required.
+
+            See [docs/INSTALL.md](https://github.com/rexionmars/TERRA/blob/main/docs/INSTALL.md).

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Build output
 build/bin/
+build/cache/
+build/stage-*/
+dist/
 
 # Frontend
 node_modules/

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ account for the app itself.
 | Doc | Contents |
 |-----|----------|
 | [User guide](docs/USER_GUIDE.md) | AOI → classify → Analysis → Compare |
-| [Install](docs/INSTALL.md) | Binary + Python env + from-source |
+| [Install](docs/INSTALL.md) | LITE vs FULL releases, Python env, from-source |
 | [Architecture](docs/ARCHITECTURE.md) | Wails shell, sidecar, STAC/COG design |
 | [API](docs/API.md) | Go bindings and sidecar JSON contracts |
 | [Troubleshooting](docs/TROUBLESHOOTING.md) | Python, STAC, models, macOS |
@@ -57,9 +57,10 @@ account for the app itself.
 
 ## Quick start
 
-1. Install Python 3.12 deps: `pip install -r requirements.txt` (see [Install](docs/INSTALL.md)).
-2. Download a [release](https://github.com/rexionmars/TERRA/releases) **or** run `wails dev` from source.
-3. Set `GEOSENSE_PYTHON` if needed, then open TERRA.
+1. Prefer a **FULL** release zip (embeds Python) — or install Python 3.12 +
+   `pip install -r requirements.txt` for **LITE** (see [Install](docs/INSTALL.md)).
+2. Download from [releases](https://github.com/rexionmars/TERRA/releases) **or** run `wails dev` from source.
+3. Open TERRA (set `GEOSENSE_PYTHON` only if using LITE / a custom interpreter).
 4. Select embedded area **A** (or draw an AOI), set a seasonal date range, model **spectral**.
 5. Click **Classify** and inspect overlays / class stats in Analysis.
 
@@ -95,13 +96,16 @@ Full walkthrough: [docs/USER_GUIDE.md](docs/USER_GUIDE.md).
 ## Download
 
 Prebuilt desktop bundles for macOS, Windows, and Linux are attached to each
-[release](https://github.com/rexionmars/TERRA/releases)
-(`TERRA-macOS-universal.zip`, `TERRA-Windows-amd64.zip`, `TERRA-Linux-amd64.zip`).
+[release](https://github.com/rexionmars/TERRA/releases). Two flavors:
 
-> **Runtime requirement.** Bundles include the UI and trained models but run
-> inference through a local Python 3.12 environment. Install with
-> `pip install -r requirements.txt` and set `GEOSENSE_PYTHON` if needed.
-> Details: [docs/INSTALL.md](docs/INSTALL.md).
+| Flavor | Example assets | Notes |
+|--------|----------------|-------|
+| **FULL** | `TERRA-macOS-arm64-full.zip`, `TERRA-*-amd64-full.zip` | Embeds Python 3.12 + spectral RF deps — unzip and run |
+| **LITE** | `TERRA-macOS-universal-lite.zip`, `TERRA-*-amd64-lite.zip` | Smaller; needs system Python + [`requirements.txt`](requirements.txt) |
+
+FULL covers **spectral** classification out of the box. Temporal Transformer /
+Prithvi still need torch (`requirements-prithvi.txt`). Details:
+[docs/INSTALL.md](docs/INSTALL.md).
 
 ## Architecture
 
@@ -131,11 +135,12 @@ Binding and JSON contracts: [docs/API.md](docs/API.md).
 
 ## Requirements
 
-- **Runtime (users):** Python 3.12 + [`requirements.txt`](requirements.txt)
+- **FULL release:** no system Python required for spectral RF
+- **LITE / from source:** Python 3.12 + [`requirements.txt`](requirements.txt)
 - **Prithvi (optional):** [`requirements-prithvi.txt`](requirements-prithvi.txt)
 - **From source:** Go 1.23+, Node.js 18+, [Wails CLI](https://wails.io)
 
-Interpreter resolution: `GEOSENSE_PYTHON` → `.venv/bin/python` → `python3` on `PATH`.
+Interpreter resolution: `GEOSENSE_PYTHON` → bundled `python/` (FULL) → `.venv` → `python3` on `PATH`.
 
 ## Development
 

--- a/backend/sidecar.go
+++ b/backend/sidecar.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -25,45 +26,101 @@ type Runner struct {
 	areasDir   string // path to embedded area GeoJSONs
 }
 
+func hasSidecar(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, "sidecar", "infer.py"))
+	return err == nil
+}
+
+// resolveAppDir finds the directory that contains sidecar/, areas/, and model/.
+// Order: GEOSENSE_APP_DIR, provided appDir, macOS Contents/Resources, then
+// parents of the executable.
+func resolveAppDir(appDir string) string {
+	if env := os.Getenv("GEOSENSE_APP_DIR"); env != "" {
+		return env
+	}
+	if hasSidecar(appDir) {
+		return appDir
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return appDir
+	}
+	dir := filepath.Dir(exe)
+	// Packaged macOS: …/Contents/MacOS/Terra → …/Contents/Resources
+	if filepath.Base(dir) == "MacOS" {
+		res := filepath.Join(filepath.Dir(dir), "Resources")
+		if hasSidecar(res) {
+			return res
+		}
+	}
+	for i := 0; i < 8; i++ {
+		if hasSidecar(dir) {
+			return dir
+		}
+		if filepath.Base(dir) == "Contents" {
+			res := filepath.Join(dir, "Resources")
+			if hasSidecar(res) {
+				return res
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return appDir
+}
+
+// resolvePython picks the interpreter: GEOSENSE_PYTHON, bundled python/,
+// repo .venv, then PATH.
+func resolvePython(appDir, repoRoot string) string {
+	if env := os.Getenv("GEOSENSE_PYTHON"); env != "" {
+		return env
+	}
+	bundled := []string{
+		filepath.Join(appDir, "python", "bin", "python3"),
+		filepath.Join(appDir, "python", "bin", "python"),
+		filepath.Join(appDir, "python", "python.exe"),
+		filepath.Join(appDir, "python", "python"),
+	}
+	for _, c := range bundled {
+		if _, err := os.Stat(c); err == nil {
+			return c
+		}
+	}
+	venvUnix := filepath.Join(repoRoot, ".venv", "bin", "python")
+	venvWin := filepath.Join(repoRoot, ".venv", "Scripts", "python.exe")
+	if runtime.GOOS == "windows" {
+		if _, err := os.Stat(venvWin); err == nil {
+			return venvWin
+		}
+		return "python"
+	}
+	if _, err := os.Stat(venvUnix); err == nil {
+		return venvUnix
+	}
+	return "python3"
+}
+
 // NewRunner resolves all required paths. appDir is the directory of the running
 // geosense-infer project (where sidecar/ and areas/ live). It is resolved from
 // (in order): GEOSENSE_APP_DIR, a candidate that actually contains sidecar/, or
 // the provided appDir.
 func NewRunner(appDir string) (*Runner, error) {
-	if env := os.Getenv("GEOSENSE_APP_DIR"); env != "" {
-		appDir = env
-	} else {
-		// When run from the project directory appDir already points at
-		// geosense-infer/. When launched as a packaged binary it may not, so
-		// probe the executable's directory and its parents for a sidecar/ dir.
-		if _, err := os.Stat(filepath.Join(appDir, "sidecar", "infer.py")); err != nil {
-			if exe, err := os.Executable(); err == nil {
-				dir := filepath.Dir(exe)
-				for i := 0; i < 6; i++ {
-					if _, err := os.Stat(filepath.Join(dir, "sidecar", "infer.py")); err == nil {
-						appDir = dir
-						break
-					}
-					dir = filepath.Dir(dir)
-				}
-			}
-		}
-	}
+	appDir = resolveAppDir(appDir)
 
 	repoRoot := filepath.Dir(appDir) // geosense-infer sits inside the repo
+	// Packaged apps keep assets under Resources; treat that as the app root.
+	if filepath.Base(appDir) == "Resources" {
+		// …/TERRA.app/Contents/Resources → repoRoot stays Contents (unused for models)
+		repoRoot = filepath.Dir(filepath.Dir(appDir))
+	}
 	if env := os.Getenv("GEOSENSE_ROOT"); env != "" {
 		repoRoot = env
 	}
 
-	python := os.Getenv("GEOSENSE_PYTHON")
-	if python == "" {
-		candidate := filepath.Join(repoRoot, ".venv", "bin", "python")
-		if _, err := os.Stat(candidate); err == nil {
-			python = candidate
-		} else {
-			python = "python3"
-		}
-	}
+	python := resolvePython(appDir, repoRoot)
 
 	sidecar := filepath.Join(appDir, "sidecar", "infer.py")
 	areasDir := filepath.Join(appDir, "areas")
@@ -112,7 +169,16 @@ func (r *Runner) Probe(ctx context.Context) (string, error) {
 	if ver == "" {
 		return "", fmt.Errorf("empty python version")
 	}
-	return fmt.Sprintf("sidecar ready · python %s · %s", ver, filepath.Base(r.sidecar)), nil
+	src := "system"
+	if strings.Contains(r.pythonPath, string(filepath.Separator)+"python"+string(filepath.Separator)) ||
+		strings.HasSuffix(filepath.Dir(filepath.Dir(r.pythonPath)), "python") ||
+		filepath.Base(filepath.Dir(r.pythonPath)) == "python" {
+		src = "bundled"
+	}
+	if os.Getenv("GEOSENSE_PYTHON") != "" {
+		src = "GEOSENSE_PYTHON"
+	}
+	return fmt.Sprintf("sidecar ready · python %s (%s) · %s", ver, src, filepath.Base(r.sidecar)), nil
 }
 
 // PythonPath returns the resolved interpreter path (for boot logs).

--- a/backend/sidecar_test.go
+++ b/backend/sidecar_test.go
@@ -94,15 +94,58 @@ func TestPngToDataURI(t *testing.T) {
 	}
 }
 
-func TestConvertLULCNilSafe(t *testing.T) {
-	if convertLULC(nil) != nil {
-		t.Fatal("expected nil")
+func TestNewRunnerPrefersBundledPython(t *testing.T) {
+	root := t.TempDir()
+	// Minimal sidecar tree
+	sid := filepath.Join(root, "sidecar")
+	if err := os.MkdirAll(sid, 0o755); err != nil {
+		t.Fatal(err)
 	}
-	out := convertLULC(&lulcSidecarPayload{Year: 2023, Source: "test"})
-	if out == nil || out.Year != 2023 {
-		t.Fatalf("unexpected: %+v", out)
+	if err := os.WriteFile(filepath.Join(sid, "infer.py"), []byte("# test\n"), 0o644); err != nil {
+		t.Fatal(err)
 	}
-	if out.Composition == nil || out.Groups == nil || out.PredVsRef == nil {
-		t.Fatal("nil slices should be normalized to empty")
+	bin := filepath.Join(root, "python", "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bundled := filepath.Join(bin, "python3")
+	if err := os.WriteFile(bundled, []byte("#!/bin/sh\necho fake\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("GEOSENSE_APP_DIR", root)
+	t.Setenv("GEOSENSE_PYTHON", "")
+	t.Setenv("GEOSENSE_MODEL_DIR", filepath.Join(root, "model"))
+	_ = os.MkdirAll(filepath.Join(root, "model"), 0o755)
+	_ = os.WriteFile(filepath.Join(root, "model", "rf_classifier.joblib"), []byte("x"), 0o644)
+
+	r, err := NewRunner(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.PythonPath() != bundled {
+		t.Fatalf("PythonPath=%s want bundled %s", r.PythonPath(), bundled)
 	}
 }
+
+func TestResolveAppDirResourcesLayout(t *testing.T) {
+	// Simulate macOS Resources layout without needing a real executable.
+	root := t.TempDir()
+	res := filepath.Join(root, "Contents", "Resources")
+	if err := os.MkdirAll(filepath.Join(res, "sidecar"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(res, "sidecar", "infer.py"), []byte("#\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GEOSENSE_APP_DIR", res)
+	t.Setenv("GEOSENSE_PYTHON", "python3")
+	r, err := NewRunner("/nonexistent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(r.sidecar, filepath.Join("Resources", "sidecar", "infer.py")) {
+		t.Fatalf("sidecar=%s", r.sidecar)
+	}
+}
+

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,20 +1,44 @@
 # Installation
 
 TERRA is a desktop app (Wails + React) with a Python sidecar for inference.
-Prebuilt bundles ship the UI and trained models; **Python 3.12 with the sidecar
-dependencies must be available on the machine**.
+Releases ship two flavors:
 
-## Option A — Prebuilt binary (recommended)
+| Flavor | Download name | Experience |
+|--------|---------------|------------|
+| **FULL** | `TERRA-*-full.zip` | Unzip and run — embeds Python 3.12 + spectral RF dependencies |
+| **LITE** | `TERRA-*-lite.zip` | Smaller UI + models; you provide Python 3.12 |
 
-1. Download the asset for your OS from
+Both include `sidecar/`, `areas/`, and `model/` next to the app binary.
+
+**FULL** covers spectral Random Forest, MapBiomas LULC, and phenology without a
+system Python. Temporal Transformer and Prithvi still need torch — use LITE (or
+FULL + override) with [`requirements-prithvi.txt`](../requirements-prithvi.txt).
+
+## Option A — FULL (recommended for most users)
+
+1. Download the **full** asset for your OS from
    [GitHub Releases](https://github.com/rexionmars/TERRA/releases)
-   (`TERRA-macOS-universal.zip`, `TERRA-Windows-amd64.zip`, or
-   `TERRA-Linux-amd64.zip`).
-2. Unzip and launch the app (`TERRA.app` / `Terra.exe` / `Terra`).
+   (`TERRA-macOS-arm64-full.zip`, `TERRA-Windows-amd64-full.zip`, or
+   `TERRA-Linux-amd64-full.zip`).
+2. Unzip and launch (`TERRA.app` / `Terra.exe` / `Terra`).
+3. Classify with model **spectral**.
+
+> macOS FULL is **Apple Silicon (arm64)**. Intel Macs should use LITE + a local
+> Python, or run from source.
+
+Optional override: set `GEOSENSE_PYTHON` to force a different interpreter even
+in FULL builds.
+
+## Option B — LITE (+ system Python)
+
+1. Download the **lite** asset
+   (`TERRA-macOS-universal-lite.zip`, `TERRA-Windows-amd64-lite.zip`, or
+   `TERRA-Linux-amd64-lite.zip`).
+2. Unzip and launch the app.
 3. Install the Python sidecar environment (next section) and point TERRA at it
    if needed.
 
-## Python sidecar environment
+### Python sidecar environment (LITE)
 
 Use Python **3.12**. From a clone of this repository (or any directory where you
 keep the env):
@@ -26,7 +50,8 @@ pip install -U pip
 pip install -r requirements.txt
 ```
 
-Optional Prithvi path (large; first run also downloads backbone weights):
+Optional Prithvi / Temporal Transformer path (large; first Prithvi run also
+downloads backbone weights):
 
 ```bash
 pip install -r requirements-prithvi.txt
@@ -43,8 +68,9 @@ pip install -r requirements-dev.txt
 Resolution order:
 
 1. `GEOSENSE_PYTHON` — absolute path to the interpreter
-2. `.venv/bin/python` at the parent of the app directory (monorepo layout)
-3. `python3` on `PATH`
+2. Bundled `python/` inside the app (FULL builds)
+3. `.venv` at the parent of the app directory (dev / monorepo layout)
+4. `python3` / `python` on `PATH`
 
 Examples:
 
@@ -57,7 +83,7 @@ export GEOSENSE_PYTHON="$HOME/venvs/terra/bin/python"
 On Windows, set a User environment variable `GEOSENSE_PYTHON` to
 `C:\path\to\.venv\Scripts\python.exe`.
 
-## Option B — From source (development)
+## Option C — From source (development)
 
 ### Dependencies
 
@@ -86,7 +112,10 @@ Production-style local binary:
 
 ```bash
 wails build
-# output under build/bin/
+# then optionally:
+scripts/package_release.sh --flavor lite --os darwin --artifact TERRA-local-lite.zip
+# or FULL (downloads python-build-standalone):
+scripts/package_release.sh --flavor full --os darwin --arch aarch64 --artifact TERRA-local-full.zip
 ```
 
 ### Configuration
@@ -102,7 +131,8 @@ wails build
 
 Serialized Random Forest artifacts in `model/` were produced with
 **scikit-learn 1.8.x**. Install a matching version (`requirements.txt` pins
-`>=1.8,<1.9`) or deserialization may warn or fail.
+`>=1.8,<1.9`) or deserialization may warn or fail. FULL builds install that pin
+into the bundled interpreter.
 
 ## Next steps
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -4,8 +4,9 @@
 
 ### “Python not found” or boot never becomes ready
 
-- Install Python 3.12 and `pip install -r requirements.txt`.
-- Set `GEOSENSE_PYTHON` to the absolute path of that interpreter.
+- Prefer a **FULL** release (`*-full.zip`), which embeds Python.
+- For **LITE**: install Python 3.12 and `pip install -r requirements.txt`.
+- Set `GEOSENSE_PYTHON` to the absolute path of that interpreter if needed.
 - Confirm: `"$GEOSENSE_PYTHON" -c "import rasterio, sklearn, pystac_client; print('ok')"`.
 
 ### `InconsistentVersionWarning` or joblib load errors

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -6,9 +6,10 @@ see [INSTALL.md](INSTALL.md). For common failures, see [TROUBLESHOOTING.md](TROU
 ## Prerequisites
 
 - A TERRA desktop build ([releases](https://github.com/rexionmars/TERRA/releases))
+  — prefer **FULL** (`*-full.zip`) for spectral RF without installing Python —
   **or** a from-source install (`wails dev` / `wails build`).
-- Python 3.12 with [`requirements.txt`](../requirements.txt) installed, and
-  `GEOSENSE_PYTHON` set if the interpreter is not on `PATH`.
+- For **LITE** builds: Python 3.12 with [`requirements.txt`](../requirements.txt),
+  and `GEOSENSE_PYTHON` if the interpreter is not on `PATH`.
 - Network access to the Microsoft Planetary Computer STAC catalog (and Hugging
   Face if you use Prithvi).
 

--- a/scripts/package_release.ps1
+++ b/scripts/package_release.ps1
@@ -1,0 +1,75 @@
+# Package TERRA release zips on Windows after `wails build`.
+# Usage:
+#   pwsh scripts/package_release.ps1 -Flavor lite|full -Artifact TERRA-Windows-amd64-lite.zip
+param(
+  [Parameter(Mandatory = $true)][ValidateSet("lite", "full")][string]$Flavor,
+  [Parameter(Mandatory = $true)][string]$Artifact,
+  [string]$Arch = "x86_64",
+  [string]$PbsTag = "20260728",
+  [string]$PbsPy = "3.12.13"
+)
+
+$ErrorActionPreference = "Stop"
+$Root = Resolve-Path (Join-Path $PSScriptRoot "..")
+Set-Location $Root
+$BinDir = Join-Path $Root "build\bin"
+$DistDir = Join-Path $Root "dist"
+$Stage = Join-Path $Root "build\stage-$Flavor"
+New-Item -ItemType Directory -Force -Path $DistDir | Out-Null
+if (Test-Path $Stage) { Remove-Item -Recurse -Force $Stage }
+New-Item -ItemType Directory -Force -Path $Stage | Out-Null
+
+function Copy-Assets([string]$Dest) {
+  New-Item -ItemType Directory -Force -Path $Dest | Out-Null
+  Copy-Item -Recurse (Join-Path $Root "sidecar") (Join-Path $Dest "sidecar")
+  Copy-Item -Recurse (Join-Path $Root "areas") (Join-Path $Dest "areas")
+  Copy-Item -Recurse (Join-Path $Root "model") (Join-Path $Dest "model")
+  Get-ChildItem -Path (Join-Path $Dest "sidecar") -Recurse -Directory -Filter "__pycache__" -ErrorAction SilentlyContinue |
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+$Exe = Get-ChildItem $BinDir -Filter "*.exe" | Select-Object -First 1
+if (-not $Exe) { throw "no .exe in $BinDir" }
+
+$OutDir = Join-Path $Stage "TERRA"
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+Copy-Item $Exe.FullName (Join-Path $OutDir "Terra.exe")
+Copy-Assets $OutDir
+
+if ($Flavor -eq "full") {
+  $Triple = switch ($Arch) {
+    "x86_64" { "x86_64-pc-windows-msvc" }
+    "amd64" { "x86_64-pc-windows-msvc" }
+    "aarch64" { "aarch64-pc-windows-msvc" }
+    default { throw "unsupported arch $Arch" }
+  }
+  $Name = "cpython-$PbsPy+$PbsTag-$Triple-install_only.tar.gz"
+  $Url = "https://github.com/astral-sh/python-build-standalone/releases/download/$PbsTag/$Name"
+  $Cache = Join-Path $Root "build\cache"
+  New-Item -ItemType Directory -Force -Path $Cache | Out-Null
+  $Tarball = Join-Path $Cache $Name
+  if (-not (Test-Path $Tarball)) {
+    Write-Host "downloading $Url"
+    Invoke-WebRequest -Uri $Url -OutFile $Tarball
+  }
+  $Tmp = Join-Path $env:TEMP ("terra-py-" + [guid]::NewGuid().ToString())
+  New-Item -ItemType Directory -Force -Path $Tmp | Out-Null
+  tar -xzf $Tarball -C $Tmp
+  $PySrc = Join-Path $Tmp "python"
+  if (-not (Test-Path $PySrc)) { throw "unexpected PBS layout" }
+  $PyDest = Join-Path $OutDir "python"
+  if (Test-Path $PyDest) { Remove-Item -Recurse -Force $PyDest }
+  Move-Item $PySrc $PyDest
+  Remove-Item -Recurse -Force $Tmp
+
+  $Py = Join-Path $PyDest "python.exe"
+  if (-not (Test-Path $Py)) { throw "bundled python.exe missing" }
+  & $Py -m pip install --upgrade pip
+  & $Py -m pip install -r (Join-Path $Root "requirements.txt")
+}
+
+$ZipPath = Join-Path $DistDir $Artifact
+if (Test-Path $ZipPath) { Remove-Item -Force $ZipPath }
+Compress-Archive -Path $OutDir -DestinationPath $ZipPath -Force
+Write-Host "wrote $ZipPath"
+Get-Item $ZipPath | Format-List FullName, Length

--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Package TERRA release zips (lite | full) after `wails build`.
+#
+# Usage:
+#   scripts/package_release.sh --flavor lite|full --os darwin|linux|windows \
+#       --artifact TERRA-macOS-arm64-full.zip [--arch aarch64|x86_64]
+#
+# Expects repo root as cwd. Copies sidecar/, areas/, model/ into the app bundle
+# or beside the binary. FULL also embeds python-build-standalone + requirements.txt.
+set -euo pipefail
+
+FLAVOR=""
+OS_NAME=""
+ARTIFACT=""
+ARCH=""
+PBS_TAG="${PBS_TAG:-20260728}"
+PBS_PY="${PBS_PY:-3.12.13}"
+
+usage() {
+  echo "usage: $0 --flavor lite|full --os darwin|linux|windows --artifact NAME.zip [--arch aarch64|x86_64]" >&2
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --flavor) FLAVOR="$2"; shift 2 ;;
+    --os) OS_NAME="$2"; shift 2 ;;
+    --artifact) ARTIFACT="$2"; shift 2 ;;
+    --arch) ARCH="$2"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[[ -n "$FLAVOR" && -n "$OS_NAME" && -n "$ARTIFACT" ]] || usage
+[[ "$FLAVOR" == "lite" || "$FLAVOR" == "full" ]] || usage
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+BIN_DIR="$ROOT/build/bin"
+DIST_DIR="$ROOT/dist"
+mkdir -p "$DIST_DIR"
+STAGE="$ROOT/build/stage-$FLAVOR"
+rm -rf "$STAGE"
+mkdir -p "$STAGE"
+
+copy_assets() {
+  local dest="$1"
+  mkdir -p "$dest"
+  cp -R "$ROOT/sidecar" "$dest/"
+  cp -R "$ROOT/areas" "$dest/"
+  cp -R "$ROOT/model" "$dest/"
+  # Drop Python caches from the tree
+  find "$dest/sidecar" -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true
+}
+
+pbs_triple() {
+  local arch="$1" osn="$2"
+  case "$osn" in
+    darwin)
+      case "$arch" in
+        aarch64|arm64) echo "aarch64-apple-darwin" ;;
+        x86_64|amd64) echo "x86_64-apple-darwin" ;;
+        *) echo "unsupported darwin arch: $arch" >&2; exit 1 ;;
+      esac
+      ;;
+    linux)
+      case "$arch" in
+        aarch64|arm64) echo "aarch64-unknown-linux-gnu" ;;
+        x86_64|amd64) echo "x86_64-unknown-linux-gnu" ;;
+        *) echo "unsupported linux arch: $arch" >&2; exit 1 ;;
+      esac
+      ;;
+    windows)
+      case "$arch" in
+        aarch64|arm64) echo "aarch64-pc-windows-msvc" ;;
+        x86_64|amd64) echo "x86_64-pc-windows-msvc" ;;
+        *) echo "unsupported windows arch: $arch" >&2; exit 1 ;;
+      esac
+      ;;
+    *) echo "unsupported os: $osn" >&2; exit 1 ;;
+  esac
+}
+
+detect_arch() {
+  case "$(uname -m)" in
+    arm64|aarch64) echo "aarch64" ;;
+    x86_64|amd64) echo "x86_64" ;;
+    *) uname -m ;;
+  esac
+}
+
+install_bundled_python() {
+  local dest="$1"
+  local arch="${ARCH:-$(detect_arch)}"
+  local triple
+  triple="$(pbs_triple "$arch" "$OS_NAME")"
+  local name="cpython-${PBS_PY}+${PBS_TAG}-${triple}-install_only.tar.gz"
+  local url="https://github.com/astral-sh/python-build-standalone/releases/download/${PBS_TAG}/${name}"
+  local cache="$ROOT/build/cache"
+  mkdir -p "$cache"
+  local tarball="$cache/$name"
+  if [[ ! -f "$tarball" ]]; then
+    echo "downloading $url"
+    curl -fL --retry 3 -o "$tarball" "$url"
+  fi
+  local tmp
+  tmp="$(mktemp -d)"
+  tar -xzf "$tarball" -C "$tmp"
+  # install_only extracts a top-level python/ directory
+  if [[ -d "$tmp/python" ]]; then
+    rm -rf "$dest/python"
+    mv "$tmp/python" "$dest/python"
+  else
+    echo "unexpected python-build-standalone layout" >&2
+    ls -la "$tmp" >&2
+    exit 1
+  fi
+  rm -rf "$tmp"
+
+  local py=""
+  if [[ -x "$dest/python/bin/python3" ]]; then
+    py="$dest/python/bin/python3"
+  elif [[ -x "$dest/python/python.exe" ]]; then
+    py="$dest/python/python.exe"
+  elif [[ -x "$dest/python/python" ]]; then
+    py="$dest/python/python"
+  else
+    echo "bundled python binary not found under $dest/python" >&2
+    exit 1
+  fi
+
+  echo "pip install -r requirements.txt into bundled python"
+  "$py" -m pip install --upgrade pip
+  "$py" -m pip install -r "$ROOT/requirements.txt"
+}
+
+case "$OS_NAME" in
+  darwin)
+    APP=$(ls -d "$BIN_DIR"/*.app 2>/dev/null | head -n1 || true)
+    [[ -n "$APP" ]] || { echo "no .app in $BIN_DIR" >&2; exit 1; }
+    APP_NAME=$(basename "$APP")
+    cp -R "$APP" "$STAGE/"
+    RES="$STAGE/$APP_NAME/Contents/Resources"
+    mkdir -p "$RES"
+    copy_assets "$RES"
+    if [[ "$FLAVOR" == "full" ]]; then
+      ARCH="${ARCH:-$(detect_arch)}"
+      install_bundled_python "$RES"
+    fi
+    (
+      cd "$STAGE"
+      ditto -c -k --keepParent "$APP_NAME" "$DIST_DIR/$ARTIFACT"
+    )
+    ;;
+  linux)
+    BIN=$(find "$BIN_DIR" -maxdepth 1 -type f ! -name "*.*" | head -n1 || true)
+    [[ -n "$BIN" ]] || { echo "no linux binary in $BIN_DIR" >&2; exit 1; }
+    mkdir -p "$STAGE/TERRA"
+    cp "$BIN" "$STAGE/TERRA/Terra"
+    chmod +x "$STAGE/TERRA/Terra"
+    copy_assets "$STAGE/TERRA"
+    if [[ "$FLAVOR" == "full" ]]; then
+      ARCH="${ARCH:-x86_64}"
+      install_bundled_python "$STAGE/TERRA"
+    fi
+    (
+      cd "$STAGE"
+      zip -r "$DIST_DIR/$ARTIFACT" TERRA
+    )
+    ;;
+  windows)
+    # Prefer PowerShell script on Windows runners; this branch supports Git Bash.
+    EXE=$(find "$BIN_DIR" -maxdepth 1 -type f -name "*.exe" | head -n1 || true)
+    [[ -n "$EXE" ]] || { echo "no .exe in $BIN_DIR" >&2; exit 1; }
+    mkdir -p "$STAGE/TERRA"
+    cp "$EXE" "$STAGE/TERRA/Terra.exe"
+    copy_assets "$STAGE/TERRA"
+    if [[ "$FLAVOR" == "full" ]]; then
+      ARCH="${ARCH:-x86_64}"
+      install_bundled_python "$STAGE/TERRA"
+    fi
+    (
+      cd "$STAGE"
+      if command -v zip >/dev/null 2>&1; then
+        zip -r "$DIST_DIR/$ARTIFACT" TERRA
+      else
+        powershell.exe -NoProfile -Command "Compress-Archive -Path TERRA -DestinationPath '$DIST_DIR/$ARTIFACT' -Force"
+      fi
+    )
+    ;;
+  *)
+    usage
+    ;;
+esac
+
+echo "wrote $DIST_DIR/$ARTIFACT"
+ls -lh "$DIST_DIR/$ARTIFACT"


### PR DESCRIPTION
## Summary
- Add LITE/FULL packaging scripts that always ship `sidecar/`, `areas/`, and `model/`
- FULL embeds python-build-standalone 3.12 + `requirements.txt` (spectral RF out of the box)
- `NewRunner` prefers bundled `python/`; release matrix publishes six zip artifacts
- Document LITE vs FULL in README and install/user/troubleshooting docs

## Test plan
- [ ] `go test ./backend/...`
- [ ] Local: `scripts/package_release.sh --flavor lite --os darwin --artifact TERRA-test-lite.zip` includes Resources/sidecar
- [ ] After merge, tag `v0.3.0` (or next) and confirm Release workflow uploads `*-lite.zip` and `*-full.zip`


Made with [Cursor](https://cursor.com)