### PR TITLE
feat(ui): subtle Web Audio tones for success/error toasts

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
-import { toast } from "sonner"
+import { notifyError, notifySuccess } from "@/lib/notify"
 import { useTheme } from "next-themes"
 import {
   ListEmbeddedAreas,
@@ -137,7 +137,7 @@ function App() {
   useEffect(() => {
     ListEmbeddedAreas()
       .then((a) => setAreas((a ?? []) as unknown as Area[]))
-      .catch((e) => toast.error("Failed to load examples: " + e))
+      .catch((e) => notifyError("Failed to load examples", e))
   }, [])
 
   useEffect(() => {
@@ -233,20 +233,20 @@ function App() {
             }
           }
         } catch (e) {
-          toast.error("Invalid file: " + e)
+          notifyError("Invalid file", e)
           return
         }
         if (!geom) {
-          toast.error("No polygon found in the file.")
+          notifyError("No polygon found in the file.")
           return
         }
         setActiveExample("")
         setCustomPolygon(geom)
-        toast.success("Polygon imported.")
+        notifySuccess("Polygon imported.")
       }
       input.click()
     } catch (e) {
-      toast.error("Import failed: " + e)
+      notifyError("Import failed", e)
     }
   }
 
@@ -370,11 +370,11 @@ function AppBody(props: {
 
   const handleViewDataCube = async () => {
     if (!props.start || !props.end) {
-      toast.error("Set the acquisition period.")
+      notifyError("Set the acquisition period.")
       return
     }
     if (!props.customPolygon && !props.activeExample) {
-      toast.error("Define an area: draw, search, or load an example.")
+      notifyError("Define an area: draw, search, or load an example.")
       return
     }
     const useExample =
@@ -398,7 +398,7 @@ function AppBody(props: {
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e)
       setDataCubeError(msg)
-      toast.error("Data cube error: " + msg)
+      notifyError("Data cube error", msg)
     } finally {
       setDataCubeLoading(false)
     }
@@ -406,11 +406,11 @@ function AppBody(props: {
 
   const handleRun = async () => {
     if (!props.start || !props.end) {
-      toast.error("Set the acquisition period.")
+      notifyError("Set the acquisition period.")
       return
     }
     if (!props.customPolygon && !props.activeExample) {
-      toast.error("Define an area: draw, search, or load an example.")
+      notifyError("Define an area: draw, search, or load an example.")
       return
     }
     props.setRunning(true)
@@ -438,7 +438,7 @@ function AppBody(props: {
         ? props.areas.find((a) => a.id === props.activeExample)?.label
         : "Custom AOI"
       props.setAnalysisLabel(label)
-      toast.success(`Classification complete — ${res.n_dates} scenes (saved).`, {
+      notifySuccess(`Classification complete — ${res.n_dates} scenes (saved).`, undefined, {
         action: {
           label: "View analysis",
           onClick: () => goAnalysis(),
@@ -446,7 +446,7 @@ function AppBody(props: {
       })
       void refreshRuns()
     } catch (e) {
-      toast.error("Inference error: " + e)
+      notifyError("Inference error", e)
     } finally {
       props.setRunning(false)
     }
@@ -456,7 +456,7 @@ function AppBody(props: {
     const useExample =
       !!props.activeExample && !!props.areas.find((a) => a.id === props.activeExample)
     if (!useExample && !props.customPolygon) {
-      toast.error("Draw a polygon or select example A/B/C.")
+      notifyError("Draw a polygon or select example A/B/C.")
       return
     }
     props.setLulcRunning(true)
@@ -520,12 +520,12 @@ function AppBody(props: {
         phenology_states: prev?.phenology_states ?? [],
         lulc,
       })
-      toast.success("Land cover / land use ready on map.", {
+      notifySuccess("Land cover / land use ready on map.", undefined, {
         action: { label: "Open analysis", onClick: () => goAnalysis() },
       })
       goMap()
     } catch (e) {
-      toast.error("LULC analysis error: " + e)
+      notifyError("LULC analysis error", e)
     } finally {
       props.setLulcRunning(false)
       props.setProgress(0)
@@ -561,9 +561,9 @@ function AppBody(props: {
           }
         }
         goAnalysis()
-        toast.success("Analysis restored.")
+        notifySuccess("Analysis restored.")
       } catch (e) {
-        toast.error("Could not load analysis: " + e)
+        notifyError("Could not load analysis", e)
       } finally {
         setLoadingRun(false)
       }

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { Search, Loader2, MapPin } from "lucide-react"
-import { toast } from "sonner"
+import { notifyError, notifyInfo } from "@/lib/notify"
 import { GeocodeSearch } from "../../wailsjs/go/main/App"
 import type { GeocodeResult } from "@/lib/types"
 
@@ -23,10 +23,10 @@ export function SearchBar({ onSelectLocation }: SearchBarProps) {
       setResults(res ?? [])
       setOpen(true)
       if ((res ?? []).length === 0) {
-        toast.message("No location found.")
+        notifyInfo("No location found.")
       }
     } catch (e) {
-      toast.error("Falha na busca: " + e)
+      notifyError("Falha na busca", e)
     } finally {
       setLoading(false)
     }

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -7,7 +7,7 @@ import {
   useState,
   type ReactNode,
 } from "react"
-import { toast } from "sonner"
+import { notifySuccess } from "@/lib/notify"
 import {
   ClearAvatar,
   CurrentUser,
@@ -106,7 +106,7 @@ export function AuthProvider({
       setUser(u)
       await loadPrefsAndRuns(u)
       setScreen("map")
-      toast.success(`Welcome back, ${u.display_name}.`)
+      notifySuccess(`Welcome back, ${u.display_name}.`)
     },
     [loadPrefsAndRuns]
   )
@@ -117,7 +117,7 @@ export function AuthProvider({
       setUser(u)
       await loadPrefsAndRuns(u)
       setScreen("map")
-      toast.success("Account created.")
+      notifySuccess("Account created.")
     },
     [loadPrefsAndRuns]
   )
@@ -127,26 +127,26 @@ export function AuthProvider({
     setUser(null)
     setPrefs(null)
     setScreen("map")
-    toast.success("Signed out.")
+    notifySuccess("Signed out.")
     await refreshRuns()
   }, [refreshRuns])
 
   const updateProfile = useCallback(async (displayName: string) => {
     const u = (await UpdateProfile(displayName)) as unknown as User
     setUser(u)
-    toast.success("Profile updated.")
+    notifySuccess("Profile updated.")
   }, [])
 
   const setAvatar = useCallback(async (dataURI: string) => {
     const u = (await SetAvatar(dataURI)) as unknown as User
     setUser(u)
-    toast.success("Photo updated.")
+    notifySuccess("Photo updated.")
   }, [])
 
   const clearAvatar = useCallback(async () => {
     const u = (await ClearAvatar()) as unknown as User
     setUser(u)
-    toast.success("Photo removed.")
+    notifySuccess("Photo removed.")
   }, [])
 
   const savePrefs = useCallback(
@@ -154,7 +154,7 @@ export function AuthProvider({
       await SavePreferences(p as never)
       setPrefs(p)
       onPrefsApplied?.(p)
-      toast.success("Preferences saved.")
+      notifySuccess("Preferences saved.")
     },
     [onPrefsApplied]
   )

--- a/frontend/src/lib/notify.ts
+++ b/frontend/src/lib/notify.ts
@@ -1,0 +1,60 @@
+import { toast, type ExternalToast } from "sonner"
+import { playNotifySound } from "@/lib/sounds"
+
+function errText(e: unknown): string {
+  const raw = e instanceof Error ? e.message : String(e)
+  return raw.replace(/^Error:\s*/i, "").trim() || "Something went wrong"
+}
+
+/** Compact path for toast descriptions. */
+function shortPath(path: string): string {
+  const parts = path.split(/[/\\]/).filter(Boolean)
+  if (parts.length <= 2) return path
+  return `…/${parts.slice(-2).join("/")}`
+}
+
+export function notifySuccess(
+  title: string,
+  description?: string,
+  opts?: ExternalToast
+) {
+  playNotifySound("success")
+  toast.success(title, {
+    description,
+    duration: 4200,
+    ...opts,
+  })
+}
+
+export function notifyError(
+  title: string,
+  error?: unknown,
+  opts?: ExternalToast
+) {
+  playNotifySound("error")
+  toast.error(title, {
+    description: error !== undefined ? errText(error) : undefined,
+    duration: 6500,
+    ...opts,
+  })
+}
+
+export function notifyInfo(
+  title: string,
+  description?: string,
+  opts?: ExternalToast
+) {
+  toast.message(title, {
+    description,
+    duration: 4000,
+    ...opts,
+  })
+}
+
+export function notifyExportOk(dest: string) {
+  notifySuccess("Exported", shortPath(dest))
+}
+
+export function notifyExportFail(error: unknown) {
+  notifyError("Export failed", error)
+}

--- a/frontend/src/lib/sounds.ts
+++ b/frontend/src/lib/sounds.ts
@@ -1,0 +1,60 @@
+type NotifyTone = "success" | "error"
+
+let ctx: AudioContext | null = null
+let lastPlayAt = 0
+const DEBOUNCE_MS = 80
+
+function getCtx(): AudioContext | null {
+  if (typeof window === "undefined") return null
+  const AC =
+    window.AudioContext ||
+    (window as unknown as { webkitAudioContext?: typeof AudioContext })
+      .webkitAudioContext
+  if (!AC) return null
+  if (!ctx) ctx = new AC()
+  return ctx
+}
+
+function tone(
+  audio: AudioContext,
+  freq: number,
+  start: number,
+  duration: number,
+  peakGain: number
+) {
+  const osc = audio.createOscillator()
+  const gain = audio.createGain()
+  osc.type = "sine"
+  osc.frequency.setValueAtTime(freq, start)
+  gain.gain.setValueAtTime(0.0001, start)
+  gain.gain.exponentialRampToValueAtTime(peakGain, start + 0.012)
+  gain.gain.exponentialRampToValueAtTime(0.0001, start + duration)
+  osc.connect(gain)
+  gain.connect(audio.destination)
+  osc.start(start)
+  osc.stop(start + duration + 0.02)
+}
+
+/** Soft Web Audio chimes for success/error toasts. No-ops if audio is unavailable. */
+export function playNotifySound(kind: NotifyTone) {
+  const now = performance.now()
+  if (now - lastPlayAt < DEBOUNCE_MS) return
+  lastPlayAt = now
+
+  try {
+    const audio = getCtx()
+    if (!audio) return
+    void audio.resume().catch(() => {})
+
+    const t0 = audio.currentTime + 0.01
+    if (kind === "success") {
+      tone(audio, 520, t0, 0.09, 0.045)
+      tone(audio, 780, t0 + 0.07, 0.11, 0.04)
+    } else {
+      tone(audio, 200, t0, 0.14, 0.05)
+      tone(audio, 160, t0 + 0.08, 0.12, 0.035)
+    }
+  } catch {
+    // Ignore autoplay / context failures — toast still shows.
+  }
+}

--- a/frontend/src/pages/AnalysisPage.tsx
+++ b/frontend/src/pages/AnalysisPage.tsx
@@ -8,7 +8,7 @@ import {
   Map as MapIcon,
   Plus,
 } from "lucide-react"
-import { toast } from "sonner"
+import { notifyError, notifyExportFail, notifyExportOk } from "@/lib/notify"
 import {
   LineChart,
   Line,
@@ -85,7 +85,7 @@ export function AnalysisPage({
     const runA = runs.find((r) => r.id === selectedIds[0])
     const runB = runs.find((r) => r.id === selectedIds[1])
     if (!runA || !runB) {
-      toast.error("Selected analyses are no longer available")
+      notifyError("Selected analyses are no longer available")
       return
     }
     setComparing(true)
@@ -96,7 +96,7 @@ export function AnalysisPage({
       ])
       setCompare({ runA, runB, resultA, resultB })
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e))
+      notifyError("Compare failed", e)
     } finally {
       setComparing(false)
     }
@@ -207,9 +207,9 @@ export function AnalysisPage({
     if (!result.raster_tif) return
     try {
       const dest = await ExportClassification(result.raster_tif)
-      if (dest) toast.success(`Exported to ${dest}`)
+      if (dest) notifyExportOk(dest)
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : String(e))
+      notifyExportFail(e)
     }
   }
 


### PR DESCRIPTION
## Summary
- Add soft Web Audio success/error chimes via `sounds.ts`
- Centralize toast feedback in `notify` helpers and play sounds on success/error
- Migrate App, auth, SearchBar, and AnalysisPage to the notify helpers

## Why a new branch
`feat/toast-sounds` was accidentally stacked on compositions work. This PR is based on `main` and contains only the notification-sounds change.

## Test plan
- [ ] Trigger a success toast (e.g. sign in / classification) and hear a soft high chime
- [ ] Trigger an error toast and hear a soft low blip
- [ ] Confirm info/message toasts stay silent
- [ ] Confirm stacked toasts do not double-blast (debounce)