### PR TITLE
feat(ui): What’s New modal after splash on version bumps

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -45,7 +45,11 @@ JOSS acceptance / production-ready install story).
 1. `main` is green (CI) and contains only what you intend to ship.
 2. Decide PATCH / MINOR / MAJOR with the table above.
 3. Update release notes mentally: what should users download (LITE vs FULL)?
-4. Tag and push:
+4. Bump embedded `AppVersion` in [`version.go`](../version.go) to match the tag
+   (or pass `-ldflags "-X main.AppVersion=X.Y.Z"` in the release build), and add a
+   matching entry in [`frontend/src/lib/whatsNew.ts`](../frontend/src/lib/whatsNew.ts)
+   if the release should show a What’s New modal.
+5. Tag and push:
 
 ```bash
 git checkout main && git pull
@@ -53,7 +57,7 @@ git tag -a v0.3.0 -m "TERRA v0.3.0 — short reason"
 git push origin v0.3.0
 ```
 
-5. Confirm the Release workflow finished and assets appear on
+6. Confirm the Release workflow finished and assets appear on
    [Releases](https://github.com/rexionmars/TERRA/releases).
 
 ## Current line

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -54,6 +54,7 @@ import { AuthProvider, useAuth } from "@/lib/auth"
 import { ThemeSync } from "@/components/ThemeSync"
 import { TitleBar } from "@/components/TitleBar"
 import { SplashScreen } from "@/components/SplashScreen"
+import { WhatsNewGate } from "@/components/WhatsNewGate"
 import { AppSidebar } from "@/components/AppSidebar"
 import { MapScreen } from "@/pages/MapScreen"
 import { AuthPage } from "@/pages/AuthPage"
@@ -294,6 +295,7 @@ function App() {
         <SplashScreen exiting={splashExiting} />
       ) : (
         <div className="app-shell-enter h-full w-full">
+          <WhatsNewGate />
           <AppBody
             areas={areas}
             activeExample={activeExample}

--- a/frontend/src/components/WhatsNewGate.tsx
+++ b/frontend/src/components/WhatsNewGate.tsx
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import { GetAppVersion } from "../../wailsjs/go/main/App"
+import { useAuth } from "@/lib/auth"
+import {
+  mergePreferenceExtras,
+  parsePreferenceExtras,
+} from "@/lib/preferenceExtras"
+import {
+  compareSemver,
+  entriesSince,
+  shouldSkipWhatsNew,
+  type WhatsNewEntry,
+} from "@/lib/whatsNew"
+import { WhatsNewModal } from "@/components/WhatsNewModal"
+
+/** Keep aligned with main.AppVersion in version.go when GetAppVersion is unavailable. */
+const FALLBACK_APP_VERSION = "0.3.0"
+
+/**
+ * After splash + prefs load: show What’s New when the product version is newer
+ * than last_seen (missing last_seen counts as never seen → show current notes once).
+ */
+export function WhatsNewGate() {
+  const { prefs, loading, savePrefs } = useAuth()
+  const [entries, setEntries] = useState<WhatsNewEntry[] | null>(null)
+  const [currentVersion, setCurrentVersion] = useState("")
+  const decidedRef = useRef(false)
+
+  useEffect(() => {
+    if (loading || !prefs || decidedRef.current) return
+    decidedRef.current = true
+
+    void (async () => {
+      let current = FALLBACK_APP_VERSION
+      try {
+        const fromGo = (await GetAppVersion())?.trim()
+        if (fromGo) current = fromGo
+      } catch {
+        /* use FALLBACK_APP_VERSION */
+      }
+
+      if (shouldSkipWhatsNew(current)) return
+
+      const last =
+        parsePreferenceExtras(prefs.extras_json).last_seen_version?.trim() || ""
+
+      const persistSeen = async () => {
+        try {
+          await savePrefs(
+            {
+              ...prefs,
+              extras_json: mergePreferenceExtras(prefs.extras_json, {
+                last_seen_version: current,
+              }),
+            },
+            { silent: true }
+          )
+        } catch {
+          /* best-effort */
+        }
+      }
+
+      // Never seen (or first launch with this feature): baseline below any release notes.
+      const baseline = last || "0.0.0"
+      if (compareSemver(current, baseline) <= 0) return
+
+      const next = entriesSince(baseline, current)
+      if (next.length === 0) {
+        await persistSeen()
+        return
+      }
+
+      setCurrentVersion(current)
+      setEntries(next)
+    })()
+  }, [loading, prefs, savePrefs])
+
+  const onContinue = useCallback(() => {
+    const version = currentVersion
+    const snapshot = prefs
+    setEntries(null)
+    if (!snapshot || !version) return
+    void savePrefs(
+      {
+        ...snapshot,
+        extras_json: mergePreferenceExtras(snapshot.extras_json, {
+          last_seen_version: version,
+        }),
+      },
+      { silent: true }
+    ).catch(() => {
+      /* best-effort */
+    })
+  }, [currentVersion, prefs, savePrefs])
+
+  if (!entries?.length || !currentVersion) return null
+
+  return (
+    <WhatsNewModal
+      currentVersion={currentVersion}
+      entries={entries}
+      onContinue={onContinue}
+    />
+  )
+}

--- a/frontend/src/components/WhatsNewModal.tsx
+++ b/frontend/src/components/WhatsNewModal.tsx
@@ -1,0 +1,95 @@
+import { useEffect } from "react"
+import type { WhatsNewEntry } from "@/lib/whatsNew"
+
+interface WhatsNewModalProps {
+  currentVersion: string
+  entries: WhatsNewEntry[]
+  onContinue: () => void
+}
+
+export function WhatsNewModal({
+  currentVersion,
+  entries,
+  onContinue,
+}: WhatsNewModalProps) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" || e.key === "Enter") {
+        e.preventDefault()
+        onContinue()
+      }
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [onContinue])
+
+  return (
+    <div
+      className="app-no-drag fixed inset-0 z-[80] flex items-center justify-center bg-black/55 p-4"
+      role="presentation"
+      onClick={onContinue}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="whats-new-title"
+        className="terra-workspace flex w-full max-w-lg flex-col overflow-hidden rounded-sm border shadow-[0_16px_48px_rgba(0,0,0,0.55)]"
+        style={{
+          borderColor: "var(--ar-border)",
+          background: "var(--ar-panel)",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="ar-header flex shrink-0 flex-col gap-1 px-4 py-3">
+          <p className="telemetry text-[10px] text-primary">WHAT’S NEW</p>
+          <h2
+            id="whats-new-title"
+            className="font-display text-lg font-semibold tracking-wide"
+          >
+            What’s new in {currentVersion}
+          </h2>
+          <p className="text-[11px] text-muted-foreground">
+            Highlights since your last update.
+          </p>
+        </div>
+
+        <div
+          className="flex max-h-[min(28rem,60vh)] flex-col gap-3 overflow-y-auto p-4"
+          style={{ background: "var(--ar-bg)" }}
+        >
+          {entries.map((entry) => (
+            <section key={entry.version} className="ar-section p-4">
+              <div className="mb-2 flex flex-wrap items-baseline gap-2">
+                <p className="eyebrow !text-foreground">{entry.title}</p>
+                <span className="telemetry text-[10px] text-muted-foreground">
+                  v{entry.version}
+                </span>
+              </div>
+              <ul className="flex list-disc flex-col gap-1.5 pl-4 text-[12px] text-muted-foreground">
+                {entry.items.map((item) => (
+                  <li key={item} className="marker:text-primary/80">
+                    <span className="text-foreground/90">{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+
+        <div
+          className="flex shrink-0 justify-end px-4 py-3"
+          style={{ borderTop: "1px solid var(--ar-border)" }}
+        >
+          <button
+            type="button"
+            autoFocus
+            onClick={onContinue}
+            className="flex h-8 items-center rounded-sm bg-primary px-4 text-[11px] font-semibold text-primary-foreground"
+          >
+            Continue
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -43,7 +43,7 @@ interface AuthContextValue {
   updateProfile: (displayName: string) => Promise<void>
   setAvatar: (dataURI: string) => Promise<void>
   clearAvatar: () => Promise<void>
-  savePrefs: (prefs: Preferences) => Promise<void>
+  savePrefs: (prefs: Preferences, opts?: { silent?: boolean }) => Promise<void>
   refreshRuns: () => Promise<void>
   refreshProjects: () => Promise<void>
 }
@@ -172,11 +172,11 @@ export function AuthProvider({
   }, [])
 
   const savePrefs = useCallback(
-    async (p: Preferences) => {
+    async (p: Preferences, opts?: { silent?: boolean }) => {
       await SavePreferences(p as never)
       setPrefs(p)
       onPrefsApplied?.(p)
-      notifySuccess("Preferences saved.")
+      if (!opts?.silent) notifySuccess("Preferences saved.")
     },
     [onPrefsApplied]
   )

--- a/frontend/src/lib/preferenceExtras.ts
+++ b/frontend/src/lib/preferenceExtras.ts
@@ -7,6 +7,8 @@ export interface PreferenceExtras {
   active_project_id?: string
   /** Last custom AOI display name (survives restart with active project / prefs). */
   aoi_label?: string
+  /** Last product version for which What’s New was shown (or silently seeded). */
+  last_seen_version?: string
 }
 
 export function parsePreferenceExtras(

--- a/frontend/src/lib/whatsNew.ts
+++ b/frontend/src/lib/whatsNew.ts
@@ -1,0 +1,65 @@
+export type WhatsNewEntry = {
+  version: string
+  title: string
+  items: string[]
+}
+
+/** Newest first. Keep in sync with AppVersion / Git tags when cutting a release. */
+export const WHATS_NEW: WhatsNewEntry[] = [
+  {
+    version: "0.3.0",
+    title: "Projects, analysis workspace & clearer naming",
+    items: [
+      "Projects hub to group analyses, overlays, and AOIs",
+      "Dark Modern chrome across Analysis, Settings, and Compare",
+      "Run names use run-* prefixes; AOI and project names stay separate",
+      "Cover map title shows the project; AOI is labeled on its own row",
+    ],
+  },
+]
+
+/** Skip What’s New for explicit local/dev builds only. */
+export function shouldSkipWhatsNew(version: string): boolean {
+  const v = version.trim().toLowerCase()
+  return !v || v === "dev" || v === "0.0.0-dev" || v === "0.0.0"
+}
+
+type SemVer = { major: number; minor: number; patch: number }
+
+function parseSemver(raw: string): SemVer | null {
+  const cleaned = raw.trim().replace(/^v/i, "").split("-")[0] ?? ""
+  const parts = cleaned.split(".").map((p) => Number.parseInt(p, 10))
+  if (parts.length < 2 || parts.some((n) => Number.isNaN(n))) return null
+  return {
+    major: parts[0] ?? 0,
+    minor: parts[1] ?? 0,
+    patch: parts[2] ?? 0,
+  }
+}
+
+/** Negative if a < b, 0 if equal, positive if a > b. Invalid → treat as equal (0). */
+export function compareSemver(a: string, b: string): number {
+  const pa = parseSemver(a)
+  const pb = parseSemver(b)
+  if (!pa || !pb) return 0
+  if (pa.major !== pb.major) return pa.major - pb.major
+  if (pa.minor !== pb.minor) return pa.minor - pb.minor
+  return pa.patch - pb.patch
+}
+
+/**
+ * Changelog entries newer than lastSeen and at most current, newest first.
+ */
+export function entriesSince(
+  lastSeen: string,
+  current: string,
+  catalog: WhatsNewEntry[] = WHATS_NEW
+): WhatsNewEntry[] {
+  return catalog
+    .filter(
+      (e) =>
+        compareSemver(e.version, lastSeen) > 0 &&
+        compareSemver(e.version, current) <= 0
+    )
+    .sort((x, y) => compareSemver(y.version, x.version))
+}

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -24,6 +24,8 @@ export function ExportOverlayFile(arg1:string,arg2:string):Promise<string>;
 
 export function GeocodeSearch(arg1:string):Promise<Array<backend.GeocodeResult>>;
 
+export function GetAppVersion():Promise<string>;
+
 export function GetBootLogs():Promise<Array<string>>;
 
 export function GetPreferences():Promise<store.Preferences>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -42,6 +42,10 @@ export function GeocodeSearch(arg1) {
   return window['go']['main']['App']['GeocodeSearch'](arg1);
 }
 
+export function GetAppVersion() {
+  return window['go']['main']['App']['GetAppVersion']();
+}
+
 export function GetBootLogs() {
   return window['go']['main']['App']['GetBootLogs']();
 }

--- a/version.go
+++ b/version.go
@@ -1,0 +1,16 @@
+package main
+
+import "strings"
+
+// AppVersion is the product SemVer without a "v" prefix.
+// Override at link time: go build -ldflags "-X main.AppVersion=0.3.0"
+var AppVersion = "0.3.0"
+
+// GetAppVersion returns the embedded product version for the UI (What's New, About).
+func (a *App) GetAppVersion() string {
+	v := strings.TrimSpace(AppVersion)
+	if v == "" {
+		return "0.0.0-dev"
+	}
+	return strings.TrimPrefix(v, "v")
+}


### PR DESCRIPTION
## Summary
- Embed `AppVersion` (`GetAppVersion`) and persist `last_seen_version` in preference extras
- Show a Dark Modern What’s New modal after splash when the product version advances past what the user has seen
- Document bumping `version.go` + `whatsNew.ts` in the releasing checklist

## Test plan
- [ ] Fresh prefs / no `last_seen_version`: modal shows notes for current version once after splash
- [ ] Continue: modal does not reappear until `AppVersion` increases
- [ ] Set `last_seen_version` to an older SemVer in prefs: modal shows again with entries in between
- [ ] Confirm `docs/RELEASING.md` mentions `AppVersion` / `whatsNew.ts`