### PR TITLE
fix(aoi): correct fly-to centroid and clear composition on new classification

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1113,19 +1113,20 @@ function AppBody(props: {
   const startNewClassification = useCallback(() => {
     props.setResult(null)
     props.setShowPredictionOverlay(true)
-    props.setAnalysisLabel(undefined)
     props.setSwipeCompare(false)
     props.setSwipeRatio(0.5)
-    props.onClearArea()
+    // Starting over drops the AOI, so the session composition must go with it:
+    // otherwise the previous AOI's overlay stays painted over the empty map.
+    // Saved compositions are reloaded from the project on reopen.
+    clearAreaAndComposition()
     goMap()
   }, [
     goMap,
+    clearAreaAndComposition,
     props.setResult,
     props.setShowPredictionOverlay,
-    props.setAnalysisLabel,
     props.setSwipeCompare,
     props.setSwipeRatio,
-    props.onClearArea,
   ])
   const applyAoiRename = useCallback(
     async (label: string) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,6 +44,7 @@ import type {
 import { leftDockTabsModeFromPrefs, parsePreferenceExtras } from "@/lib/preferenceExtras"
 import { makeRunLabel, resolveAoiDisplayLabel, aoiLabelFromRunSummary } from "@/lib/aoiLabel"
 import { projectOverlayToComposition } from "@/lib/projectOverlays"
+import { geometryCentroid, usesExampleArea } from "@/lib/geometry"
 import { ProjectSwitcher } from "@/components/ProjectSwitcher"
 import { resolveCompositionMeta } from "@/lib/compositeCatalog"
 import {
@@ -539,9 +540,7 @@ function AppBody(props: {
 
   const syncProjectAoi = useCallback(
     async (projectId: string, labelOverride?: string) => {
-      const useExample =
-        !!props.activeExample &&
-        !!props.areas.find((a) => a.id === props.activeExample)
+      const useExample = usesExampleArea(props.activeExample, props.areas)
       const renamed = (labelOverride ?? props.analysisLabel)?.trim()
       let label = renamed
       if (!label) {
@@ -622,21 +621,13 @@ function AppBody(props: {
           const label = savedLabel || p.name
           props.setAnalysisLabel(label)
           void persistAoiLabel(label)
-          if (aoi.polygon?.type === "Polygon") {
-            const ring = aoi.polygon.coordinates?.[0]
-            if (ring?.length) {
-              let lat = 0
-              let lon = 0
-              for (const [x, y] of ring) {
-                lon += x
-                lat += y
-              }
-              props.setFlyTo({
-                lat: lat / ring.length,
-                lon: lon / ring.length,
-                key: Date.now(),
-              })
-            }
+          const centroid = geometryCentroid(aoi.polygon)
+          if (centroid) {
+            props.setFlyTo({
+              lat: centroid[1],
+              lon: centroid[0],
+              key: Date.now(),
+            })
           }
         }
         const overlays = (await ListProjectOverlays(
@@ -723,8 +714,7 @@ function AppBody(props: {
       notifyError("Define an area: draw, search, or load an example.")
       return
     }
-    const useExample =
-      !!props.activeExample && !!props.areas.find((a) => a.id === props.activeExample)
+    const useExample = usesExampleArea(props.activeExample, props.areas)
     const req: DataCubeRequest = {
       area_id: useExample ? props.activeExample : "",
       polygon_geojson: useExample ? null : props.customPolygon,
@@ -766,8 +756,7 @@ function AppBody(props: {
       notifyError("Define an area first.")
       return
     }
-    const useExample =
-      !!props.activeExample && !!props.areas.find((a) => a.id === props.activeExample)
+    const useExample = usesExampleArea(props.activeExample, props.areas)
     const req: CompositeRequest = {
       area_id: useExample ? props.activeExample : "",
       polygon_geojson: useExample ? null : props.customPolygon,
@@ -863,8 +852,7 @@ function AppBody(props: {
       notifyError("Define an area: draw, search, or load an example.")
       return
     }
-    const useExample =
-      !!props.activeExample && !!props.areas.find((a) => a.id === props.activeExample)
+    const useExample = usesExampleArea(props.activeExample, props.areas)
     const req: DataCubeRequest = {
       area_id: useExample ? props.activeExample : "",
       polygon_geojson: useExample ? null : props.customPolygon,
@@ -903,8 +891,7 @@ function AppBody(props: {
     props.setProgress(0)
     props.setProgressMsg("iniciando")
     props.setResult(null)
-    const useExample =
-      !!props.activeExample && !!props.areas.find((a) => a.id === props.activeExample)
+    const useExample = usesExampleArea(props.activeExample, props.areas)
     const aoiLabel =
       props.analysisLabel?.trim() ||
       (useExample
@@ -953,8 +940,7 @@ function AppBody(props: {
   }
 
   const handleAnalyzeLULC = async () => {
-    const useExample =
-      !!props.activeExample && !!props.areas.find((a) => a.id === props.activeExample)
+    const useExample = usesExampleArea(props.activeExample, props.areas)
     if (!useExample && !props.customPolygon) {
       notifyError("Draw a polygon or select example A/B/C.")
       return
@@ -1060,21 +1046,13 @@ function AppBody(props: {
         const aoi = parseRunPolygon(run.polygon_geojson, props.areas)
         props.setActiveExample(aoi.exampleId)
         props.setCustomPolygon(aoi.polygon)
-        if (aoi.polygon?.type === "Polygon") {
-          const ring = aoi.polygon.coordinates?.[0]
-          if (ring?.length) {
-            let lat = 0
-            let lon = 0
-            for (const [x, y] of ring) {
-              lon += x
-              lat += y
-            }
-            props.setFlyTo({
-              lat: lat / ring.length,
-              lon: lon / ring.length,
-              key: Date.now(),
-            })
-          }
+        const centroid = geometryCentroid(aoi.polygon)
+        if (centroid) {
+          props.setFlyTo({
+            lat: centroid[1],
+            lon: centroid[0],
+            key: Date.now(),
+          })
         }
         goAnalysis()
         notifySuccess("Analysis restored.")

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -18,6 +18,11 @@ import type { LatLngBoundsExpression } from "leaflet"
 import type { Area, PredictResult, GeoJSONGeometry, CompositionOverlay } from "@/lib/types"
 import { majoritySmoothOverlay } from "@/lib/smoothOverlay"
 import {
+  polygonOuterRing,
+  ringCentroid,
+  type LonLat,
+} from "@/lib/geometry"
+import {
   getAoiContourScheme,
   type AoiContourScheme,
   type AoiContourSchemeId,
@@ -645,30 +650,6 @@ function DrawControl({
   }, [map, customPolygon])
 
   return null
-}
-
-type LonLat = [number, number] // [lon, lat]
-
-function polygonOuterRing(geometry: GeoJSONGeometry): LonLat[] | null {
-  if (geometry.type === "Polygon") {
-    return (geometry.coordinates[0] as LonLat[]) ?? null
-  }
-  if (geometry.type === "MultiPolygon") {
-    const multi = geometry.coordinates as unknown as number[][][][]
-    return (multi[0]?.[0] as LonLat[]) ?? null
-  }
-  return null
-}
-
-function ringCentroid(ring: LonLat[]): LonLat {
-  let lon = 0
-  let lat = 0
-  const n = Math.max(1, ring.length - 1)
-  for (let i = 0; i < ring.length - 1; i++) {
-    lon += ring[i][0]
-    lat += ring[i][1]
-  }
-  return [lon / n, lat / n]
 }
 
 /** Ray-cast point-in-polygon (lon/lat), for AOI right-click hit testing. */

--- a/frontend/src/lib/geometry.ts
+++ b/frontend/src/lib/geometry.ts
@@ -1,0 +1,71 @@
+import type { Area, GeoJSONGeometry } from "@/lib/types"
+
+/** Coordinate pair in GeoJSON axis order: [lon, lat]. */
+export type LonLat = [number, number]
+
+/**
+ * Outer ring of a Polygon, or the outer ring of the first part of a
+ * MultiPolygon. Returns null for geometries without a usable ring.
+ */
+export function polygonOuterRing(geometry: GeoJSONGeometry): LonLat[] | null {
+  if (geometry.type === "Polygon") {
+    return (geometry.coordinates[0] as LonLat[]) ?? null
+  }
+  if (geometry.type === "MultiPolygon") {
+    const multi = geometry.coordinates as unknown as number[][][][]
+    return (multi[0]?.[0] as LonLat[]) ?? null
+  }
+  return null
+}
+
+/**
+ * Arithmetic mean of a linear ring's vertices.
+ *
+ * GeoJSON linear rings repeat the first position as the last one (RFC 7946
+ * section 3.1.6), so the closing vertex is excluded to avoid weighting it
+ * twice. Including it biases the result toward the first vertex by roughly
+ * 15-35 m on the bundled example AOIs.
+ *
+ * This is the vertex centroid, not the area centroid: it is used to pick a
+ * camera target for flyTo, not for any area-weighted measurement.
+ */
+export function ringCentroid(ring: LonLat[]): LonLat {
+  if (ring.length === 0) return [0, 0]
+  const closed =
+    ring.length > 1 &&
+    ring[0][0] === ring[ring.length - 1][0] &&
+    ring[0][1] === ring[ring.length - 1][1]
+  const count = closed ? ring.length - 1 : ring.length
+  if (count === 0) return [ring[0][0], ring[0][1]]
+  let lon = 0
+  let lat = 0
+  for (let i = 0; i < count; i++) {
+    lon += ring[i][0]
+    lat += ring[i][1]
+  }
+  return [lon / count, lat / count]
+}
+
+/** Vertex centroid of a geometry's outer ring, or null when it has none. */
+export function geometryCentroid(
+  geometry: GeoJSONGeometry | null | undefined
+): LonLat | null {
+  if (!geometry) return null
+  const ring = polygonOuterRing(geometry)
+  if (!ring?.length) return null
+  return ringCentroid(ring)
+}
+
+/**
+ * True when `activeExample` names an area that is present in `areas`.
+ *
+ * Requests send either an area id or an inline polygon, never both, so this
+ * guard decides which branch applies. A stale id that no longer resolves falls
+ * back to the drawn polygon rather than referencing a missing area.
+ */
+export function usesExampleArea(
+  activeExample: string,
+  areas: Area[]
+): boolean {
+  return !!activeExample && areas.some((a) => a.id === activeExample)
+}


### PR DESCRIPTION
## Summary

Two AOI state defects. The first is a measurable geometry error; the second is stale overlay state.

## Changes

**Fly-to centroid excluded the closing ring vertex.** `App.tsx` computed the camera target with two inline loops that averaged every vertex of the outer ring. GeoJSON linear rings repeat the first position as the last (RFC 7946 §3.1.6), so the first vertex was weighted twice and the target drifted toward it by **27.1 m, 34.8 m and 14.6 m** on the bundled example areas A, B and C.

`MapView` already had a correct `ringCentroid` that skipped the closing vertex, but it was file-local, so both call sites in `App.tsx` reimplemented it and got it wrong. Moved `polygonOuterRing` and `ringCentroid` into `lib/geometry.ts`, added `geometryCentroid` as the shared entry point.

Two further gaps closed along the way:
- The inline loops only handled `Polygon`; a `MultiPolygon` AOI silently produced no fly-to at all.
- `ringCentroid` assumed closure rather than checking it, so an unclosed ring would have divided by `n-1` incorrectly.

**Composition persisted after starting a new classification.** `startNewClassification` reset the result, label, swipe state and AOI, but left `composition`, `compositionGallery` and the scene selection untouched — so the previous AOI's band composition stayed painted on an otherwise empty map, and the only way out was the Clear button.

The cleanup already existed in `clearAreaAndComposition`, which every `onClearArea` entry point uses; `startNewClassification` hand-rolled a partial copy of it. It now delegates instead.

Closing the result panel with X is deliberately left as is: it does not drop the AOI, so it stays a "hide this result" action.

Also replaced six copies of the `activeExample` guard with `usesExampleArea`.

## Testing

- `tsc --noEmit` clean; `npm run build` and `wails build` succeed
- `go test ./backend/...` passes both packages
- `pytest sidecar/tests -q` — 25 passed
- Centroid verified against the real `areas/*.geojson`: drift figures above measured directly, and closed vs unclosed squares both return `[1,1]`
- Edge cases checked: empty ring, single vertex and null geometry degrade without `NaN`; `MultiPolygon` now returns a centroid where the old code returned nothing

## Checklist

- [ ] Tests added/updated — no frontend test suite exists in this repo; verification was done against the bundled AOI fixtures and is described above
- [x] Documentation updated — rationale and measured figures are in the commit messages and code comments
- [x] No console errors/warnings
- [x] Code follows project standards

---
Stacked series, merge in order: **this PR** → a11y/contrast → EO metadata → data tables.
