### PR TITLE
feat(map): swipe compare and AOI right-click menu

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,10 @@ import type {
   DataCubeResult,
   DataCubeRequest,
 } from "@/lib/types"
+import {
+  DEFAULT_AOI_CONTOUR_SCHEME,
+  type AoiContourSchemeId,
+} from "@/lib/aoiStyle"
 import { AuthProvider, useAuth } from "@/lib/auth"
 import { ThemeSync } from "@/components/ThemeSync"
 import { TitleBar } from "@/components/TitleBar"
@@ -105,6 +109,10 @@ function App() {
   const [showConfidence, setShowConfidence] = useState(false)
   const [confidenceOnTop, setConfidenceOnTop] = useState(true)
   const [smoothOverlay, setSmoothOverlay] = useState(false)
+  const [swipeCompare, setSwipeCompare] = useState(false)
+  const [swipeRatio, setSwipeRatio] = useState(0.5)
+  const [aoiContourScheme, setAoiContourScheme] =
+    useState<AoiContourSchemeId>(DEFAULT_AOI_CONTOUR_SCHEME)
   const [running, setRunning] = useState<boolean>(false)
   const [progress, setProgress] = useState<number>(0)
   const [progressMsg, setProgressMsg] = useState<string>("")
@@ -274,6 +282,9 @@ function App() {
             showConfidence={showConfidence}
             confidenceOnTop={confidenceOnTop}
             smoothOverlay={smoothOverlay}
+            swipeCompare={swipeCompare}
+            swipeRatio={swipeRatio}
+            aoiContourScheme={aoiContourScheme}
             running={running}
             progress={progress}
             progressMsg={progressMsg}
@@ -295,6 +306,9 @@ function App() {
             setShowConfidence={setShowConfidence}
             setConfidenceOnTop={setConfidenceOnTop}
             setSmoothOverlay={setSmoothOverlay}
+            setSwipeCompare={setSwipeCompare}
+            setSwipeRatio={setSwipeRatio}
+            setAoiContourScheme={setAoiContourScheme}
             setRunning={setRunning}
             setProgress={setProgress}
             setProgressMsg={setProgressMsg}
@@ -329,6 +343,9 @@ function AppBody(props: {
   showConfidence: boolean
   confidenceOnTop: boolean
   smoothOverlay: boolean
+  swipeCompare: boolean
+  swipeRatio: number
+  aoiContourScheme: AoiContourSchemeId
   running: boolean
   progress: number
   progressMsg: string
@@ -350,6 +367,9 @@ function AppBody(props: {
   setShowConfidence: (v: boolean) => void
   setConfidenceOnTop: (v: boolean) => void
   setSmoothOverlay: (v: boolean) => void
+  setSwipeCompare: (v: boolean) => void
+  setSwipeRatio: (v: number) => void
+  setAoiContourScheme: (id: AoiContourSchemeId) => void
   setRunning: (v: boolean) => void
   setProgress: (v: number) => void
   setProgressMsg: (v: string) => void
@@ -585,15 +605,25 @@ function AppBody(props: {
   const backToAnalysesList = useCallback(() => {
     props.setResult(null)
     props.setAnalysisLabel(undefined)
+    props.setSwipeCompare(false)
     goAnalysis()
-  }, [goAnalysis, props.setResult, props.setAnalysisLabel])
+  }, [goAnalysis, props.setResult, props.setAnalysisLabel, props.setSwipeCompare])
 
   const startNewClassification = useCallback(() => {
     props.setResult(null)
     props.setAnalysisLabel(undefined)
+    props.setSwipeCompare(false)
+    props.setSwipeRatio(0.5)
     props.onClearArea()
     goMap()
-  }, [goMap, props.setResult, props.setAnalysisLabel, props.onClearArea])
+  }, [
+    goMap,
+    props.setResult,
+    props.setAnalysisLabel,
+    props.setSwipeCompare,
+    props.setSwipeRatio,
+    props.onClearArea,
+  ])
 
   const areaLabel = useMemo(() => {
     if (props.analysisLabel) return props.analysisLabel
@@ -628,7 +658,12 @@ function AppBody(props: {
               showConfidence={props.showConfidence}
               confidenceOnTop={props.confidenceOnTop}
               smoothOverlay={props.smoothOverlay}
+              swipeCompare={props.swipeCompare}
+              swipeRatio={props.swipeRatio}
               areaLabel={areaLabel}
+              onAreaLabelChange={(label) => props.setAnalysisLabel(label)}
+              aoiContourScheme={props.aoiContourScheme}
+              onAoiContourSchemeChange={props.setAoiContourScheme}
               hasArea={props.hasArea}
               start={props.start}
               end={props.end}
@@ -662,12 +697,16 @@ function AppBody(props: {
               onShowConfidenceChange={props.setShowConfidence}
               onConfidenceOnTopChange={props.setConfidenceOnTop}
               onSmoothOverlayChange={props.setSmoothOverlay}
+              onSwipeCompareChange={props.setSwipeCompare}
+              onSwipeRatioChange={props.setSwipeRatio}
               onRun={handleRun}
               onAnalyzeLULC={handleAnalyzeLULC}
               lulcRunning={props.lulcRunning}
               onCloseResult={() => {
                 props.setResult(null)
                 props.setAnalysisLabel(undefined)
+                props.setSwipeCompare(false)
+                props.setSwipeRatio(0.5)
               }}
               onNewClassification={startNewClassification}
               onViewDataCube={() => void handleViewDataCube()}

--- a/frontend/src/components/AoiContextMenu.tsx
+++ b/frontend/src/components/AoiContextMenu.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useRef, useState, type CSSProperties } from "react"
+import { Check, Pencil, Focus, Trash2 } from "lucide-react"
+import {
+  AOI_CONTOUR_SCHEMES,
+  type AoiContourSchemeId,
+} from "@/lib/aoiStyle"
+
+export interface AoiContextMenuState {
+  /** Position relative to the map screen container. */
+  x: number
+  y: number
+}
+
+interface AoiContextMenuProps {
+  menu: AoiContextMenuState
+  areaName: string
+  schemeId: AoiContourSchemeId
+  canClear: boolean
+  onClose: () => void
+  onRename: (name: string) => void
+  onSchemeChange: (id: AoiContourSchemeId) => void
+  onFitToArea: () => void
+  onClearArea: () => void
+}
+
+export function AoiContextMenu({
+  menu,
+  areaName,
+  schemeId,
+  canClear,
+  onClose,
+  onRename,
+  onSchemeChange,
+  onFitToArea,
+  onClearArea,
+}: AoiContextMenuProps) {
+  const rootRef = useRef<HTMLDivElement | null>(null)
+  const [renaming, setRenaming] = useState(false)
+  const [draft, setDraft] = useState(areaName)
+  const [pos, setPos] = useState({ x: menu.x, y: menu.y })
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    setDraft(areaName)
+    setRenaming(false)
+    setPos({ x: menu.x, y: menu.y })
+  }, [areaName, menu.x, menu.y])
+
+  useEffect(() => {
+    const el = rootRef.current
+    const parent = el?.offsetParent as HTMLElement | null
+    if (!el || !parent) return
+    const pad = 8
+    // Anchor at the horizontal midpoint of the top edge (not top-left).
+    const centeredX = menu.x - el.offsetWidth / 2
+    const maxX = Math.max(pad, parent.clientWidth - el.offsetWidth - pad)
+    const maxY = Math.max(pad, parent.clientHeight - el.offsetHeight - pad)
+    setPos({
+      x: Math.min(Math.max(pad, centeredX), maxX),
+      y: Math.min(Math.max(pad, menu.y), maxY),
+    })
+  }, [menu.x, menu.y, renaming])
+
+  useEffect(() => {
+    if (renaming) inputRef.current?.focus()
+  }, [renaming])
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose()
+    }
+    const onPointer = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) onClose()
+    }
+    window.addEventListener("keydown", onKey)
+    const t = window.setTimeout(() => {
+      window.addEventListener("mousedown", onPointer)
+    }, 0)
+    return () => {
+      window.clearTimeout(t)
+      window.removeEventListener("keydown", onKey)
+      window.removeEventListener("mousedown", onPointer)
+    }
+  }, [onClose])
+
+  const commitRename = () => {
+    const next = draft.trim()
+    if (next) onRename(next)
+    setRenaming(false)
+    onClose()
+  }
+
+  const style: CSSProperties = { left: pos.x, top: pos.y }
+
+  return (
+    <div
+      ref={rootRef}
+      className="panel app-no-drag absolute z-[1200] w-[13.5rem] overflow-hidden rounded-md py-1 shadow-lg"
+      style={style}
+      role="menu"
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      <p className="truncate px-3 pb-1 pt-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+        Area
+      </p>
+
+      {renaming ? (
+        <form
+          className="flex items-center gap-1 px-2 pb-2"
+          onSubmit={(e) => {
+            e.preventDefault()
+            commitRename()
+          }}
+        >
+          <input
+            ref={inputRef}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            className="h-7 min-w-0 flex-1 rounded-sm border border-border bg-background px-2 text-xs text-foreground outline-none focus:border-primary"
+            maxLength={64}
+            aria-label="Area name"
+          />
+          <button
+            type="submit"
+            className="flex size-7 items-center justify-center rounded-sm text-primary hover:bg-primary/10"
+            title="Save name"
+          >
+            <Check className="size-3.5" />
+          </button>
+        </form>
+      ) : (
+        <button
+          type="button"
+          role="menuitem"
+          className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-foreground hover:bg-secondary"
+          onClick={() => setRenaming(true)}
+        >
+          <Pencil className="size-3.5 shrink-0 text-muted-foreground" />
+          Rename area…
+        </button>
+      )}
+
+      <div className="px-3 py-2">
+        <p className="mb-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+          Contour color
+        </p>
+        <div className="flex flex-wrap gap-1.5">
+          {AOI_CONTOUR_SCHEMES.map((s) => {
+            const active = s.id === schemeId
+            return (
+              <button
+                key={s.id}
+                type="button"
+                title={s.label}
+                aria-label={`Contour ${s.label}`}
+                aria-pressed={active}
+                className={`size-6 rounded-full border-2 transition-transform hover:scale-105 ${
+                  active
+                    ? "border-primary ring-1 ring-primary/40"
+                    : "border-transparent"
+                }`}
+                style={{ backgroundColor: s.stroke }}
+                onClick={() => {
+                  onSchemeChange(s.id)
+                  onClose()
+                }}
+              />
+            )
+          })}
+        </div>
+      </div>
+
+      <hr className="hairline mx-2" />
+
+      <button
+        type="button"
+        role="menuitem"
+        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-foreground hover:bg-secondary"
+        onClick={() => {
+          onFitToArea()
+          onClose()
+        }}
+      >
+        <Focus className="size-3.5 shrink-0 text-muted-foreground" />
+        Fit map to area
+      </button>
+
+      {canClear && (
+        <button
+          type="button"
+          role="menuitem"
+          className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-destructive hover:bg-secondary"
+          onClick={() => {
+            onClearArea()
+            onClose()
+          }}
+        >
+          <Trash2 className="size-3.5 shrink-0" />
+          Clear area
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState, type RefObject } from "react"
 import {
   MapContainer,
   TileLayer,
@@ -17,6 +17,15 @@ import "./leafletDrawPatch"
 import type { LatLngBoundsExpression } from "leaflet"
 import type { Area, PredictResult, GeoJSONGeometry } from "@/lib/types"
 import { majoritySmoothOverlay } from "@/lib/smoothOverlay"
+import {
+  getAoiContourScheme,
+  type AoiContourScheme,
+  type AoiContourSchemeId,
+} from "@/lib/aoiStyle"
+import {
+  AoiContextMenu,
+  type AoiContextMenuState,
+} from "@/components/AoiContextMenu"
 
 interface MapViewProps {
   areas: Area[]
@@ -31,7 +40,15 @@ interface MapViewProps {
   /** When true (default), keep class prediction under the confidence overlay. */
   confidenceOnTop: boolean
   smoothOverlay: boolean
+  /** Vertical wipe: left = basemap, right = prediction. */
+  swipeCompare: boolean
+  swipeRatio: number
+  onSwipeRatioChange: (ratio: number) => void
   areaLabel?: string
+  onAreaLabelChange: (label: string) => void
+  aoiContourScheme: AoiContourSchemeId
+  onAoiContourSchemeChange: (id: AoiContourSchemeId) => void
+  onClearArea: () => void
   onViewChange: (v: { lat: number; lon: number; zoom: number }) => void
 }
 
@@ -254,6 +271,7 @@ function FitBounds({
 /**
  * Prediction ImageOverlay. Smooth = contour/isoband style (solid colors,
  * curved class boundaries via blur→argmax), not soft RGB blend.
+ * Optional swipeRatio clips the overlay so the left side reveals the basemap.
  */
 function PredictionOverlay({
   url,
@@ -261,13 +279,17 @@ function PredictionOverlay({
   opacity,
   smooth,
   zIndex = 400,
+  swipeRatio = null,
 }: {
   url: string
   bounds: LatLngBoundsExpression
   opacity: number
   smooth: boolean
   zIndex?: number
+  /** 0–1 map-container fraction; null disables clip. */
+  swipeRatio?: number | null
 }) {
+  const map = useMap()
   const ref = useRef<L.ImageOverlay | null>(null)
   const [displayUrl, setDisplayUrl] = useState(url)
 
@@ -317,6 +339,39 @@ function PredictionOverlay({
     ref.current?.setZIndex(zIndex)
   }, [zIndex])
 
+  useEffect(() => {
+    const applyClip = () => {
+      const img = ref.current?.getElement()
+      if (!img) return
+      if (swipeRatio == null) {
+        img.style.clipPath = ""
+        return
+      }
+      const mapRect = map.getContainer().getBoundingClientRect()
+      const imgRect = img.getBoundingClientRect()
+      if (imgRect.width <= 0 || imgRect.height <= 0) {
+        img.style.clipPath = ""
+        return
+      }
+      const lineX = mapRect.left + swipeRatio * mapRect.width
+      const clipLeft = Math.max(0, Math.min(imgRect.width, lineX - imgRect.left))
+      img.style.clipPath = `inset(0 0 0 ${clipLeft}px)`
+    }
+
+    applyClip()
+    const overlay = ref.current
+    overlay?.on("load", applyClip)
+    map.on("move zoom moveend zoomend viewreset", applyClip)
+    window.addEventListener("resize", applyClip)
+    return () => {
+      overlay?.off("load", applyClip)
+      map.off("move zoom moveend zoomend viewreset", applyClip)
+      window.removeEventListener("resize", applyClip)
+      const img = ref.current?.getElement()
+      if (img) img.style.clipPath = ""
+    }
+  }, [map, swipeRatio, displayUrl, opacity])
+
   return (
     <ImageOverlay
       ref={ref}
@@ -326,6 +381,102 @@ function PredictionOverlay({
       zIndex={zIndex}
       className="overlay-crisp"
     />
+  )
+}
+
+/** Locks pan while the swipe handle is dragged. */
+function MapDragLock({ locked }: { locked: boolean }) {
+  const map = useMap()
+  useEffect(() => {
+    if (locked) {
+      map.dragging.disable()
+      return () => {
+        map.dragging.enable()
+      }
+    }
+    map.dragging.enable()
+  }, [locked, map])
+  return null
+}
+
+/** Vertical wipe handle overlaid on the map container (DOM, not a Leaflet layer). */
+function SwipeDivider({
+  ratio,
+  onRatioChange,
+  onDraggingChange,
+  rightLabel = "Prediction",
+}: {
+  ratio: number
+  onRatioChange: (ratio: number) => void
+  onDraggingChange: (dragging: boolean) => void
+  rightLabel?: string
+}) {
+  const trackRef = useRef<HTMLDivElement | null>(null)
+
+  const setFromClientX = (clientX: number) => {
+    const el = trackRef.current
+    if (!el) return
+    const rect = el.getBoundingClientRect()
+    if (rect.width <= 0) return
+    const next = Math.min(0.92, Math.max(0.08, (clientX - rect.left) / rect.width))
+    onRatioChange(next)
+  }
+
+  return (
+    <div
+      ref={trackRef}
+      className="map-swipe-track app-no-drag pointer-events-none absolute inset-0 z-[1050]"
+      aria-hidden={false}
+    >
+      <div
+        className="pointer-events-none absolute inset-y-0 w-px bg-white/85 shadow-[0_0_0_1px_rgba(0,0,0,0.35)]"
+        style={{ left: `${ratio * 100}%`, transform: "translateX(-50%)" }}
+      />
+      <div
+        className="pointer-events-none absolute top-3 -translate-x-full rounded-sm bg-black/55 px-1.5 py-0.5 text-[10px] tracking-wide text-white/90"
+        style={{ left: `calc(${ratio * 100}% - 8px)` }}
+      >
+        Imagery
+      </div>
+      <div
+        className="pointer-events-none absolute top-3 translate-x-0 rounded-sm bg-black/55 px-1.5 py-0.5 text-[10px] tracking-wide text-white/90"
+        style={{ left: `calc(${ratio * 100}% + 8px)` }}
+      >
+        {rightLabel}
+      </div>
+      <button
+        type="button"
+        aria-label={`Drag to compare imagery and ${rightLabel.toLowerCase()}`}
+        className="map-swipe-handle pointer-events-auto absolute top-1/2 flex h-11 w-7 -translate-x-1/2 -translate-y-1/2 cursor-ew-resize items-center justify-center rounded-full border border-white/70 bg-black/55 shadow-md outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+        style={{ left: `${ratio * 100}%` }}
+        onPointerDown={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          const target = e.currentTarget
+          target.setPointerCapture(e.pointerId)
+          onDraggingChange(true)
+          setFromClientX(e.clientX)
+        }}
+        onPointerMove={(e) => {
+          if (!e.currentTarget.hasPointerCapture(e.pointerId)) return
+          e.preventDefault()
+          e.stopPropagation()
+          setFromClientX(e.clientX)
+        }}
+        onPointerUp={(e) => {
+          if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+            e.currentTarget.releasePointerCapture(e.pointerId)
+          }
+          onDraggingChange(false)
+        }}
+        onPointerCancel={() => onDraggingChange(false)}
+      >
+        <span className="flex gap-0.5" aria-hidden>
+          <span className="h-4 w-0.5 rounded-full bg-white/90" />
+          <span className="h-4 w-0.5 rounded-full bg-white/90" />
+        </span>
+      </button>
+    </div>
   )
 }
 
@@ -487,6 +638,100 @@ function ringCentroid(ring: LonLat[]): LonLat {
   return [lon / n, lat / n]
 }
 
+/** Ray-cast point-in-polygon (lon/lat), for AOI right-click hit testing. */
+function pointInRing(lon: number, lat: number, ring: LonLat[]): boolean {
+  let inside = false
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const xi = ring[i][0]
+    const yi = ring[i][1]
+    const xj = ring[j][0]
+    const yj = ring[j][1]
+    const intersect =
+      yi > lat !== yj > lat &&
+      lon < ((xj - xi) * (lat - yi)) / (yj - yi + Number.EPSILON) + xi
+    if (intersect) inside = !inside
+  }
+  return inside
+}
+
+function pointInAoi(lon: number, lat: number, geometry: GeoJSONGeometry): boolean {
+  if (geometry.type === "Polygon") {
+    const coords = geometry.coordinates as LonLat[][]
+    const outer = coords[0]
+    if (!outer || !pointInRing(lon, lat, outer)) return false
+    for (let h = 1; h < coords.length; h++) {
+      if (pointInRing(lon, lat, coords[h])) return false
+    }
+    return true
+  }
+  if (geometry.type === "MultiPolygon") {
+    const multi = geometry.coordinates as unknown as LonLat[][][]
+    return multi.some((poly) => {
+      const outer = poly[0]
+      if (!outer || !pointInRing(lon, lat, outer)) return false
+      for (let h = 1; h < poly.length; h++) {
+        if (pointInRing(lon, lat, poly[h])) return false
+      }
+      return true
+    })
+  }
+  return false
+}
+
+/**
+ * Captures right-clicks on the map (including over prediction ImageOverlays).
+ * Suppresses the Wails/browser menu and opens the AOI menu when inside the polygon.
+ */
+function AoiRightClickBridge({
+  geometry,
+  containerRef,
+  onOpen,
+}: {
+  geometry: GeoJSONGeometry | null
+  containerRef: RefObject<HTMLDivElement | null>
+  onOpen: (menu: AoiContextMenuState | null) => void
+}) {
+  const map = useMap()
+  const geometryRef = useRef(geometry)
+  geometryRef.current = geometry
+  const onOpenRef = useRef(onOpen)
+  onOpenRef.current = onOpen
+  const containerRefStable = containerRef
+
+  useEffect(() => {
+    const el = map.getContainer()
+    const onContextMenu = (e: MouseEvent) => {
+      // Always block native Reload / Inspect on the map surface.
+      e.preventDefault()
+      e.stopPropagation()
+
+      const g = geometryRef.current
+      if (!g) {
+        onOpenRef.current(null)
+        return
+      }
+
+      const ll = map.mouseEventToLatLng(e)
+      if (!pointInAoi(ll.lng, ll.lat, g)) {
+        onOpenRef.current(null)
+        return
+      }
+
+      const root = containerRefStable.current
+      const rect = root?.getBoundingClientRect()
+      onOpenRef.current({
+        x: e.clientX - (rect?.left ?? 0),
+        y: e.clientY - (rect?.top ?? 0),
+      })
+    }
+
+    el.addEventListener("contextmenu", onContextMenu, true)
+    return () => el.removeEventListener("contextmenu", onContextMenu, true)
+  }, [map, containerRefStable])
+
+  return null
+}
+
 /** Longest edge in the southern band of the AOI — label glues to this segment. */
 function pickContourEdge(geometry: GeoJSONGeometry): {
   a: LonLat
@@ -525,14 +770,17 @@ function pickContourEdge(geometry: GeoJSONGeometry): {
 }
 
 /**
- * Thin white AOI outline + name chip glued to a contour edge and rotated with it.
+ * Thin AOI outline + name chip glued to a contour edge and rotated with it.
+ * Right-click is handled by AoiRightClickBridge (works above prediction overlays).
  */
 function AoiContour({
   geometry,
   label,
+  scheme,
 }: {
   geometry: GeoJSONGeometry
   label: string
+  scheme: AoiContourScheme
 }) {
   const edge = useMemo(() => pickContourEdge(geometry), [geometry])
   const centroid = useMemo(() => {
@@ -543,20 +791,48 @@ function AoiContour({
   return (
     <>
       <GeoJSON
+        key={`aoi-outline-${scheme.id}`}
         data={geometry as GeoJSON.Geometry}
         interactive={false}
-        style={{
-          color: "#ffffff",
-          weight: 1.5,
+        pathOptions={{
+          color: scheme.stroke,
+          weight: 2,
           opacity: 1,
+          fillColor: scheme.stroke,
           fillOpacity: 0,
         }}
       />
       {edge && centroid && label.trim() && (
-        <AoiEdgeLabel edge={edge} centroid={centroid} label={label.trim()} />
+        <AoiEdgeLabel
+          edge={edge}
+          centroid={centroid}
+          label={label.trim()}
+          scheme={scheme}
+        />
       )}
     </>
   )
+}
+
+/** Fits the map to the active AOI when `nonce` increments. */
+function FitAoiOnRequest({
+  geometry,
+  nonce,
+}: {
+  geometry: GeoJSONGeometry | null
+  nonce: number
+}) {
+  const map = useMap()
+  useEffect(() => {
+    if (!geometry || nonce <= 0) return
+    try {
+      const layer = L.geoJSON(geometry as GeoJSON.GeoJsonObject)
+      map.fitBounds(layer.getBounds(), { padding: [40, 40] })
+    } catch {
+      // ignore invalid bounds
+    }
+  }, [map, geometry, nonce])
+  return null
 }
 
 /** Chip anchored outside a contour segment, rotated to match the edge angle. */
@@ -564,10 +840,12 @@ function AoiEdgeLabel({
   edge,
   centroid,
   label,
+  scheme,
 }: {
   edge: { a: LonLat; b: LonLat; mid: LonLat }
   centroid: LonLat
   label: string
+  scheme: AoiContourScheme
 }) {
   const map = useMap()
   const [pose, setPose] = useState<{
@@ -641,11 +919,11 @@ function AoiEdgeLabel({
       .replace(/"/g, "&quot;")
     return L.divIcon({
       className: "aoi-label",
-      html: `<div class="aoi-label-chip" style="transform:translate(-50%,-50%) rotate(${pose.angle}deg)">${safe}</div>`,
+      html: `<div class="aoi-label-chip" style="transform:translate(-50%,-50%) rotate(${pose.angle}deg);background:${scheme.chipBg};color:${scheme.chipFg}">${safe}</div>`,
       iconSize: [0, 0],
       iconAnchor: [0, 0],
     })
-  }, [label, pose])
+  }, [label, pose, scheme.chipBg, scheme.chipFg])
 
   if (!pose || !icon) return null
 
@@ -671,10 +949,25 @@ export function MapView({
   showConfidence,
   confidenceOnTop,
   smoothOverlay,
+  swipeCompare,
+  swipeRatio,
+  onSwipeRatioChange,
   areaLabel,
+  onAreaLabelChange,
+  aoiContourScheme,
+  onAoiContourSchemeChange,
+  onClearArea,
   onViewChange,
 }: MapViewProps) {
   const center = useMemo<[number, number]>(() => [-14.5, -52], [])
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [swipeDragging, setSwipeDragging] = useState(false)
+  const [aoiMenu, setAoiMenu] = useState<AoiContextMenuState | null>(null)
+  const [fitAoiNonce, setFitAoiNonce] = useState(0)
+  const contourScheme = useMemo(
+    () => getAoiContourScheme(aoiContourScheme),
+    [aoiContourScheme]
+  )
 
   const overlayUrl =
     result?.overlay_uri || result?.lulc?.map_uri || result?.reference_uri || ""
@@ -693,9 +986,16 @@ export function MapView({
       result.extent.lat_max === 0
     )
 
+  const swipeActive = swipeCompare && !!overlayUrl && hasValidExtent
+
   // Confidence is semi-transparent, so prediction always shows through unless
   // we hide it. When confidenceOnTop is off, show confidence alone.
+  // Swipe clips whichever overlay(s) are visible so the left side shows basemap.
   const showPredictionUnderConfidence = !showConfidence || confidenceOnTop
+  const predictionOpacity = swipeActive
+    ? Math.max(overlayOpacity, 0.88)
+    : overlayOpacity
+  const swipeClip = swipeActive ? swipeRatio : null
   const predictionLayer =
     result &&
     hasValidExtent &&
@@ -706,23 +1006,40 @@ export function MapView({
         key="prediction"
         url={overlayUrl}
         bounds={overlayBounds}
-        opacity={overlayOpacity}
+        opacity={predictionOpacity}
         smooth={smoothOverlay}
         zIndex={400}
+        swipeRatio={swipeClip}
       />
     ) : null
 
   const confidenceLayer =
-    result && hasValidExtent && overlayBounds && showConfidence && result.confidence_uri ? (
+    result &&
+    hasValidExtent &&
+    overlayBounds &&
+    showConfidence &&
+    result.confidence_uri ? (
       <PredictionOverlay
         key="confidence"
         url={result.confidence_uri}
         bounds={overlayBounds}
-        opacity={Math.min(1, overlayOpacity + 0.15)}
+        opacity={
+          swipeActive
+            ? Math.max(Math.min(1, overlayOpacity + 0.15), 0.9)
+            : Math.min(1, overlayOpacity + 0.15)
+        }
         smooth={false}
         zIndex={450}
+        swipeRatio={swipeClip}
       />
     ) : null
+
+  const swipeRightLabel =
+    showConfidence && !showPredictionUnderConfidence
+      ? "Confidence"
+      : showConfidence
+        ? "Confidence"
+        : "Prediction"
 
   // Example outlines are shown only when no custom polygon is active, as faint
   // clickable shortcuts to the article's validated sites.
@@ -745,7 +1062,8 @@ export function MapView({
   }, [areaLabel, activeExample, areas, customPolygon])
 
   return (
-    <div className="absolute inset-0">
+    // z-0 keeps swipe chrome inside this stacking context, under Result/Control panels
+    <div ref={containerRef} className="absolute inset-0 z-0">
     <MapContainer center={center} zoom={4} className="h-full w-full" zoomControl={false}>
       <ZoomControl position="bottomright" />
       <LayersControl position="topright">
@@ -792,15 +1110,50 @@ export function MapView({
       {confidenceLayer}
 
       {aoiGeometry && (
-        <AoiContour geometry={aoiGeometry} label={aoiName} />
+        <AoiContour
+          geometry={aoiGeometry}
+          label={aoiName}
+          scheme={contourScheme}
+        />
       )}
 
       <DrawControl customPolygon={customPolygon} onPolygonDrawn={onPolygonDrawn} />
       <FlyToController flyTo={flyTo} />
       <FitBounds customPolygon={customPolygon} result={result} />
+      <FitAoiOnRequest geometry={aoiGeometry} nonce={fitAoiNonce} />
+      <AoiRightClickBridge
+        geometry={aoiGeometry}
+        containerRef={containerRef}
+        onOpen={setAoiMenu}
+      />
       <ViewReporter onViewChange={onViewChange} />
       <BasemapDateAttribution />
+      <MapDragLock locked={swipeDragging} />
     </MapContainer>
+    {swipeActive && (
+      <SwipeDivider
+        ratio={swipeRatio}
+        onRatioChange={onSwipeRatioChange}
+        onDraggingChange={setSwipeDragging}
+        rightLabel={swipeRightLabel}
+      />
+    )}
+    {aoiMenu && aoiGeometry && (
+      <AoiContextMenu
+        menu={aoiMenu}
+        areaName={aoiName || "AOI"}
+        schemeId={contourScheme.id}
+        canClear={!!customPolygon || !!activeExample}
+        onClose={() => setAoiMenu(null)}
+        onRename={onAreaLabelChange}
+        onSchemeChange={onAoiContourSchemeChange}
+        onFitToArea={() => setFitAoiNonce((n) => n + 1)}
+        onClearArea={() => {
+          setAoiMenu(null)
+          onClearArea()
+        }}
+      />
+    )}
     </div>
   )
 }

--- a/frontend/src/components/ResultsPanel.tsx
+++ b/frontend/src/components/ResultsPanel.tsx
@@ -12,6 +12,8 @@ interface ResultsPanelProps {
   onConfidenceOnTopChange: (v: boolean) => void
   smoothOverlay: boolean
   onSmoothOverlayChange: (v: boolean) => void
+  swipeCompare: boolean
+  onSwipeCompareChange: (v: boolean) => void
   onClose: () => void
   onNewClassification: () => void
 }
@@ -24,6 +26,8 @@ export function ResultsPanel({
   onConfidenceOnTopChange,
   smoothOverlay,
   onSmoothOverlayChange,
+  swipeCompare,
+  onSwipeCompareChange,
   onClose,
   onNewClassification,
 }: ResultsPanelProps) {
@@ -118,6 +122,15 @@ export function ResultsPanel({
                 />
                 Smooth prediction overlay
               </label>
+              <label className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                <input
+                  type="checkbox"
+                  checked={swipeCompare}
+                  onChange={(e) => onSwipeCompareChange(e.target.checked)}
+                  className="accent-primary"
+                />
+                Swipe imagery ↔ overlay
+              </label>
               {!isLulcOnly && (
                 <label className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
                   <input
@@ -169,7 +182,9 @@ export function ResultsPanel({
             <p className="text-[10px] text-muted-foreground">
               {isLulcOnly
                 ? "MapBiomas cover on the map. Open Analysis for groups, diversity and details."
-                : "Open Analysis for land cover / use, cover map, VI series and phenology."}
+                : swipeCompare
+                  ? "Drag the handle to reveal satellite imagery under the prediction / confidence overlay."
+                  : "Open Analysis for land cover / use, cover map, VI series and phenology."}
             </p>
           </div>
         </>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -416,6 +416,12 @@
   transform: none;
 }
 
+/* Map swipe (imagery ↔ prediction) — handle sits above leaflet panes */
+.map-swipe-handle {
+  touch-action: none;
+  user-select: none;
+}
+
 /* AOI name chip — glued to contour edge, rotation applied inline */
 .aoi-label {
   background: transparent !important;
@@ -425,6 +431,7 @@
   display: inline-block;
   padding: 3px 9px;
   border-radius: 4px;
+  /* Default chip chrome; MapView may override via inline scheme colors */
   background: rgb(245 245 243 / 0.97);
   color: rgb(55 55 55);
   font-family: var(--font-sans);

--- a/frontend/src/lib/aoiStyle.ts
+++ b/frontend/src/lib/aoiStyle.ts
@@ -1,0 +1,75 @@
+/** Contour / label chrome for the active AOI on the map. */
+
+export type AoiContourSchemeId =
+  | "white"
+  | "ochre"
+  | "cyan"
+  | "lime"
+  | "rose"
+  | "ink"
+
+export interface AoiContourScheme {
+  id: AoiContourSchemeId
+  label: string
+  /** Stroke color for the polygon outline. */
+  stroke: string
+  /** Label chip background. */
+  chipBg: string
+  /** Label chip text. */
+  chipFg: string
+}
+
+export const AOI_CONTOUR_SCHEMES: AoiContourScheme[] = [
+  {
+    id: "white",
+    label: "White",
+    stroke: "#ffffff",
+    chipBg: "rgb(245 245 243 / 0.97)",
+    chipFg: "rgb(55 55 55)",
+  },
+  {
+    id: "ochre",
+    label: "Ochre",
+    stroke: "#c2703d",
+    chipBg: "rgb(194 112 61 / 0.95)",
+    chipFg: "#fff8f0",
+  },
+  {
+    id: "cyan",
+    label: "Cyan",
+    stroke: "#22d3ee",
+    chipBg: "rgb(8 47 54 / 0.92)",
+    chipFg: "#a5f3fc",
+  },
+  {
+    id: "lime",
+    label: "Lime",
+    stroke: "#a3e635",
+    chipBg: "rgb(26 46 5 / 0.92)",
+    chipFg: "#d9f99d",
+  },
+  {
+    id: "rose",
+    label: "Rose",
+    stroke: "#fb7185",
+    chipBg: "rgb(76 5 25 / 0.92)",
+    chipFg: "#fecdd3",
+  },
+  {
+    id: "ink",
+    label: "Ink",
+    stroke: "#1c1917",
+    chipBg: "rgb(28 25 23 / 0.94)",
+    chipFg: "#fafaf9",
+  },
+]
+
+export const DEFAULT_AOI_CONTOUR_SCHEME: AoiContourSchemeId = "white"
+
+export function getAoiContourScheme(
+  id: AoiContourSchemeId | string | undefined
+): AoiContourScheme {
+  return (
+    AOI_CONTOUR_SCHEMES.find((s) => s.id === id) ?? AOI_CONTOUR_SCHEMES[0]
+  )
+}

--- a/frontend/src/pages/MapScreen.tsx
+++ b/frontend/src/pages/MapScreen.tsx
@@ -6,6 +6,7 @@ import type {
   ModelKind,
   PredictResult,
 } from "@/lib/types"
+import type { AoiContourSchemeId } from "@/lib/aoiStyle"
 import { MapView } from "@/components/MapView"
 import { SearchBar } from "@/components/SearchBar"
 import { ControlPanel } from "@/components/ControlPanel"
@@ -23,7 +24,12 @@ export interface MapScreenProps {
   showConfidence: boolean
   confidenceOnTop: boolean
   smoothOverlay: boolean
+  swipeCompare: boolean
+  swipeRatio: number
   areaLabel?: string
+  onAreaLabelChange: (label: string) => void
+  aoiContourScheme: AoiContourSchemeId
+  onAoiContourSchemeChange: (id: AoiContourSchemeId) => void
   hasArea: boolean
   start: string
   end: string
@@ -52,6 +58,8 @@ export interface MapScreenProps {
   onShowConfidenceChange: (v: boolean) => void
   onConfidenceOnTopChange: (v: boolean) => void
   onSmoothOverlayChange: (v: boolean) => void
+  onSwipeCompareChange: (v: boolean) => void
+  onSwipeRatioChange: (v: number) => void
   onRun: () => void
   onAnalyzeLULC: () => void
   lulcRunning?: boolean
@@ -80,7 +88,14 @@ export function MapScreen(props: MapScreenProps) {
         showConfidence={props.showConfidence}
         confidenceOnTop={props.confidenceOnTop}
         smoothOverlay={props.smoothOverlay}
+        swipeCompare={props.swipeCompare}
+        swipeRatio={props.swipeRatio}
+        onSwipeRatioChange={props.onSwipeRatioChange}
         areaLabel={props.areaLabel}
+        onAreaLabelChange={props.onAreaLabelChange}
+        aoiContourScheme={props.aoiContourScheme}
+        onAoiContourSchemeChange={props.onAoiContourSchemeChange}
+        onClearArea={props.onClearArea}
         onViewChange={props.onViewChange}
       />
 
@@ -140,6 +155,8 @@ export function MapScreen(props: MapScreenProps) {
             onConfidenceOnTopChange={props.onConfidenceOnTopChange}
             smoothOverlay={props.smoothOverlay}
             onSmoothOverlayChange={props.onSmoothOverlayChange}
+            swipeCompare={props.swipeCompare}
+            onSwipeCompareChange={props.onSwipeCompareChange}
             onClose={props.onCloseResult}
             onNewClassification={props.onNewClassification}
           />


### PR DESCRIPTION
## Summary
- Add a vertical **swipe** control to compare satellite imagery with prediction/confidence overlays.
- Add an AOI **right-click menu** (works over overlays): rename area, contour color schemes, fit map, clear area.
- Menu anchors at the horizontal midpoint of its top edge under the cursor.

## Test plan
- [x] Classify an AOI → enable **Swipe imagery ↔ overlay** → drag handle; basemap left, overlay right.
- [x] With swipe on, enable confidence and confirm both layers clip together.
- [x] Right-click inside AOI (including over prediction) → custom menu (not Reload/Inspect).
- [x] Rename area and switch contour colors; confirm chip/outline update.
- [x] Fit map to area / Clear area from the menu.
- [x] Confirm Result panel stays above the swipe divider.