### PR TITLE
fix(ui): keep hub project selected when opening the map

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,7 +11,6 @@ import {
   RenderComposite,
   OpenExternal,
   RevealMainWindow,
-  SavePreferences,
   SaveProjectOverlay,
   ListProjectOverlays,
   GetProject,
@@ -418,7 +417,7 @@ function AppBody(props: {
   onClearArea: () => void
   onImportPolygon: () => void
 }) {
-  const { refreshRuns, refreshProjects, screen, goAnalysis, goMap, runs, projects, prefs } =
+  const { refreshRuns, refreshProjects, screen, goAnalysis, goMap, runs, projects, prefs, savePrefs } =
     useAuth()
   const [loadingRun, setLoadingRun] = useState(false)
   const [dataCubeOpen, setDataCubeOpen] = useState(false)
@@ -451,58 +450,91 @@ function AppBody(props: {
   const [composeStretchHigh, setComposeStretchHigh] = useState(98)
   const [composeOpacity, setComposeOpacity] = useState(0.85)
   const didRestoreProjectRef = useRef(false)
+  const prefsRef = useRef(prefs)
+  prefsRef.current = prefs
+  const activeProjectIdRef = useRef(activeProjectId)
+  activeProjectIdRef.current = activeProjectId
+  /** Set when activate runs before prefs have loaded; flushed on next prefs hydrate. */
+  const pendingActiveProjectRef = useRef<string | null | undefined>(undefined)
 
   const persistAoiLabel = useCallback(
     async (label: string | null) => {
-      if (!prefs) return
-      const extras = parsePreferenceExtras(prefs.extras_json)
+      const current = prefsRef.current
+      if (!current) return
+      const extras = parsePreferenceExtras(current.extras_json)
+      // Keep React's active project — prefs may lag behind a just-activated id.
+      const aid = activeProjectIdRef.current?.trim()
+      if (aid) extras.active_project_id = aid
+      else delete extras.active_project_id
       const next = label?.trim()
       if (next) extras.aoi_label = next
       else delete extras.aoi_label
       try {
-        await SavePreferences({
-          ...prefs,
-          extras_json: JSON.stringify(extras),
-        } as never)
+        await savePrefs(
+          {
+            ...current,
+            extras_json: JSON.stringify(extras),
+          },
+          { silent: true }
+        )
       } catch {
         /* best-effort */
       }
     },
-    [prefs]
+    [savePrefs]
   )
-
-  useEffect(() => {
-    const extras = parsePreferenceExtras(prefs?.extras_json)
-    const id = extras.active_project_id?.trim() || null
-    if (!id) {
-      setActiveProjectId(null)
-      const orphanLabel = extras.aoi_label?.trim()
-      if (orphanLabel && !props.analysisLabel) {
-        props.setAnalysisLabel(orphanLabel)
-      }
-      return
-    }
-    setActiveProjectId(id)
-  }, [prefs?.extras_json, props.analysisLabel, props.setAnalysisLabel])
 
   const persistActiveProjectId = useCallback(
     async (id: string | null) => {
       setActiveProjectId(id)
-      if (!prefs) return
-      const extras = parsePreferenceExtras(prefs.extras_json)
+      activeProjectIdRef.current = id
+      const current = prefsRef.current
+      if (!current) {
+        pendingActiveProjectRef.current = id
+        return
+      }
+      pendingActiveProjectRef.current = undefined
+      const extras = parsePreferenceExtras(current.extras_json)
       if (id) extras.active_project_id = id
       else delete extras.active_project_id
       try {
-        await SavePreferences({
-          ...prefs,
-          extras_json: JSON.stringify(extras),
-        } as never)
+        await savePrefs(
+          {
+            ...current,
+            extras_json: JSON.stringify(extras),
+          },
+          { silent: true }
+        )
       } catch {
         /* best-effort */
       }
     },
-    [prefs]
+    [savePrefs]
   )
+
+  // Hydrate active project from prefs only when extras change — never on AOI rename.
+  useEffect(() => {
+    if (!prefs) return
+    if (pendingActiveProjectRef.current !== undefined) {
+      const pending = pendingActiveProjectRef.current
+      pendingActiveProjectRef.current = undefined
+      void persistActiveProjectId(pending)
+      return
+    }
+    const extras = parsePreferenceExtras(prefs.extras_json)
+    const id = extras.active_project_id?.trim() || null
+    if (id) {
+      setActiveProjectId(id)
+      return
+    }
+    setActiveProjectId(null)
+    const orphanLabel = extras.aoi_label?.trim()
+    if (orphanLabel && !props.analysisLabel) {
+      props.setAnalysisLabel(orphanLabel)
+    }
+    // Intentionally omit analysisLabel: renaming AOI must not re-run this sync.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only follow prefs extras
+  }, [prefs, prefs?.extras_json, persistActiveProjectId])
 
   const syncProjectAoi = useCallback(
     async (projectId: string, labelOverride?: string) => {

--- a/frontend/src/pages/AnalysisPage.tsx
+++ b/frontend/src/pages/AnalysisPage.tsx
@@ -72,7 +72,7 @@ interface AnalysisPageProps {
   /** Rename the active AOI (same path as map context-menu rename). */
   onAreaLabelChange?: (label: string) => void
   /** Set map active project when opening a project from the hub. */
-  onActivateProject?: (projectId: string) => void
+  onActivateProject?: (projectId: string) => void | Promise<void>
   /** Currently active project on the map (keeps Analysis list scoped). */
   activeProjectId?: string | null
 }
@@ -281,8 +281,8 @@ export function AnalysisPage({
       setNewName("")
       setSelectedProjectId(p.id)
       setHubView("detail")
+      if (onActivateProject) await onActivateProject(p.id)
       notifySuccess("Project created", name)
-      onActivateProject?.(p.id)
     } catch (e) {
       notifyError("Could not create project", e)
     } finally {
@@ -481,7 +481,14 @@ export function AnalysisPage({
         </button>
         <button
           type="button"
-          onClick={goMap}
+          onClick={() => {
+            void (async () => {
+              if (selectedProjectId && onActivateProject) {
+                await onActivateProject(selectedProjectId)
+              }
+              goMap()
+            })()
+          }}
           className="ar-ghost flex h-9 items-center gap-1.5 rounded-sm border px-4 text-xs text-muted-foreground hover:text-foreground"
         >
           <MapIcon className="h-3.5 w-3.5" />
@@ -509,7 +516,9 @@ export function AnalysisPage({
             setSelectedProjectId(id)
             setHubView("detail")
             clearSelection()
-            onActivateProject?.(id)
+            void (async () => {
+              if (onActivateProject) await onActivateProject(id)
+            })()
           }}
           onOpenUnassigned={() => {
             setHubView("unassigned")
@@ -534,8 +543,12 @@ export function AnalysisPage({
                     <button
                       type="button"
                       onClick={() => {
-                        onActivateProject?.(selectedProject.id)
-                        goMap()
+                        void (async () => {
+                          if (onActivateProject) {
+                            await onActivateProject(selectedProject.id)
+                          }
+                          goMap()
+                        })()
                       }}
                       className="ar-ghost flex h-8 items-center gap-1.5 rounded-sm border px-3 text-[11px] text-muted-foreground hover:text-foreground"
                     >
@@ -776,7 +789,18 @@ export function AnalysisPage({
               <ArrowLeft className="h-3 w-3" />
               Saved analyses
             </button>
-            <button type="button" onClick={goMap} className={btnGhost}>
+            <button
+              type="button"
+              onClick={() => {
+                void (async () => {
+                  if (selectedProjectId && onActivateProject) {
+                    await onActivateProject(selectedProjectId)
+                  }
+                  goMap()
+                })()
+              }}
+              className={btnGhost}
+            >
               <MapIcon className="h-3 w-3" />
               View on map
             </button>


### PR DESCRIPTION
## Summary
- Persist `active_project_id` through `savePrefs` so React prefs stay in sync with SQLite
- Avoid wiping the active project when AOI label changes or prefs hydrate late
- Await project activation on create / open / Go to map / View on map so the ProjectSwitcher shows the correct project

## Test plan
- [ ] Create a project in the hub → Go to map → switcher shows that project
- [ ] Open an existing project → Open on map → project stays selected
- [ ] Rename AOI → active project does not reset to “No project”
- [ ] Select “No project” in the switcher → clears as expected