### PR TITLE
fix(ui): keep overlay visibility controls only in Overlay Tools

### DIFF
--- a/frontend/src/components/CompositionPanel.tsx
+++ b/frontend/src/components/CompositionPanel.tsx
@@ -2,7 +2,6 @@ import { forwardRef, useMemo, useState } from "react"
 import { motion } from "motion/react"
 import {
   ChevronLeft,
-  Layers,
   Loader2,
   CheckCircle2,
   Pencil,
@@ -65,8 +64,6 @@ export interface CompositionPanelProps {
   stretchLow: number
   stretchHigh: number
   onStretchChange: (low: number, high: number) => void
-  opacity: number
-  onOpacityChange: (v: number) => void
   running: boolean
   progress: number
   progressMsg: string
@@ -107,8 +104,6 @@ export const CompositionPanel = forwardRef<
     stretchLow,
     stretchHigh,
     onStretchChange,
-    opacity,
-    onOpacityChange,
     running,
     progress,
     progressMsg,
@@ -383,18 +378,6 @@ export const CompositionPanel = forwardRef<
               />
             </div>
           </label>
-          <label className="flex flex-col gap-1 text-[10px] text-muted-foreground">
-            Opacity {Math.round(opacity * 100)}%
-            <input
-              type="range"
-              min={0.15}
-              max={1}
-              step={0.05}
-              value={opacity}
-              onChange={(e) => onOpacityChange(Number(e.target.value))}
-              className="w-full accent-primary"
-            />
-          </label>
 
           {running && (
             <div className="flex flex-col gap-1">
@@ -434,9 +417,9 @@ export const CompositionPanel = forwardRef<
               Apply
             </button>
           </div>
-          <p className="flex items-center gap-1 text-[10px] text-muted-foreground">
-            <Layers className="size-3" />
-            Applying hides the prediction overlay; toggle both from Results.
+          <p className="text-[10px] text-muted-foreground">
+            Applying hides the prediction overlay; toggle visibility and
+            opacity from Overlay Tools.
           </p>
         </Section>
       </motion.div>

--- a/frontend/src/components/ControlPanel.tsx
+++ b/frontend/src/components/ControlPanel.tsx
@@ -39,10 +39,6 @@ interface ControlPanelProps {
   onModelKindChange: (m: ModelKind) => void
   prithviMode: "pixel" | "patch"
   onPrithviModeChange: (m: "pixel" | "patch") => void
-  overlayOpacity: number
-  onOpacityChange: (v: number) => void
-  smoothOverlay: boolean
-  onSmoothOverlayChange: (v: boolean) => void
   running: boolean
   progress: number
   progressMsg: string
@@ -101,10 +97,6 @@ export const ControlPanel = forwardRef<HTMLDivElement, ControlPanelProps>(
     onModelKindChange,
     prithviMode,
     onPrithviModeChange,
-    overlayOpacity,
-    onOpacityChange,
-    smoothOverlay,
-    onSmoothOverlayChange,
     running,
     progress,
     progressMsg,
@@ -387,35 +379,6 @@ export const ControlPanel = forwardRef<HTMLDivElement, ControlPanelProps>(
             Cumulative temporal mode is available with Random Forest only.
           </p>
         )}
-        <div className="flex flex-col gap-1">
-          <div className="flex items-center justify-between">
-            <span className="eyebrow">overlay opacity</span>
-            <span className="telemetry text-xs text-foreground">
-              {Math.round(overlayOpacity * 100)}%
-            </span>
-          </div>
-          <input
-            type="range"
-            min={0}
-            max={1}
-            step={0.05}
-            value={overlayOpacity}
-            onChange={(e) => onOpacityChange(parseFloat(e.target.value))}
-            className="accent-[var(--primary)]"
-          />
-        </div>
-        <label className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-          <input
-            type="checkbox"
-            checked={smoothOverlay}
-            onChange={(e) => onSmoothOverlayChange(e.target.checked)}
-            className="accent-primary"
-          />
-          Smooth prediction overlay
-        </label>
-        <p className="-mt-1 text-[10px] leading-snug text-muted-foreground/80">
-          Contour style — solid classes, curved boundaries
-        </p>
       </Section>
 
       <div className="mt-auto flex flex-col gap-2 pt-2">

--- a/frontend/src/components/ResultsPanel.tsx
+++ b/frontend/src/components/ResultsPanel.tsx
@@ -6,209 +6,127 @@ import { useAuth } from "@/lib/auth"
 
 interface ResultsPanelProps {
   result: PredictResult
-  showPredictionOverlay: boolean
-  onShowPredictionOverlayChange: (v: boolean) => void
-  showConfidence: boolean
-  onShowConfidenceChange: (v: boolean) => void
-  confidenceOnTop: boolean
-  onConfidenceOnTopChange: (v: boolean) => void
-  smoothOverlay: boolean
-  onSmoothOverlayChange: (v: boolean) => void
-  swipeCompare: boolean
-  onSwipeCompareChange: (v: boolean) => void
   onClose: () => void
   onNewClassification: () => void
 }
 
 export const ResultsPanel = forwardRef<HTMLDivElement, ResultsPanelProps>(
-  function ResultsPanel(
-    {
-      result,
-      showPredictionOverlay,
-      onShowPredictionOverlayChange,
-      showConfidence,
-      onShowConfidenceChange,
-      confidenceOnTop,
-      onConfidenceOnTopChange,
-      smoothOverlay,
-      onSmoothOverlayChange,
-      swipeCompare,
-      onSwipeCompareChange,
-      onClose,
-      onNewClassification,
-    },
-    ref
-  ) {
-  const [collapsed, setCollapsed] = useState(false)
-  const { goAnalysis } = useAuth()
+  function ResultsPanel({ result, onClose, onNewClassification }, ref) {
+    const [collapsed, setCollapsed] = useState(false)
+    const { goAnalysis } = useAuth()
 
-  const isLulcOnly =
-    !!result.lulc &&
-    !(result.n_dates > 0) &&
-    !(result.confidence_uri && result.confidence_uri.length > 0)
+    const isLulcOnly =
+      !!result.lulc &&
+      !(result.n_dates > 0) &&
+      !(result.confidence_uri && result.confidence_uri.length > 0)
 
-  const stats = isLulcOnly
-    ? (result.lulc?.composition ?? []).map((c) => ({
-        class_id: c.class_id,
-        name: c.name,
-        color: c.color,
-        pct: c.pct,
-      }))
-    : result.class_stats
+    const stats = isLulcOnly
+      ? (result.lulc?.composition ?? []).map((c) => ({
+          class_id: c.class_id,
+          name: c.name,
+          color: c.color,
+          pct: c.pct,
+        }))
+      : result.class_stats
 
-  const subtitle = isLulcOnly
-    ? `MapBiomas ${result.lulc?.year ?? 2023} · ${result.lulc?.metrics.area_ha.toFixed(1) ?? "—"} ha`
-    : `${result.n_dates} scenes · ${result.date_range?.[0] ?? "—"} → ${result.date_range?.[1] ?? "—"}`
+    const subtitle = isLulcOnly
+      ? `MapBiomas ${result.lulc?.year ?? 2023} · ${result.lulc?.metrics.area_ha.toFixed(1) ?? "—"} ha`
+      : `${result.n_dates} scenes · ${result.date_range?.[0] ?? "—"} → ${result.date_range?.[1] ?? "—"}`
 
-  return (
-    <motion.div
-      ref={ref}
-      className="panel app-no-drag absolute bottom-3 left-[23.5rem] right-16 z-[1000] mx-auto max-w-[36rem] rounded-md"
-      initial={{ opacity: 0, y: 24 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: 24 }}
-      transition={{ type: "spring", stiffness: 380, damping: 32 }}
-    >
-      <div className="flex items-center justify-between px-3 py-2">
-        <div className="flex items-baseline gap-2">
-          <span className="eyebrow !text-foreground">
-            {isLulcOnly ? "Land cover" : "Result"}
-          </span>
-          <span className="telemetry text-[11px] text-muted-foreground">
-            {subtitle}
-            {!isLulcOnly && result.mean_confidence > 0 && (
-              <> · conf {(result.mean_confidence * 100).toFixed(0)}%</>
-            )}
-          </span>
-        </div>
-        <div className="flex items-center gap-1">
-          <button
-            type="button"
-            onClick={goAnalysis}
-            className="flex items-center gap-1 rounded-sm px-2 py-1 text-[11px] text-primary hover:bg-primary/10"
-            title="Open analysis"
-          >
-            <ChartColumn className="size-3.5" />
-            Analysis
-          </button>
-          <button
-            type="button"
-            onClick={onNewClassification}
-            className="flex items-center gap-1 rounded-sm px-2 py-1 text-[11px] text-muted-foreground hover:bg-secondary hover:text-foreground"
-            title="Start a new classification"
-          >
-            <Plus className="size-3.5" />
-            New
-          </button>
-          <button
-            onClick={() => setCollapsed((c) => !c)}
-            className="text-muted-foreground hover:text-foreground"
-            title={collapsed ? "Expand" : "Collapse"}
-          >
-            {collapsed ? <ChevronUp className="size-4" /> : <ChevronDown className="size-4" />}
-          </button>
-          <button
-            onClick={onClose}
-            className="text-muted-foreground hover:text-foreground"
-            title="Close result"
-          >
-            <X className="size-4" />
-          </button>
-        </div>
-      </div>
-
-      {!collapsed && (
-        <>
-          <hr className="hairline" />
-          <div className="flex flex-col gap-3 p-3">
-            <div className="grid grid-cols-2 gap-x-3 gap-y-2">
-              <label className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-                <input
-                  type="checkbox"
-                  checked={showPredictionOverlay}
-                  onChange={(e) =>
-                    onShowPredictionOverlayChange(e.target.checked)
-                  }
-                  className="accent-primary"
-                />
-                Show prediction overlay
-              </label>
-              <label className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-                <input
-                  type="checkbox"
-                  checked={smoothOverlay}
-                  onChange={(e) => onSmoothOverlayChange(e.target.checked)}
-                  className="accent-primary"
-                />
-                Smooth prediction overlay
-              </label>
-              <label className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-                <input
-                  type="checkbox"
-                  checked={swipeCompare}
-                  onChange={(e) => onSwipeCompareChange(e.target.checked)}
-                  className="accent-primary"
-                />
-                Swipe imagery ↔ overlay
-              </label>
-              {!isLulcOnly && (
-                <label className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-                  <input
-                    type="checkbox"
-                    checked={showConfidence}
-                    onChange={(e) => onShowConfidenceChange(e.target.checked)}
-                    className="accent-primary"
-                  />
-                  Show confidence overlay
-                </label>
+    return (
+      <motion.div
+        ref={ref}
+        className="panel app-no-drag absolute bottom-3 left-[23.5rem] right-16 z-[1000] mx-auto max-w-[36rem] rounded-md"
+        initial={{ opacity: 0, y: 24 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: 24 }}
+        transition={{ type: "spring", stiffness: 380, damping: 32 }}
+      >
+        <div className="flex items-center justify-between px-3 py-2">
+          <div className="flex items-baseline gap-2">
+            <span className="eyebrow !text-foreground">
+              {isLulcOnly ? "Land cover" : "Result"}
+            </span>
+            <span className="telemetry text-[11px] text-muted-foreground">
+              {subtitle}
+              {!isLulcOnly && result.mean_confidence > 0 && (
+                <> · conf {(result.mean_confidence * 100).toFixed(0)}%</>
               )}
-              {!isLulcOnly && (
-                <label
-                  className={`flex items-center gap-1.5 text-[11px] text-muted-foreground ${
-                    !showConfidence ? "opacity-45" : ""
-                  }`}
-                >
-                  <input
-                    type="checkbox"
-                    checked={confidenceOnTop}
-                    disabled={!showConfidence}
-                    onChange={(e) => onConfidenceOnTopChange(e.target.checked)}
-                    className="accent-primary"
-                  />
-                  Keep prediction under confidence
-                </label>
-              )}
-            </div>
-            <ul className="flex flex-col gap-1.5">
-              {stats.slice(0, 5).map((s) => (
-                <li key={s.class_id} className="flex items-center gap-2 text-xs">
-                  <span
-                    className="size-2.5 shrink-0 rounded-[2px]"
-                    style={{ backgroundColor: s.color }}
-                  />
-                  <span className="w-40 shrink-0 truncate">{s.name}</span>
-                  <span className="relative h-2 flex-1 overflow-hidden rounded-full bg-secondary">
-                    <span
-                      className="absolute inset-y-0 left-0 rounded-full"
-                      style={{ width: `${s.pct}%`, backgroundColor: s.color }}
-                    />
-                  </span>
-                  <span className="telemetry w-12 shrink-0 text-right text-foreground">
-                    {s.pct.toFixed(1)}%
-                  </span>
-                </li>
-              ))}
-            </ul>
-            <p className="text-[10px] text-muted-foreground">
-              {isLulcOnly
-                ? "MapBiomas cover on the map. Open Analysis for groups, diversity and details."
-                : swipeCompare
-                  ? "Drag the handle to reveal satellite imagery under the prediction / confidence overlay."
-                  : "Open Analysis for land cover / use, cover map, VI series and phenology."}
-            </p>
+            </span>
           </div>
-        </>
-      )}
-    </motion.div>
-  )
-})
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={goAnalysis}
+              className="flex items-center gap-1 rounded-sm px-2 py-1 text-[11px] text-primary hover:bg-primary/10"
+              title="Open analysis"
+            >
+              <ChartColumn className="size-3.5" />
+              Analysis
+            </button>
+            <button
+              type="button"
+              onClick={onNewClassification}
+              className="flex items-center gap-1 rounded-sm px-2 py-1 text-[11px] text-muted-foreground hover:bg-secondary hover:text-foreground"
+              title="Start a new classification"
+            >
+              <Plus className="size-3.5" />
+              New
+            </button>
+            <button
+              onClick={() => setCollapsed((c) => !c)}
+              className="text-muted-foreground hover:text-foreground"
+              title={collapsed ? "Expand" : "Collapse"}
+            >
+              {collapsed ? (
+                <ChevronUp className="size-4" />
+              ) : (
+                <ChevronDown className="size-4" />
+              )}
+            </button>
+            <button
+              onClick={onClose}
+              className="text-muted-foreground hover:text-foreground"
+              title="Close result"
+            >
+              <X className="size-4" />
+            </button>
+          </div>
+        </div>
+
+        {!collapsed && (
+          <>
+            <hr className="hairline" />
+            <div className="flex flex-col gap-3 p-3">
+              <ul className="flex flex-col gap-1.5">
+                {stats.slice(0, 5).map((s) => (
+                  <li key={s.class_id} className="flex items-center gap-2 text-xs">
+                    <span
+                      className="size-2.5 shrink-0 rounded-[2px]"
+                      style={{ backgroundColor: s.color }}
+                    />
+                    <span className="w-40 shrink-0 truncate">{s.name}</span>
+                    <span className="relative h-2 flex-1 overflow-hidden rounded-full bg-secondary">
+                      <span
+                        className="absolute inset-y-0 left-0 rounded-full"
+                        style={{ width: `${s.pct}%`, backgroundColor: s.color }}
+                      />
+                    </span>
+                    <span className="telemetry w-12 shrink-0 text-right text-foreground">
+                      {s.pct.toFixed(1)}%
+                    </span>
+                  </li>
+                ))}
+              </ul>
+              <p className="text-[10px] text-muted-foreground">
+                {isLulcOnly
+                  ? "MapBiomas cover on the map. Open Analysis for groups, diversity and details."
+                  : "Overlay visibility, swipe, and opacity live in Overlay Tools. Open Analysis for cover map, VI series and phenology."}
+              </p>
+            </div>
+          </>
+        )}
+      </motion.div>
+    )
+  }
+)

--- a/frontend/src/pages/MapScreen.tsx
+++ b/frontend/src/pages/MapScreen.tsx
@@ -251,10 +251,6 @@ export function MapScreen(props: MapScreenProps) {
             onModelKindChange={props.onModelKindChange}
             prithviMode={props.prithviMode}
             onPrithviModeChange={props.onPrithviModeChange}
-            overlayOpacity={props.overlayOpacity}
-            onOpacityChange={props.onOpacityChange}
-            smoothOverlay={props.smoothOverlay}
-            onSmoothOverlayChange={props.onSmoothOverlayChange}
             running={props.running}
             progress={props.progress}
             progressMsg={props.progressMsg}
@@ -293,8 +289,6 @@ export function MapScreen(props: MapScreenProps) {
             stretchLow={props.composeStretchLow}
             stretchHigh={props.composeStretchHigh}
             onStretchChange={props.onComposeStretchChange}
-            opacity={props.composeOpacity}
-            onOpacityChange={props.onComposeOpacityChange}
             running={props.composeRunning}
             progress={props.composeProgress}
             progressMsg={props.composeProgressMsg}
@@ -319,16 +313,6 @@ export function MapScreen(props: MapScreenProps) {
           <ResultsPanel
             key="prediction-status"
             result={props.result!}
-            showPredictionOverlay={props.showPredictionOverlay}
-            onShowPredictionOverlayChange={props.onShowPredictionOverlayChange}
-            showConfidence={props.showConfidence}
-            onShowConfidenceChange={props.onShowConfidenceChange}
-            confidenceOnTop={props.confidenceOnTop}
-            onConfidenceOnTopChange={props.onConfidenceOnTopChange}
-            smoothOverlay={props.smoothOverlay}
-            onSmoothOverlayChange={props.onSmoothOverlayChange}
-            swipeCompare={props.swipeCompare}
-            onSwipeCompareChange={props.onSwipeCompareChange}
             onClose={props.onCloseResult}
             onNewClassification={props.onNewClassification}
           />


### PR DESCRIPTION
## Summary
- Remove duplicated prediction/composition overlay toggles and opacity controls from Result, Classify, and Compositions panels
- Overlay Tools remains the single place for visibility, swipe, smooth, and opacity

## Test plan
- [ ] After classify, Result strip shows stats only (no overlay checkboxes)
- [ ] Classify panel has no opacity / smooth controls
- [ ] Compositions panel has stretch + Apply/Clear but no opacity slider
- [ ] Overlay Tools still controls prediction, confidence, composition, swipe, opacity