### PR TITLE
docs: add SemVer releasing policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,13 @@ pytest sidecar/tests -q
 5. Prefer small, reviewable commits with imperative messages
    (e.g. `fix: handle empty STAC results`).
 
+## Releases
+
+Not every merge should produce a GitHub Release. We follow SemVer and only tag
+when shipping new binaries (or a critical install fix). See
+[docs/RELEASING.md](docs/RELEASING.md) for PATCH / MINOR / MAJOR rules and the
+pre-tag checklist.
+
 ## Code layout
 
 | Path | Role |

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ account for the app itself.
 |-----|----------|
 | [User guide](docs/USER_GUIDE.md) | AOI → classify → Analysis → Compare |
 | [Install](docs/INSTALL.md) | LITE vs FULL releases, Python env, from-source |
+| [Releasing](docs/RELEASING.md) | SemVer tags, when to bump, when not to release |
 | [Architecture](docs/ARCHITECTURE.md) | Wails shell, sidecar, STAC/COG design |
 | [API](docs/API.md) | Go bindings and sidecar JSON contracts |
 | [Troubleshooting](docs/TROUBLESHOOTING.md) | Python, STAC, models, macOS |

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -138,4 +138,5 @@ into the bundled interpreter.
 
 - [User guide](USER_GUIDE.md) — first classification
 - [Troubleshooting](TROUBLESHOOTING.md) — common errors
+- [Releasing](RELEASING.md) — SemVer / when to tag
 - [Contributing](../CONTRIBUTING.md) — tests and PRs

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,63 @@
+# Releasing TERRA
+
+TERRA uses [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`).
+Git tags use a `v` prefix (`v0.3.0`); the version itself is `0.3.0`.
+
+Pushing a tag matching `v*` runs [`.github/workflows/release.yml`](../.github/workflows/release.yml)
+and publishes LITE/FULL zip assets.
+
+## What counts as the “public API”
+
+For this desktop app, treat as user-facing surface:
+
+- Documented workflows (AOI → Classify → Analysis → Compare)
+- Install flavors (LITE / FULL) and layout of release zips
+- Environment variables (`GEOSENSE_*`) and sidecar JSON contracts
+- Documented model choices and runtime requirements
+
+Internal refactors, tests, and CI that do not change the above are not release-worthy by themselves.
+
+## When to bump
+
+| Bump | Tag example | Use when |
+|------|-------------|----------|
+| **PATCH** | `v0.2.1` | Bug fixes, packaging fixes, critical doc fixes for install — no new capability |
+| **MINOR** | `v0.3.0` | New backward-compatible capability (e.g. FULL installer, Compare, new optional model) |
+| **MAJOR** | `v1.0.0` | Breaking change to install/use contracts (removed env vars, incompatible sidecar/zip layout) |
+
+Precedence: if a release mixes types, use the **highest** bump (MAJOR > MINOR > PATCH).
+
+### Still in `0.y.z`
+
+Pre-1.0 means the product may evolve quickly. Prefer **MINOR** for features and
+**PATCH** for fixes. Reserve **`1.0.0`** for a stability milestone (e.g. after
+JOSS acceptance / production-ready install story).
+
+## Do not tag for every merge
+
+- Docs-only, wiki, CONTRIBUTING, or CI tweaks that do not change binaries →
+  **merge to `main` without a release tag**.
+- Batch several small fixes into one **PATCH** instead of daily micro-releases.
+- Uncertain builds → prerelease tags: `v0.3.0-rc.1` (still matches `v*`).
+
+## Checklist before `git tag`
+
+1. `main` is green (CI) and contains only what you intend to ship.
+2. Decide PATCH / MINOR / MAJOR with the table above.
+3. Update release notes mentally: what should users download (LITE vs FULL)?
+4. Tag and push:
+
+```bash
+git checkout main && git pull
+git tag -a v0.3.0 -m "TERRA v0.3.0 — short reason"
+git push origin v0.3.0
+```
+
+5. Confirm the Release workflow finished and assets appear on
+   [Releases](https://github.com/rexionmars/TERRA/releases).
+
+## Current line
+
+Latest published tags (see GitHub for the full list): `v0.1.0`, `v0.2.0`.
+The LITE/FULL packaging work on `main` is a **MINOR** when you next cut binaries
+(e.g. `v0.3.0`), not a jump to `1.0.0`.


### PR DESCRIPTION
## Summary
- Add `docs/RELEASING.md` with SemVer rules tailored to TERRA (desktop + LITE/FULL)
- Clarify when not to tag (docs-only merges) and that LITE/FULL ships as a MINOR (`v0.3.0`), not `1.0.0`
- Link from README, CONTRIBUTING, and INSTALL

## Test plan
- [ ] Links from README / CONTRIBUTING / INSTALL resolve on GitHub


Made with [Cursor](https://cursor.com)