### PR TITLE
feat(analysis): inspect the research pack from the analysis header

### DIFF
--- a/frontend/src/components/DataTableView.tsx
+++ b/frontend/src/components/DataTableView.tsx
@@ -1,0 +1,261 @@
+import { useMemo, useState } from "react"
+import { ArrowDown, ArrowUp, Check, Copy, Table2 } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { notifyError, notifySuccess } from "@/lib/notify"
+import {
+  formatNumber,
+  tableToCSV,
+  type CellValue,
+  type DataTable,
+} from "@/lib/analysisTables"
+
+type SortState = { column: number; direction: "asc" | "desc" } | null
+
+function compare(a: CellValue, b: CellValue): number {
+  const aEmpty = a === null || a === undefined || a === ""
+  const bEmpty = b === null || b === undefined || b === ""
+  // Missing values sort last in either direction rather than as zero.
+  if (aEmpty && bEmpty) return 0
+  if (aEmpty) return 1
+  if (bEmpty) return -1
+  if (typeof a === "number" && typeof b === "number") return a - b
+  return String(a).localeCompare(String(b), undefined, { numeric: true })
+}
+
+/**
+ * Renders one analysis table with the same columns and value formatting the
+ * research pack writes to CSV, so a figure read here matches the exported file.
+ *
+ * Sorting is view-only; copy and download always emit the table in its stored
+ * order, which is the order the exporter uses.
+ */
+export function DataTableView({
+  table,
+  caption,
+  onDownload,
+}: {
+  table: DataTable
+  caption?: string
+  /** Omit to hide the download action (copy is always available). */
+  onDownload?: (table: DataTable) => void
+}) {
+  const [sort, setSort] = useState<SortState>(null)
+  const [copied, setCopied] = useState(false)
+
+  const rows = useMemo(() => {
+    if (!sort) return table.rows
+    const dir = sort.direction === "asc" ? 1 : -1
+    return [...table.rows].sort(
+      (a, b) => compare(a[sort.column], b[sort.column]) * dir
+    )
+  }, [table.rows, sort])
+
+  const toggleSort = (index: number) => {
+    setSort((cur) => {
+      if (cur?.column !== index) return { column: index, direction: "asc" }
+      if (cur.direction === "asc") return { column: index, direction: "desc" }
+      return null
+    })
+  }
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(tableToCSV(table))
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1400)
+    } catch (e) {
+      notifyError("Could not copy the table", e)
+    }
+  }
+
+  return (
+    <div className="flex min-w-0 flex-col gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="telemetry text-[10px] text-muted-foreground">
+          {table.rows.length} {table.rows.length === 1 ? "row" : "rows"}
+          {" · "}
+          {table.csvName}
+          {caption ? ` · ${caption}` : ""}
+        </p>
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            onClick={() => void copy()}
+            className="ar-ghost flex h-7 items-center gap-1.5 rounded-sm border px-2 text-[10px] text-muted-foreground hover:text-foreground"
+            title="Copy this table as CSV"
+          >
+            {copied ? (
+              <Check className="h-3 w-3 text-primary" />
+            ) : (
+              <Copy className="h-3 w-3" />
+            )}
+            {copied ? "Copied" : "Copy CSV"}
+          </button>
+          {onDownload && (
+            <button
+              type="button"
+              onClick={() => onDownload(table)}
+              className="ar-ghost flex h-7 items-center gap-1.5 rounded-sm border px-2 text-[10px] text-muted-foreground hover:text-foreground"
+              title={`Save ${table.csvName}`}
+            >
+              <Table2 className="h-3 w-3" />
+              Save CSV
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Wide tables scroll inside the section rather than widening the page. */}
+      <div className="ar-inset max-h-[22rem] overflow-auto">
+        <table className="w-full min-w-max text-left text-[11px]">
+          <thead className="sticky top-0 z-10">
+            <tr
+              className="border-b"
+              style={{
+                borderColor: "var(--ar-border)",
+                background: "var(--ar-raised)",
+              }}
+            >
+              {table.columns.map((c, i) => {
+                const active = sort?.column === i
+                return (
+                  <th
+                    key={c.key}
+                    scope="col"
+                    aria-sort={
+                      active
+                        ? sort.direction === "asc"
+                          ? "ascending"
+                          : "descending"
+                        : "none"
+                    }
+                    className="p-0 font-normal"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => toggleSort(i)}
+                      className={cn(
+                        "telemetry flex w-full items-center gap-1 px-2.5 py-1.5 text-[10px] hover:text-foreground",
+                        c.numeric ? "justify-end" : "justify-start",
+                        active ? "text-foreground" : "text-muted-foreground"
+                      )}
+                      title={`Sort by ${c.key}`}
+                    >
+                      {c.key}
+                      {active &&
+                        (sort.direction === "asc" ? (
+                          <ArrowUp className="h-2.5 w-2.5" />
+                        ) : (
+                          <ArrowDown className="h-2.5 w-2.5" />
+                        ))}
+                    </button>
+                  </th>
+                )
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, r) => (
+              <tr
+                key={r}
+                className="border-b last:border-b-0"
+                style={{ borderColor: "var(--ar-border)" }}
+              >
+                {row.map((cell, c) => {
+                  const col = table.columns[c]
+                  const text = formatNumber(cell)
+                  return (
+                    <td
+                      key={col.key}
+                      className={cn(
+                        "whitespace-nowrap px-2.5 py-1.5",
+                        col.numeric
+                          ? "telemetry text-right text-foreground"
+                          : "text-muted-foreground"
+                      )}
+                    >
+                      {col.swatch && text ? (
+                        <span className="flex items-center gap-1.5">
+                          <span
+                            className="size-2.5 shrink-0 rounded-[2px]"
+                            style={{ backgroundColor: text }}
+                          />
+                          <span className="telemetry">{text}</span>
+                        </span>
+                      ) : (
+                        text
+                      )}
+                    </td>
+                  )
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+/** Shared success path for saving a single table through the Wails exporter. */
+export function notifyTableSaved(dest: string) {
+  if (dest) notifySuccess("Table saved", dest)
+}
+
+export type SectionView = "chart" | "table"
+
+/**
+ * Switches a section between its chart and the table behind it.
+ *
+ * Two mutually exclusive views of one dataset, so this is a radio group rather
+ * than a pair of buttons or a tablist: the section heading already names the
+ * dataset, and a tablist would imply panels that persist independently.
+ */
+export function ChartTableToggle({
+  value,
+  onChange,
+  label,
+  disabled,
+}: {
+  value: SectionView
+  onChange: (v: SectionView) => void
+  /** Names the dataset being switched, for the group's accessible name. */
+  label: string
+  /** Set when the section has no table, e.g. all values are missing. */
+  disabled?: boolean
+}) {
+  const options: { id: SectionView; text: string }[] = [
+    { id: "chart", text: "Chart" },
+    { id: "table", text: "Table" },
+  ]
+  return (
+    <div
+      role="radiogroup"
+      aria-label={`${label} view`}
+      className="ar-raised flex shrink-0 gap-0.5 p-0.5"
+    >
+      {options.map((o) => {
+        const active = value === o.id
+        return (
+          <button
+            key={o.id}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            disabled={disabled && o.id === "table"}
+            onClick={() => onChange(o.id)}
+            className={cn(
+              "rounded-sm px-2 py-0.5 text-[10px] font-medium transition-colors",
+              active
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground",
+              disabled && o.id === "table" && "cursor-not-allowed opacity-40"
+            )}
+          >
+            {o.text}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/ResearchPackModal.tsx
+++ b/frontend/src/components/ResearchPackModal.tsx
@@ -1,0 +1,385 @@
+import { useEffect, useMemo, useState } from "react"
+import { Braces, Download, Map as MapIcon, Shapes, Table2, X } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { notifyExportFail, notifyExportOk } from "@/lib/notify"
+import { ExportResearchPack } from "../../wailsjs/go/main/App"
+import type { GeoJSONGeometry, PredictResult } from "@/lib/types"
+import { allAnalysisTables, type DataTable } from "@/lib/analysisTables"
+import { DataTableView } from "@/components/DataTableView"
+import {
+  geometryAreaHectares,
+  geometryBounds,
+  geometryCentroid,
+  polygonParts,
+} from "@/lib/geometry"
+
+/**
+ * Inspector for the research pack, opened from the analysis header.
+ *
+ * The export writes a manifest, the AOI geometry, nine CSV tables and the
+ * classification raster, and none of it could be read without unzipping the
+ * archive elsewhere. This lists the same entries the ZIP contains and renders
+ * each one, so the pack can be checked before it leaves the application.
+ *
+ * Entries are named after the files the exporter writes, so what is inspected
+ * here maps one-to-one onto what lands on disk.
+ */
+
+type EntryKind = "manifest" | "aoi" | "table" | "raster"
+
+interface PackEntry {
+  /** Path inside the ZIP. */
+  name: string
+  kind: EntryKind
+  /** Short right-aligned annotation in the list. */
+  detail: string
+  table?: DataTable
+}
+
+function parseGeometry(raw?: string): GeoJSONGeometry | null {
+  if (!raw?.trim()) return null
+  try {
+    const parsed = JSON.parse(raw) as
+      | GeoJSONGeometry
+      | { geometry?: GeoJSONGeometry }
+    const geom =
+      (parsed as { geometry?: GeoJSONGeometry }).geometry ??
+      (parsed as GeoJSONGeometry)
+    return geom?.type === "Polygon" || geom?.type === "MultiPolygon"
+      ? geom
+      : null
+  } catch {
+    return null
+  }
+}
+
+function iconFor(kind: EntryKind) {
+  if (kind === "manifest") return <Braces className="h-3.5 w-3.5 shrink-0" />
+  if (kind === "aoi") return <Shapes className="h-3.5 w-3.5 shrink-0" />
+  if (kind === "raster") return <MapIcon className="h-3.5 w-3.5 shrink-0" />
+  return <Table2 className="h-3.5 w-3.5 shrink-0" />
+}
+
+export function ResearchPackModal({
+  result,
+  modelKind,
+  areaLabel,
+  areaId,
+  polygonGeoJSON,
+  onClose,
+}: {
+  result: PredictResult
+  modelKind: string
+  areaLabel?: string
+  areaId?: string
+  /** AOI as GeoJSON text, the same value the exporter receives. */
+  polygonGeoJSON?: string
+  onClose: () => void
+}) {
+  const [selected, setSelected] = useState<string | null>(null)
+  const [exporting, setExporting] = useState(false)
+
+  const geometry = useMemo(
+    () => parseGeometry(polygonGeoJSON),
+    [polygonGeoJSON]
+  )
+
+  /** Mirrors the manifest map written by BuildResearchPackZIP. */
+  const manifestRows = useMemo(() => {
+    if (!result) return []
+    return [
+      ["schema_version", "1"],
+      ["exported_at", "set when the pack is written"],
+      ["model_kind", modelKind || ""],
+      ["area_id", areaId ?? ""],
+      ["aoi_label", areaLabel?.trim() ?? ""],
+      ["n_dates", String(result.n_dates ?? 0)],
+      ["date_range", (result.date_range ?? []).join(" → ")],
+      ["mean_confidence", String(result.mean_confidence ?? 0)],
+      [
+        "extent",
+        result.extent
+          ? `${result.extent.lon_min}, ${result.extent.lat_min}, ${result.extent.lon_max}, ${result.extent.lat_max}`
+          : "",
+      ],
+    ]
+  }, [result, modelKind, areaId, areaLabel])
+
+  const entries = useMemo((): PackEntry[] => {
+    if (!result) return []
+    const list: PackEntry[] = [
+      { name: "manifest.json", kind: "manifest", detail: "run metadata" },
+    ]
+    if (geometry) {
+      const parts = polygonParts(geometry).length
+      list.push({
+        name: "aoi.geojson",
+        kind: "aoi",
+        detail: parts === 1 ? "1 part" : `${parts} parts`,
+      })
+    }
+    for (const t of allAnalysisTables(result)) {
+      list.push({
+        name: t.csvName,
+        kind: "table",
+        detail: `${t.rows.length} ${t.rows.length === 1 ? "row" : "rows"}`,
+        table: t,
+      })
+    }
+    if (result.raster_tif) {
+      list.push({
+        name: "rasters/classification.tif",
+        kind: "raster",
+        detail: "GeoTIFF",
+      })
+    }
+    return list
+  }, [result, geometry])
+
+  const active = useMemo(
+    () => entries.find((e) => e.name === selected) ?? entries[0] ?? null,
+    [entries, selected]
+  )
+
+  const exportPack = async () => {
+    if (!result) return
+    setExporting(true)
+    try {
+      // Strip the bulky data URIs, matching what the analysis page sends.
+      const pack = {
+        ...result,
+        overlay_uri: "",
+        confidence_uri: "",
+        ndvi_mean_uri: "",
+        true_color_uri: "",
+        reference_uri: "",
+        lulc: result.lulc
+          ? { ...result.lulc, map_uri: "", map_png: "" }
+          : result.lulc,
+      }
+      const dest = await ExportResearchPack(
+        {
+          model_kind: modelKind,
+          area_id: areaId ?? "",
+          aoi_label: areaLabel?.trim() || "",
+          polygon_geojson: polygonGeoJSON?.trim() || "",
+        },
+        pack as never
+      )
+      if (dest) notifyExportOk(dest)
+    } catch (e) {
+      notifyExportFail(e)
+    } finally {
+      setExporting(false)
+    }
+  }
+
+  // Escape closes, matching the other modals on this screen.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose()
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [onClose])
+
+  return (
+    <div
+      className="app-no-drag absolute inset-0 z-[2000] flex items-center justify-center bg-black/65 p-4 backdrop-blur-[2px]"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Research pack contents"
+        className="terra-workspace flex h-[min(48rem,92vh)] w-full max-w-6xl overflow-hidden rounded-sm border shadow-[0_16px_48px_rgba(0,0,0,0.55)]"
+        style={{
+          borderColor: "var(--ar-border)",
+          background: "var(--ar-panel)",
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+      <aside className="ar-sidebar flex w-[15rem] shrink-0 flex-col">
+        <div className="shrink-0 px-3.5 pb-2 pt-4">
+          <p className="font-display text-sm font-semibold tracking-wide text-foreground">
+            Research pack
+          </p>
+          <p className="telemetry mt-0.5 text-[10px] text-muted-foreground">
+            {entries.length} {entries.length === 1 ? "entry" : "entries"}
+          </p>
+        </div>
+        <nav className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-2 pb-2">
+          {entries.map((e) => {
+            const isActive = active?.name === e.name
+            return (
+              <button
+                key={e.name}
+                type="button"
+                onClick={() => setSelected(e.name)}
+                title={e.name}
+                className={cn(
+                  "ar-nav-item flex w-full items-center gap-2 px-2 py-1.5 text-left text-[11px]",
+                  isActive
+                    ? "is-active"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                {iconFor(e.kind)}
+                <span className="min-w-0 flex-1 truncate">{e.name}</span>
+                <span className="telemetry shrink-0 text-[10px] text-muted-foreground">
+                  {e.detail}
+                </span>
+              </button>
+            )
+          })}
+        </nav>
+      </aside>
+
+      <main className="flex min-h-0 min-w-0 flex-1 flex-col">
+        <header className="ar-header flex shrink-0 flex-wrap items-start justify-between gap-3 px-5 py-4 sm:px-6 lg:px-8">
+          <div className="min-w-0">
+            <p className="telemetry text-[10px] text-primary">DATA</p>
+            <h1 className="mt-0.5 truncate font-display text-xl font-semibold tracking-wide">
+              {active?.name ?? "Research pack"}
+            </h1>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {areaLabel ? `${areaLabel} · ` : ""}
+              Exactly what the research pack export writes to disk.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+          <button
+            type="button"
+            disabled={exporting}
+            onClick={() => void exportPack()}
+            className="flex h-9 items-center gap-1.5 rounded-sm bg-primary px-4 text-xs font-semibold text-primary-foreground disabled:opacity-60"
+          >
+            <Download className="h-3.5 w-3.5" />
+            {exporting ? "Exporting…" : "Export pack"}
+          </button>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              title="Close"
+              className="ar-ghost flex size-9 shrink-0 items-center justify-center rounded-sm border text-muted-foreground hover:text-foreground"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5 sm:px-6 lg:px-8">
+          {active?.kind === "table" && active.table ? (
+            <DataTableView table={active.table} />
+          ) : active?.kind === "manifest" ? (
+            <section className="ar-section p-4">
+              <p className="eyebrow mb-3">manifest.json</p>
+              <dl className="flex flex-col gap-1.5">
+                {manifestRows.map(([k, v]) => (
+                  <div
+                    key={k}
+                    className="grid grid-cols-[10rem_minmax(0,1fr)] items-baseline gap-3 border-b pb-1.5 text-[11px] last:border-b-0"
+                    style={{ borderColor: "var(--ar-border)" }}
+                  >
+                    <dt className="telemetry text-muted-foreground">{k}</dt>
+                    <dd className="telemetry break-words text-foreground">
+                      {v || <span className="text-muted-foreground">—</span>}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+              <p className="mt-3 text-[10px] text-muted-foreground">
+                exported_at is stamped by the exporter when the archive is
+                written, so it is not known until then.
+              </p>
+            </section>
+          ) : active?.kind === "aoi" && geometry ? (
+            <AoiEntry geometry={geometry} raw={polygonGeoJSON ?? ""} />
+          ) : active?.kind === "raster" ? (
+            <section className="ar-section p-4">
+              <p className="eyebrow mb-3">rasters/classification.tif</p>
+              <p className="text-[11px] text-muted-foreground">
+                The classification raster is copied into the archive from{" "}
+                <span className="telemetry text-foreground">
+                  {result.raster_tif}
+                </span>
+                . It is written in the Sentinel-2 UTM projection of the source
+                scene, not in the lon/lat used by the extent above, so a tool
+                reading it should take the CRS from the file itself.
+              </p>
+            </section>
+          ) : null}
+        </div>
+      </main>
+      </div>
+    </div>
+  )
+}
+
+function AoiEntry({
+  geometry,
+  raw,
+}: {
+  geometry: GeoJSONGeometry
+  raw: string
+}) {
+  const bounds = geometryBounds(geometry)
+  const centroid = geometryCentroid(geometry)
+  const parts = polygonParts(geometry)
+  const vertices = parts.reduce(
+    (sum, part) => sum + part.reduce((s, ring) => s + ring.length, 0),
+    0
+  )
+  const holes = parts.reduce((sum, part) => sum + Math.max(0, part.length - 1), 0)
+
+  const facts: [string, string][] = [
+    ["type", geometry.type],
+    ["parts", String(parts.length)],
+    ["interior rings", String(holes)],
+    ["vertices", String(vertices)],
+    ["area", `${geometryAreaHectares(geometry).toFixed(2)} ha`],
+    [
+      "centroid",
+      centroid ? `${centroid[0].toFixed(5)}, ${centroid[1].toFixed(5)}` : "—",
+    ],
+    [
+      "bbox W/S/E/N",
+      bounds
+        ? `${bounds.lonMin.toFixed(5)}, ${bounds.latMin.toFixed(5)}, ${bounds.lonMax.toFixed(5)}, ${bounds.latMax.toFixed(5)}`
+        : "—",
+    ],
+    ["crs", "EPSG:4326 (WGS 84)"],
+  ]
+
+  return (
+    <div className="flex flex-col gap-3">
+      <section className="ar-section p-4">
+        <p className="eyebrow mb-3">aoi.geojson</p>
+        <dl className="flex flex-col gap-1.5">
+          {facts.map(([k, v]) => (
+            <div
+              key={k}
+              className="grid grid-cols-[10rem_minmax(0,1fr)] items-baseline gap-3 border-b pb-1.5 text-[11px] last:border-b-0"
+              style={{ borderColor: "var(--ar-border)" }}
+            >
+              <dt className="telemetry text-muted-foreground">{k}</dt>
+              <dd className="telemetry break-words text-foreground">{v}</dd>
+            </div>
+          ))}
+        </dl>
+        <p className="mt-3 text-[10px] text-muted-foreground">
+          Area is a vertex-shoelace on an equirectangular projection about the
+          AOI latitude, and the centroid is a vertex mean, adequate as a map
+          target but not an area centroid.
+        </p>
+      </section>
+      <section className="ar-section p-4">
+        <p className="eyebrow mb-3">geometry source</p>
+        <pre className="ar-inset max-h-64 overflow-auto p-3 text-[10px] leading-relaxed text-muted-foreground">
+          {raw}
+        </pre>
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/lib/analysisTables.ts
+++ b/frontend/src/lib/analysisTables.ts
@@ -1,0 +1,345 @@
+/**
+ * Table definitions for the analysis data views.
+ *
+ * Column names, order and value formatting mirror backend/export_research.go,
+ * which writes the same nine tables into the research pack ZIP. What the
+ * application shows on screen and what it exports must be the same table, so a
+ * figure read here can be cited from the exported CSV without re-deriving it.
+ *
+ * Edit both together. The CSV file name on each definition is the file the Go
+ * writer produces, which is the anchor for checking the two still agree.
+ */
+import type {
+  ClassStat,
+  LULCAnalysis,
+  PhenologyMetrics,
+  PhenologyStatePoint,
+  PredictResult,
+  TemporalPoint,
+  VISeriesPoint,
+} from "@/lib/types"
+
+export type CellValue = string | number | null | undefined
+
+export interface TableColumn {
+  /** Column name, identical to the CSV header written by the Go exporter. */
+  key: string
+  /** Right-align and use the monospace face for numeric columns. */
+  numeric?: boolean
+  /** Render a colour swatch from this cell's hex value instead of the text. */
+  swatch?: boolean
+}
+
+export interface DataTable {
+  id: string
+  /** File name in the research pack; the anchor for parity with Go. */
+  csvName: string
+  columns: TableColumn[]
+  rows: CellValue[][]
+}
+
+/**
+ * Go writes floats with strconv.FormatFloat(v, 'f', -1, 64): the shortest
+ * decimal that round-trips, with no exponent and no thousands separator.
+ * JavaScript's default number-to-string is also shortest-round-trip but uses
+ * exponential notation outside 1e-7..1e21, so those are expanded here.
+ */
+export function formatNumber(v: CellValue): string {
+  if (v === null || v === undefined || v === "") return ""
+  if (typeof v === "string") return v
+  if (!Number.isFinite(v)) return ""
+  const s = String(v)
+  const m = s.match(/^(-?)(\d+)(?:\.(\d+))?[eE]([+-]?\d+)$/)
+  if (!m) return s
+  // Expand the exponent by moving the point, rather than toFixed, which is
+  // itself exponential at or above 1e21.
+  const [, sign, intPart, fracPart = "", expPart] = m
+  const exp = Number(expPart)
+  const digits = intPart + fracPart
+  if (exp >= 0) {
+    const point = intPart.length + exp
+    return (
+      sign +
+      (point >= digits.length
+        ? digits + "0".repeat(point - digits.length)
+        : `${digits.slice(0, point)}.${digits.slice(point)}`)
+    )
+  }
+  return `${sign}0.${"0".repeat(-exp - intPart.length)}${digits}`
+}
+
+function table(
+  id: string,
+  csvName: string,
+  columns: TableColumn[],
+  rows: CellValue[][]
+): DataTable | null {
+  return rows.length ? { id, csvName, columns, rows } : null
+}
+
+const num = (key: string): TableColumn => ({ key, numeric: true })
+
+export function classStatsTable(stats: ClassStat[]): DataTable | null {
+  return table(
+    "class_stats",
+    "class_stats.csv",
+    [
+      num("class_id"),
+      { key: "name" },
+      { key: "color", swatch: true },
+      num("pixels"),
+      num("pct"),
+      num("area_ha"),
+    ],
+    (stats ?? []).map((c) => [
+      c.class_id,
+      c.name,
+      c.color,
+      c.pixels,
+      c.pct,
+      c.area_ha,
+    ])
+  )
+}
+
+export function viSeriesTable(series: VISeriesPoint[]): DataTable | null {
+  return table(
+    "vi_series",
+    "vi_series.csv",
+    [
+      { key: "date" },
+      num("ndvi_mean"),
+      num("ndvi_std"),
+      num("evi_mean"),
+      num("evi_std"),
+      num("savi_mean"),
+      num("savi_std"),
+    ],
+    (series ?? []).map((p) => [
+      p.date,
+      p.ndvi_mean,
+      p.ndvi_std,
+      p.evi_mean,
+      p.evi_std,
+      p.savi_mean,
+      p.savi_std,
+    ])
+  )
+}
+
+/** True when at least one metric is present; matches hasPhenology in Go. */
+export function hasPhenology(ph?: PhenologyMetrics | null): boolean {
+  if (!ph) return false
+  return [
+    ph.sos_doy,
+    ph.pos_doy,
+    ph.eos_doy,
+    ph.los_days,
+    ph.peak,
+    ph.base,
+    ph.amplitude,
+  ].some((v) => v !== null && v !== undefined)
+}
+
+export function phenologyTable(
+  ph?: PhenologyMetrics | null
+): DataTable | null {
+  if (!hasPhenology(ph) || !ph) return null
+  return table(
+    "phenology",
+    "phenology.csv",
+    [
+      num("sos_doy"),
+      num("pos_doy"),
+      num("eos_doy"),
+      num("los_days"),
+      num("peak"),
+      num("base"),
+      num("amplitude"),
+    ],
+    [
+      [
+        ph.sos_doy,
+        ph.pos_doy,
+        ph.eos_doy,
+        ph.los_days,
+        ph.peak,
+        ph.base,
+        ph.amplitude,
+      ],
+    ]
+  )
+}
+
+export function phenologyStatesTable(
+  states: PhenologyStatePoint[]
+): DataTable | null {
+  return table(
+    "phenology_states",
+    "phenology_states.csv",
+    [
+      { key: "date" },
+      num("state"),
+      { key: "state_name" },
+      { key: "color", swatch: true },
+      num("ndvi_mean"),
+    ],
+    (states ?? []).map((s) => [
+      s.date,
+      s.state,
+      s.state_name,
+      s.color,
+      s.ndvi_mean,
+    ])
+  )
+}
+
+export function temporalTable(points: TemporalPoint[]): DataTable | null {
+  return table(
+    "temporal",
+    "temporal.csv",
+    [
+      { key: "date" },
+      num("n_dates_stack"),
+      num("soja_ndvi_mean"),
+      num("soja_retention_pct"),
+      { key: "dominant" },
+    ],
+    (points ?? []).map((t) => [
+      t.date,
+      t.n_dates_stack,
+      t.soja_ndvi_mean,
+      t.soja_retention_pct,
+      t.dominant ?? "",
+    ])
+  )
+}
+
+export function lulcMetricsTable(lulc?: LULCAnalysis | null): DataTable | null {
+  if (!lulc?.metrics) return null
+  const m = lulc.metrics
+  return table(
+    "lulc_metrics",
+    "lulc_metrics.csv",
+    [
+      num("year"),
+      { key: "source" },
+      num("area_ha"),
+      num("n_pixels"),
+      num("n_classes"),
+      num("shannon_h"),
+      num("pielou_j"),
+      { key: "dominant_class" },
+      num("dominant_pct"),
+      num("soja_pct"),
+      num("outras_lav_pct"),
+      num("agricola_pct"),
+    ],
+    [
+      [
+        lulc.year,
+        lulc.source,
+        m.area_ha,
+        m.n_pixels,
+        m.n_classes,
+        m.shannon_h,
+        m.pielou_j,
+        m.dominant_class,
+        m.dominant_pct,
+        m.soja_pct,
+        m.outras_lav_pct,
+        m.agricola_pct,
+      ],
+    ]
+  )
+}
+
+export function lulcCompositionTable(
+  lulc?: LULCAnalysis | null
+): DataTable | null {
+  return table(
+    "lulc_composition",
+    "lulc_composition.csv",
+    [
+      num("class_id"),
+      { key: "name" },
+      { key: "color", swatch: true },
+      { key: "group" },
+      num("pixels"),
+      num("pct"),
+      num("area_ha"),
+    ],
+    (lulc?.composition ?? []).map((c) => [
+      c.class_id,
+      c.name,
+      c.color,
+      c.group,
+      c.pixels,
+      c.pct,
+      c.area_ha,
+    ])
+  )
+}
+
+export function lulcGroupsTable(lulc?: LULCAnalysis | null): DataTable | null {
+  return table(
+    "lulc_groups",
+    "lulc_groups.csv",
+    [
+      { key: "group" },
+      { key: "color", swatch: true },
+      num("pct"),
+      num("area_ha"),
+    ],
+    (lulc?.groups ?? []).map((g) => [g.group, g.color, g.pct, g.area_ha])
+  )
+}
+
+export function lulcPredVsRefTable(
+  lulc?: LULCAnalysis | null
+): DataTable | null {
+  return table(
+    "lulc_pred_vs_ref",
+    "lulc_pred_vs_ref.csv",
+    [
+      num("class_id"),
+      { key: "name" },
+      { key: "color", swatch: true },
+      num("pct_ref"),
+      num("pct_pred"),
+    ],
+    (lulc?.pred_vs_ref ?? []).map((r) => [
+      r.class_id,
+      r.name,
+      r.color,
+      r.pct_ref,
+      r.pct_pred,
+    ])
+  )
+}
+
+/** Every table a result can produce, in the order the ZIP writes them. */
+export function allAnalysisTables(result: PredictResult): DataTable[] {
+  return [
+    classStatsTable(result.class_stats ?? []),
+    viSeriesTable(result.vi_series ?? []),
+    phenologyTable(result.phenology),
+    phenologyStatesTable(result.phenology_states ?? []),
+    temporalTable(result.temporal ?? []),
+    lulcMetricsTable(result.lulc),
+    lulcCompositionTable(result.lulc),
+    lulcGroupsTable(result.lulc),
+    lulcPredVsRefTable(result.lulc),
+  ].filter((t): t is DataTable => t !== null)
+}
+
+/** RFC 4180 quoting, matching encoding/csv on the Go side. */
+export function tableToCSV(t: DataTable): string {
+  const esc = (v: string) =>
+    /[",\r\n]/.test(v) ? `"${v.replace(/"/g, '""')}"` : v
+  const lines = [t.columns.map((c) => esc(c.key)).join(",")]
+  for (const row of t.rows) {
+    lines.push(row.map((cell) => esc(formatNumber(cell))).join(","))
+  }
+  return lines.join("\n")
+}

--- a/frontend/src/pages/AnalysisPage.tsx
+++ b/frontend/src/pages/AnalysisPage.tsx
@@ -9,6 +9,7 @@ import {
   Map as MapIcon,
   Pencil,
   Plus,
+  Table2,
   Trash2,
   X,
 } from "lucide-react"
@@ -46,6 +47,7 @@ import {
 import { LulcSection } from "@/components/LulcSection"
 import { CompareAnalyses } from "@/components/CompareAnalyses"
 import { ProjectsHub } from "@/components/ProjectsHub"
+import { ResearchPackModal } from "@/components/ResearchPackModal"
 import {
   AnalysisPlotModal,
   type AnalysisPlotAsset,
@@ -153,6 +155,7 @@ export function AnalysisPage({
   const [selectedPlot, setSelectedPlot] = useState<AnalysisPlotAsset | null>(
     null
   )
+  const [packOpen, setPackOpen] = useState(false)
   const [renamingTitle, setRenamingTitle] = useState(false)
   const [titleDraft, setTitleDraft] = useState("")
   const titleInputRef = useRef<HTMLInputElement | null>(null)
@@ -1031,6 +1034,16 @@ export function AnalysisPage({
             {canExportTables && (
               <button
                 type="button"
+                onClick={() => setPackOpen(true)}
+                className={btnGhost}
+              >
+                <Table2 className="h-3 w-3" />
+                Research pack
+              </button>
+            )}
+            {canExportTables && (
+              <button
+                type="button"
                 onClick={() => void exportTables()}
                 className={btnGhost}
               >
@@ -1290,6 +1303,17 @@ export function AnalysisPage({
           {runsPanel}
         </div>
       </div>
+
+      {packOpen && (
+        <ResearchPackModal
+          result={result}
+          modelKind={modelKind}
+          areaLabel={areaLabel}
+          areaId={areaId}
+          polygonGeoJSON={polygonGeoJSON}
+          onClose={() => setPackOpen(false)}
+        />
+      )}
 
       {selectedPlot && (
         <AnalysisPlotModal


### PR DESCRIPTION
## Summary

The research pack export writes a manifest, the AOI geometry, nine CSV tables and the classification raster, and none of it could be read without unzipping the archive in another tool. Every value is already in memory on the analysis screen.

## Changes

A **Research pack** button in the analysis header opens a modal listing the same entries the ZIP contains, named after the files the exporter writes:

| Entry | Rendered as |
|---|---|
| `manifest.json` | field list |
| `aoi.geojson` | geometry facts + source text |
| `class_stats.csv` | table |
| `vi_series.csv` | table |
| `phenology.csv` | table |
| `phenology_states.csv` | table |
| `temporal.csv` | table |
| `lulc_metrics.csv` | table |
| `lulc_composition.csv` | table |
| `lulc_groups.csv` | table |
| `lulc_pred_vs_ref.csv` | table |
| `rasters/classification.tif` | provenance note |

Details that carry over into how the data reads:

- `manifest.json` notes that `exported_at` is stamped by the exporter and so is not known beforehand, rather than showing a placeholder value.
- `aoi.geojson` states type, parts, interior rings, vertices, area, centroid, bbox with named edges and an explicit **EPSG:4326**. The area and centroid methods are stated rather than implied, since a vertex mean is a map target and not an area centroid.
- The raster entry states that the GeoTIFF carries the **Sentinel-2 UTM projection**, not the lon/lat of the extent shown beside it, so a tool reading the file takes the CRS from the file itself.

Exporting the pack is available from the modal, so the archive can be checked before it is written. The button appears under the same condition as **Export tables**, so it is never offered for a result with no tabular content.

### Parity with the exporter

`lib/analysisTables.ts` holds the column definitions and mirrors `backend/export_research.go`: same columns, same order, same value formatting, so a figure read on screen matches the exported CSV without re-deriving it.

Sorting is view-only — copy always emits the stored order, which is the exporter's order. Missing values sort last in either direction rather than being treated as zero.

## Testing

- `tsc --noEmit` clean; `npm run build` and `wails build` succeed
- `go test ./backend/...` passes; `pytest sidecar/tests -q` — 25 passed
- **Column parity checked mechanically**: headers extracted from both the Go and TypeScript sources and diffed — 9 tables, 0 divergences, same order
- **Float formatting checked** against `strconv.FormatFloat(v, 'f', -1, 64)` across 12 magnitudes including both exponential boundaries — 0 divergences. This caught one real defect: `toFixed(20)` is itself exponential at or above 1e21, so `1e21` rendered as `1e+21` where Go expands it; replaced with manual exponent expansion.

## Checklist

- [x] Tests added/updated — no frontend test suite exists; parity with the exporter was verified mechanically as described above
- [x] Documentation updated — `analysisTables.ts` documents that it mirrors `export_research.go` and must be edited in step
- [x] No console errors/warnings
- [x] Code follows project standards

## Not included

Saving a single table to disk: `ExportOverlayFile` hardcodes a PNG/GeoTIFF file filter, so a CSV branch there is a prerequisite. The component already accepts the action for when that lands. The full ZIP export is unchanged.

---
Last of the stacked series. Merge after #24, #25 and #26.