### PR TITLE
feat(hub): unify the class palette and surface EO metadata on the projects page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1353,6 +1353,7 @@ function AppBody(props: {
               >
                 <AnalysisPage
                   result={props.result}
+                  areas={props.areas}
                   modelKind={props.modelKind}
                   areaLabel={areaLabel}
                   areaId={props.activeExample || undefined}

--- a/frontend/src/components/AoiFootprint.tsx
+++ b/frontend/src/components/AoiFootprint.tsx
@@ -1,0 +1,105 @@
+import { useMemo } from "react"
+import { cn } from "@/lib/utils"
+import { geometryBounds, polygonParts } from "@/lib/geometry"
+import type { GeoJSONGeometry } from "@/lib/types"
+
+/**
+ * Outline of an AOI as inline SVG.
+ *
+ * A catalogue entry is recognised by its shape, so the browse grid draws the
+ * actual boundary rather than a type icon. Inline SVG keeps this offline and
+ * free of tile requests, which matters because the hub renders one per project.
+ *
+ * Longitude is scaled by cos(latitude) so parcels are not stretched east-west
+ * at Brazilian latitudes. Every part of a MultiPolygon is drawn, and interior
+ * rings are cut out with the even-odd fill rule.
+ *
+ * The outline is normalised to its own bounds, so it carries shape but not
+ * scale; pair it with an area figure wherever size matters.
+ */
+export function AoiFootprint({
+  geometry,
+  className,
+  title,
+}: {
+  geometry: GeoJSONGeometry | null | undefined
+  className?: string
+  title?: string
+}) {
+  const path = useMemo(() => {
+    if (!geometry) return null
+    const bounds = geometryBounds(geometry)
+    if (!bounds) return null
+    const midLat = (bounds.latMin + bounds.latMax) / 2
+    const kx = Math.cos((midLat * Math.PI) / 180) || 1
+
+    // Work in metres-proportional units before normalising, so the aspect
+    // ratio reflects ground distance rather than degrees.
+    const x0 = bounds.lonMin * kx
+    const x1 = bounds.lonMax * kx
+    const spanX = Math.max(x1 - x0, 1e-9)
+    const spanY = Math.max(bounds.latMax - bounds.latMin, 1e-9)
+    const span = Math.max(spanX, spanY)
+
+    // Centre the shorter axis inside a square viewBox.
+    const padX = (span - spanX) / 2
+    const padY = (span - spanY) / 2
+
+    const project = ([lon, lat]: [number, number]): [number, number] => [
+      ((lon * kx - x0 + padX) / span) * 100,
+      // SVG y grows downward; latitude grows north.
+      100 - ((lat - bounds.latMin + padY) / span) * 100,
+    ]
+
+    const segments: string[] = []
+    for (const part of polygonParts(geometry)) {
+      for (const ring of part) {
+        if (!ring || ring.length < 3) continue
+        const pts = ring.map(project)
+        segments.push(
+          `M ${pts.map(([x, y]) => `${x.toFixed(2)} ${y.toFixed(2)}`).join(" L ")} Z`
+        )
+      }
+    }
+    return segments.length ? segments.join(" ") : null
+  }, [geometry])
+
+  if (!path) {
+    return (
+      <div
+        className={cn(
+          "flex items-center justify-center text-[9px] text-muted-foreground",
+          className
+        )}
+      >
+        <span
+          className="flex h-10 w-14 items-center justify-center rounded-sm border border-dashed"
+          style={{ borderColor: "var(--ar-border)" }}
+        >
+          No AOI
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <svg
+      viewBox="-4 -4 108 108"
+      className={className}
+      role="img"
+      aria-label={title ?? "Area of interest outline"}
+      preserveAspectRatio="xMidYMid meet"
+    >
+      {title ? <title>{title}</title> : null}
+      <path
+        d={path}
+        fillRule="evenodd"
+        fill="rgb(var(--p-accent) / 0.18)"
+        stroke="rgb(var(--p-accent) / 0.85)"
+        strokeWidth={2}
+        strokeLinejoin="round"
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  )
+}

--- a/frontend/src/components/ProjectFolderCard.tsx
+++ b/frontend/src/components/ProjectFolderCard.tsx
@@ -1,44 +1,26 @@
 import { cn } from "@/lib/utils"
-import type { Project } from "@/lib/types"
-
-function FolderGlyph({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 48 40"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      className={className}
-      aria-hidden
-    >
-      <path
-        d="M2 10.5C2 8.567 3.567 7 5.5 7H16.2c.7 0 1.37.3 1.84.82L20.5 10.5H42.5c1.933 0 3.5 1.567 3.5 3.5V32.5c0 1.933-1.567 3.5-3.5 3.5h-37C3.567 36 2 34.433 2 32.5V10.5Z"
-        fill="rgb(var(--p-accent) / 0.16)"
-        stroke="rgb(var(--p-accent) / 0.75)"
-        strokeWidth="1.25"
-      />
-      <path
-        d="M2 16H46"
-        stroke="rgb(var(--p-accent))"
-        strokeWidth="1"
-        opacity="0.28"
-      />
-    </svg>
-  )
-}
+import type { GeoJSONGeometry, Project } from "@/lib/types"
+import { geometryAreaHectares } from "@/lib/geometry"
+import { AoiFootprint } from "@/components/AoiFootprint"
+import { formatHectares } from "@/lib/runSummary"
 
 export function ProjectFolderCard({
   project,
+  geometry,
   onOpen,
   selected,
   className,
 }: {
   project: Project
+  /** Resolved AOI geometry; null when the project has none. */
+  geometry?: GeoJSONGeometry | null
   onOpen: () => void
   selected?: boolean
   className?: string
 }) {
   const runs = project.run_count ?? 0
   const overlays = project.overlay_count ?? 0
+  const areaHa = geometry ? geometryAreaHectares(geometry) : 0
 
   return (
     <button
@@ -58,7 +40,11 @@ export function ProjectFolderCard({
           borderBottom: "1px solid var(--ar-border, rgb(var(--p-line) / 0.35))",
         }}
       >
-        <FolderGlyph className="h-14 w-[4.25rem] shrink-0 transition-transform group-hover:scale-[1.04]" />
+        <AoiFootprint
+          geometry={geometry}
+          title={`${project.name} area of interest`}
+          className="h-16 w-16 shrink-0 transition-transform group-hover:scale-[1.04]"
+        />
       </div>
       <div className="mt-auto min-w-0 px-3.5 py-3">
         <p className="truncate font-display text-sm font-semibold tracking-wide text-foreground">
@@ -69,9 +55,20 @@ export function ProjectFolderCard({
           1.4.3. Selected cards therefore use the full-contrast text color
           (9.54:1), which is also the conventional treatment for a selected row.
         */}
+        {/* The outline is normalised to its own bounds and so carries no
+            scale; the area figure is what distinguishes a 20 ha plot from a
+            2000 ha farm. Hectares throughout, the working unit here. */}
         <p
           className={cn(
             "telemetry mt-1 text-[10px]",
+            selected ? "text-foreground" : "text-muted-foreground"
+          )}
+        >
+          {areaHa > 0 ? formatHectares(areaHa) : "No AOI set"}
+        </p>
+        <p
+          className={cn(
+            "telemetry mt-0.5 text-[10px]",
             selected ? "text-foreground" : "text-muted-foreground"
           )}
         >

--- a/frontend/src/components/ProjectsHub.tsx
+++ b/frontend/src/components/ProjectsHub.tsx
@@ -1,13 +1,15 @@
 import { useMemo, useState, type ReactNode } from "react"
 import { FolderKanban, Inbox, Plus, Search } from "lucide-react"
 import { cn } from "@/lib/utils"
-import type { Project } from "@/lib/types"
+import type { Area, Project } from "@/lib/types"
+import { resolveProjectGeometry } from "@/lib/geometry"
 import { ProjectFolderCard } from "@/components/ProjectFolderCard"
 
 export type ProjectsHubSelection = "all" | "unassigned" | string
 
 export function ProjectsHub({
   projects,
+  areas,
   unassignedCount,
   selection,
   creating,
@@ -21,6 +23,8 @@ export function ProjectsHub({
   children,
 }: {
   projects: Project[]
+  /** Embedded example areas, to resolve a project stored as an area_id. */
+  areas?: Area[]
   unassignedCount: number
   selection: ProjectsHubSelection
   creating: boolean
@@ -128,7 +132,6 @@ export function ProjectsHub({
             {filtered.map((p) => {
               const runs = p.run_count ?? 0
               const overlays = p.overlay_count ?? 0
-              const count = runs + overlays
               const active = selection === p.id
               // The badge sums two independent counts, so state them in the
               // accessible name rather than leaving a bare number.
@@ -155,11 +158,16 @@ export function ProjectsHub({
                       )}
                     />
                     <span className="min-w-0 flex-1 truncate">{p.name}</span>
+                    {/* Two independent counts, shown as such: twelve
+                        classifications and twelve compositions are opposite
+                        states of work, and their sum said neither. */}
                     <span
                       className="telemetry shrink-0 text-[10px] text-muted-foreground"
                       aria-label={countLabel}
                     >
-                      {count}
+                      {runs}
+                      <span className="opacity-45"> · </span>
+                      {overlays}
                     </span>
                   </button>
                 </li>
@@ -291,6 +299,7 @@ export function ProjectsHub({
                   <li key={p.id} className="min-h-[10.5rem]">
                     <ProjectFolderCard
                       project={p}
+                      geometry={resolveProjectGeometry(p, areas ?? [])}
                       onOpen={() => onOpenProject(p.id)}
                       selected={selection === p.id}
                       className="h-full min-h-[10.5rem]"

--- a/frontend/src/lib/classPalette.ts
+++ b/frontend/src/lib/classPalette.ts
@@ -1,0 +1,25 @@
+/**
+ * Static class legend for the five classes the classifier can emit.
+ *
+ * Mirrors sidecar/class_palette.py, which is the canonical definition shared by
+ * the classification path (infer.py) and the MapBiomas reference path
+ * (lulc.py). Edit both together: this list is what the legend renders next to
+ * the reference image, so a divergence here reintroduces the defect where the
+ * legend described a different palette than the image beside it.
+ *
+ * Overlays and class statistics carry their own colour from the backend
+ * (ClassStat.color), so this list is only used where no run data is present.
+ */
+export interface ClassLegendEntry {
+  id: number
+  name: string
+  color: string
+}
+
+export const MAPBIOMAS_CLASS_LEGEND: ClassLegendEntry[] = [
+  { id: 3, name: "Forest Formation", color: "#006400" },
+  { id: 21, name: "Agriculture-Pasture Mosaic", color: "#fff3bf" },
+  { id: 25, name: "Non-vegetated Area", color: "#ffa07a" },
+  { id: 39, name: "Soybean", color: "#f5b3c8" },
+  { id: 41, name: "Other Temporary Crops", color: "#e974ed" },
+]

--- a/frontend/src/lib/geometry.ts
+++ b/frontend/src/lib/geometry.ts
@@ -46,6 +46,102 @@ export function ringCentroid(ring: LonLat[]): LonLat {
   return [lon / count, lat / count]
 }
 
+/**
+ * Every ring of a geometry, as [outer, ...holes] per part.
+ *
+ * polygonOuterRing keeps only the first part of a MultiPolygon, which is enough
+ * to pick a camera target but not to draw or measure one: rural properties are
+ * routinely split into several parts by a road or a riparian buffer, and the
+ * dropped parts would be missing from both the outline and the area.
+ */
+export function polygonParts(geometry: GeoJSONGeometry): LonLat[][][] {
+  if (geometry.type === "Polygon") {
+    const rings = geometry.coordinates as unknown as LonLat[][]
+    return rings?.length ? [rings] : []
+  }
+  if (geometry.type === "MultiPolygon") {
+    const multi = geometry.coordinates as unknown as LonLat[][][]
+    return (multi ?? []).filter((part) => part?.length)
+  }
+  return []
+}
+
+/** Longitude/latitude bounds over every part. */
+export function geometryBounds(
+  geometry: GeoJSONGeometry | null | undefined
+): { lonMin: number; latMin: number; lonMax: number; latMax: number } | null {
+  if (!geometry) return null
+  let lonMin = Infinity
+  let latMin = Infinity
+  let lonMax = -Infinity
+  let latMax = -Infinity
+  for (const part of polygonParts(geometry)) {
+    for (const [lon, lat] of part[0] ?? []) {
+      if (lon < lonMin) lonMin = lon
+      if (lat < latMin) latMin = lat
+      if (lon > lonMax) lonMax = lon
+      if (lat > latMax) latMax = lat
+    }
+  }
+  if (!Number.isFinite(lonMin) || !Number.isFinite(latMin)) return null
+  return { lonMin, latMin, lonMax, latMax }
+}
+
+/** Metres per degree on a sphere of the mean Earth radius (IUGG). */
+const EARTH_RADIUS_M = 6371008.8
+const METRES_PER_DEGREE = (2 * Math.PI * EARTH_RADIUS_M) / 360
+
+/**
+ * Area in square metres, summing outer rings and subtracting interior rings.
+ *
+ * Uses a shoelace on an equirectangular projection about the geometry's own
+ * latitude, which at field scale agrees with the spherical-excess formula to
+ * within a few square metres over tens of hectares.
+ *
+ * Both axes take the same metres-per-degree constant, with longitude scaled by
+ * cos(latitude). Mixing the usual ellipsoidal pair (111320 for longitude,
+ * 110540 for latitude) instead introduces a systematic bias of about 0.48
+ * percent, which is 0.34 ha on a 71 ha parcel.
+ */
+export function geometryAreaM2(
+  geometry: GeoJSONGeometry | null | undefined
+): number {
+  if (!geometry) return 0
+  const bounds = geometryBounds(geometry)
+  if (!bounds) return 0
+  const midLat = (bounds.latMin + bounds.latMax) / 2
+  const kx = METRES_PER_DEGREE * Math.cos((midLat * Math.PI) / 180)
+  const ky = METRES_PER_DEGREE
+
+  const ringArea = (ring: LonLat[]): number => {
+    if (!ring || ring.length < 3) return 0
+    const closed =
+      ring[0][0] === ring[ring.length - 1][0] &&
+      ring[0][1] === ring[ring.length - 1][1]
+    const pts = closed ? ring.slice(0, -1) : ring
+    let sum = 0
+    for (let i = 0; i < pts.length; i++) {
+      const [x1, y1] = pts[i]
+      const [x2, y2] = pts[(i + 1) % pts.length]
+      sum += x1 * kx * (y2 * ky) - x2 * kx * (y1 * ky)
+    }
+    return Math.abs(sum / 2)
+  }
+
+  let total = 0
+  for (const part of polygonParts(geometry)) {
+    total += ringArea(part[0])
+    for (let h = 1; h < part.length; h++) total -= ringArea(part[h])
+  }
+  return Math.max(0, total)
+}
+
+export function geometryAreaHectares(
+  geometry: GeoJSONGeometry | null | undefined
+): number {
+  return geometryAreaM2(geometry) / 10_000
+}
+
 /** Vertex centroid of a geometry's outer ring, or null when it has none. */
 export function geometryCentroid(
   geometry: GeoJSONGeometry | null | undefined
@@ -54,6 +150,35 @@ export function geometryCentroid(
   const ring = polygonOuterRing(geometry)
   if (!ring?.length) return null
   return ringCentroid(ring)
+}
+
+/**
+ * AOI geometry of a project, or null when it has none.
+ *
+ * A project stores either an inline polygon or a reference to an embedded
+ * example area, and projects created from the hub start with neither, so the
+ * absent case is normal rather than exceptional.
+ */
+export function resolveProjectGeometry(
+  project: { polygon_geojson?: string; area_id?: string },
+  areas: Area[]
+): GeoJSONGeometry | null {
+  const raw = project.polygon_geojson?.trim()
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as GeoJSONGeometry
+      if (parsed?.type === "Polygon" || parsed?.type === "MultiPolygon") {
+        return parsed
+      }
+    } catch {
+      /* stored text is opaque; fall through to the area reference */
+    }
+  }
+  const areaId = project.area_id?.trim()
+  if (areaId) {
+    return areas.find((a) => a.id === areaId)?.geometry ?? null
+  }
+  return null
 }
 
 /**

--- a/frontend/src/lib/projectOverlays.ts
+++ b/frontend/src/lib/projectOverlays.ts
@@ -17,6 +17,26 @@ type OverlayMeta = {
   label?: string
 }
 
+/**
+ * Identifying caption for a saved composition: the acquisition date and what
+ * was rendered from it. A composition is identified by its scene date and band
+ * triplet (or index), not by its nickname, so a browse grid that shows only the
+ * title cannot distinguish two compositions of the same field.
+ *
+ * Returns an empty string when the overlay carries no usable metadata, which
+ * happens for rows written before meta_json existed.
+ */
+export function compositionCaption(raw?: string): string {
+  const meta = parseOverlayMeta(raw)
+  const what =
+    meta.kind === "index"
+      ? meta.index?.toUpperCase()
+      : meta.bands?.length === 3
+        ? meta.bands.join("-")
+        : undefined
+  return [meta.sceneDate, what].filter(Boolean).join(" · ")
+}
+
 export function parseOverlayMeta(raw?: string): OverlayMeta {
   if (!raw?.trim()) return {}
   try {

--- a/frontend/src/lib/runSummary.ts
+++ b/frontend/src/lib/runSummary.ts
@@ -1,0 +1,82 @@
+/**
+ * Readers for the summary JSON stored with every saved run.
+ *
+ * app.go writes class_stats, date_range, n_dates and mean_confidence into
+ * InferenceRun.summary, so a run list can state what a run produced without a
+ * LoadAnalysis round trip per row. Every reader is defensive: summary is opaque
+ * TEXT and rows written by older versions omit keys.
+ */
+
+export interface RunClassStat {
+  class_id: number
+  name: string
+  color: string
+  pct: number
+  area_ha: number
+}
+
+export interface RunSummary {
+  classStats: RunClassStat[]
+  /** Observed acquisition extent [first, last], as opposed to the requested window. */
+  dateRange: [string, string] | null
+  nDates: number | null
+}
+
+function isClassStat(v: unknown): v is RunClassStat {
+  if (!v || typeof v !== "object") return false
+  const o = v as Record<string, unknown>
+  return typeof o.name === "string" && typeof o.color === "string"
+}
+
+export function parseRunSummary(summary?: string | null): RunSummary {
+  const empty: RunSummary = { classStats: [], dateRange: null, nDates: null }
+  if (!summary?.trim()) return empty
+  try {
+    const j = JSON.parse(summary) as Record<string, unknown>
+    const rawStats = Array.isArray(j.class_stats) ? j.class_stats : []
+    const classStats = rawStats.filter(isClassStat)
+    const rawRange = Array.isArray(j.date_range) ? j.date_range : []
+    const dateRange =
+      typeof rawRange[0] === "string" &&
+      typeof rawRange[1] === "string" &&
+      rawRange[0] &&
+      rawRange[1]
+        ? ([rawRange[0], rawRange[1]] as [string, string])
+        : null
+    return {
+      classStats,
+      dateRange,
+      nDates: typeof j.n_dates === "number" ? j.n_dates : null,
+    }
+  } catch {
+    return empty
+  }
+}
+
+/**
+ * The class covering the most pixels. class_statistics emits class_stats
+ * ordered by pixel count descending (sidecar/infer.py), so this is element 0
+ * rather than a scan.
+ */
+export function dominantClass(stats: RunClassStat[]): RunClassStat | null {
+  return stats[0] ?? null
+}
+
+/**
+ * Area the model actually assigned a class to, which is not the AOI area: the
+ * qualifying-pixel mask differs per model, so the same AOI classified twice can
+ * report two figures. Label it as classified area, never as AOI area.
+ */
+export function classifiedAreaHa(stats: RunClassStat[]): number {
+  return stats.reduce(
+    (sum, s) => sum + (typeof s.area_ha === "number" ? s.area_ha : 0),
+    0
+  )
+}
+
+export function formatHectares(ha: number): string {
+  if (!Number.isFinite(ha) || ha <= 0) return "—"
+  if (ha < 10) return `${ha.toFixed(2)} ha`
+  if (ha < 1000) return `${ha.toFixed(1)} ha`
+  return `${Math.round(ha).toLocaleString()} ha`
+}

--- a/frontend/src/pages/AnalysisPage.tsx
+++ b/frontend/src/pages/AnalysisPage.tsx
@@ -25,6 +25,7 @@ import {
 } from "recharts"
 import { useAuth } from "@/lib/auth"
 import type {
+  Area,
   InferenceRun,
   PredictResult,
   Project,
@@ -51,15 +52,15 @@ import {
 } from "@/components/AnalysisPlotModal"
 import { cn } from "@/lib/utils"
 import { displayRunLabel } from "@/lib/aoiLabel"
-import { parseOverlayMeta } from "@/lib/projectOverlays"
+import { compositionCaption, parseOverlayMeta } from "@/lib/projectOverlays"
+import { MAPBIOMAS_CLASS_LEGEND } from "@/lib/classPalette"
+import {
+  classifiedAreaHa,
+  dominantClass,
+  formatHectares,
+  parseRunSummary,
+} from "@/lib/runSummary"
 
-const MAPBIOMAS_LEGEND = [
-  { id: 3, name: "Forest Formation", color: "#006d2c" },
-  { id: 21, name: "Agri-Pasture Mosaic", color: "#fee391" },
-  { id: 25, name: "Non-vegetated", color: "#d73027" },
-  { id: 39, name: "Soybean", color: "#4292c6" },
-  { id: 41, name: "Other temporary crops", color: "#9e9ac8" },
-]
 
 type ProjectTab = "analyses" | "compositions"
 
@@ -69,12 +70,24 @@ const PROJECT_TABS: { id: ProjectTab; label: string }[] = [
   { id: "compositions", label: "Band compositions" },
 ]
 
+/**
+ * Display name for a model_kind enum. Shared so the run list and the detail
+ * header cannot disagree; the list previously printed the raw enum.
+ */
+function modelDisplayName(kind: string): string {
+  if (kind === "temporal_transformer") return "Temporal Transformer"
+  if (kind === "prithvi") return "Prithvi-EO 2.0"
+  return "Random Forest"
+}
+
 const tabId = (id: ProjectTab) => `project-tab-${id}`
 const tabPanelId = (id: ProjectTab) => `project-panel-${id}`
 
 interface AnalysisPageProps {
   result: PredictResult | null
   modelKind: string
+  /** Embedded example areas, for resolving project AOIs stored as area_id. */
+  areas?: Area[]
   areaLabel?: string
   areaId?: string
   /** Current AOI polygon as GeoJSON text (geometry or Feature). */
@@ -103,6 +116,7 @@ type CompareState = {
 export function AnalysisPage({
   result,
   modelKind,
+  areas,
   areaLabel,
   areaId,
   polygonGeoJSON,
@@ -415,12 +429,7 @@ export function AnalysisPage({
     ]
   )
 
-  const modelLabel =
-    modelKind === "temporal_transformer"
-      ? "Temporal Transformer"
-      : modelKind === "prithvi"
-        ? "Prithvi-EO 2.0"
-        : "Random Forest"
+  const modelLabel = modelDisplayName(modelKind)
 
   const plotAssets = useMemo((): AnalysisPlotAsset[] => {
     if (!result) return []
@@ -581,6 +590,7 @@ export function AnalysisPage({
       <div className="terra-workspace app-no-drag relative flex h-full min-h-0 flex-col overflow-hidden">
         <ProjectsHub
           projects={projects}
+          areas={areas}
           unassignedCount={unassignedCount}
           selection={hubSelection}
           creating={creating}
@@ -723,7 +733,7 @@ export function AnalysisPage({
                       project is active.
                     </p>
                   ) : (
-                    <ul className="grid grid-cols-3 gap-1.5 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-8">
+                    <ul className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
                       {projectOverlays.map((o) => (
                         <li key={o.id}>
                           <button
@@ -740,9 +750,18 @@ export function AnalysisPage({
                                 />
                               ) : null}
                             </div>
-                            <p className="truncate px-1.5 py-1 text-[9px] text-foreground group-hover:text-primary">
-                              {o.title}
-                            </p>
+                            <div className="px-1.5 py-1">
+                              <p className="truncate text-[10px] text-foreground group-hover:text-primary">
+                                {o.title}
+                              </p>
+                              {/* Scene date and band triplet identify a
+                                  composition; the title alone does not. */}
+                              {compositionCaption(o.meta_json) && (
+                                <p className="telemetry truncate text-[9px] text-muted-foreground">
+                                  {compositionCaption(o.meta_json)}
+                                </p>
+                              )}
+                            </div>
                           </button>
                         </li>
                       ))}
@@ -1091,7 +1110,7 @@ export function AnalysisPage({
                 className="mt-3 flex flex-wrap gap-3 border-t pt-3"
                 style={{ borderColor: "var(--ar-border)" }}
               >
-                {MAPBIOMAS_LEGEND.map((c) => (
+                {MAPBIOMAS_CLASS_LEGEND.map((c) => (
                   <span
                     key={c.id}
                     className="flex items-center gap-1.5 text-[10px] text-muted-foreground"
@@ -1276,7 +1295,7 @@ export function AnalysisPage({
         <AnalysisPlotModal
           plot={selectedPlot}
           plots={plotAssets}
-          legend={MAPBIOMAS_LEGEND}
+          legend={MAPBIOMAS_CLASS_LEGEND}
           onClose={() => setSelectedPlot(null)}
         />
       )}
@@ -1627,6 +1646,9 @@ function SavedRunsPanel({
             const selected = selectedIds.includes(r.id)
             const slot =
               selectedIds[0] === r.id ? "A" : selectedIds[1] === r.id ? "B" : null
+            const summary = parseRunSummary(r.summary)
+            const dominant = dominantClass(summary.classStats)
+            const classified = classifiedAreaHa(summary.classStats)
             return (
               <li
                 key={r.id}
@@ -1657,8 +1679,45 @@ function SavedRunsPanel({
                         {r.n_dates} scenes
                       </span>
                     </div>
+                    {/* What the run produced, from summary already in memory —
+                        saves a LoadAnalysis round trip just to see the result. */}
+                    {dominant && (
+                      <div className="mt-1 flex items-center gap-1.5">
+                        <span
+                          className="size-2.5 shrink-0 rounded-[2px]"
+                          style={{ backgroundColor: dominant.color }}
+                        />
+                        <span className="truncate text-foreground">
+                          {dominant.name}
+                          {typeof dominant.pct === "number"
+                            ? ` ${dominant.pct.toFixed(1)}%`
+                            : ""}
+                        </span>
+                        {classified > 0 && (
+                          <span className="telemetry shrink-0 text-muted-foreground">
+                            {formatHectares(classified)} classified
+                          </span>
+                        )}
+                      </div>
+                    )}
+                    {/* The requested window is a query; date_range is the extent
+                        actually observed. Older runs have no date_range. */}
                     <div className="mt-0.5 text-muted-foreground">
-                      {r.model_kind} · {r.period_start} → {r.period_end}
+                      {modelDisplayName(r.model_kind)}
+                      {" · "}
+                      {summary.dateRange ? (
+                        <>
+                          observed {summary.dateRange[0]} → {summary.dateRange[1]}
+                          <span className="opacity-70">
+                            {" "}
+                            (requested {r.period_start} → {r.period_end})
+                          </span>
+                        </>
+                      ) : (
+                        <>
+                          {r.period_start} → {r.period_end}
+                        </>
+                      )}
                     </div>
                     <div className="telemetry mt-1 text-[10px] text-muted-foreground/80">
                       {new Date(r.created_at).toLocaleString()}

--- a/sidecar/class_palette.py
+++ b/sidecar/class_palette.py
@@ -1,0 +1,73 @@
+"""
+Canonical MapBiomas class metadata for every raster this application renders.
+
+Both the classification path (infer.py) and the reference path (lulc.py) draw
+MapBiomas class ids, and both previously carried their own MAPBIOMAS_COLORS
+literal. The two disagreed on every class they shared, so a prediction and the
+MapBiomas reference it is compared against were painted in different colours
+for the same class, and the legend shown next to the reference image described
+the prediction palette instead:
+
+    class 3  Forest Formation        infer #006d2c   lulc #006400
+    class 21 Agriculture-Pasture     infer #fee391   lulc #fff3bf
+    class 25 Non-vegetated Area      infer #d73027   lulc #ffa07a
+    class 39 Soybean                 infer #4292c6   lulc #f5b3c8
+    class 41 Other Temporary Crops   infer #9e9ac8   lulc #e974ed
+
+The values below are the reference-path palette, which follows MapBiomas
+conventions (class 39 #f5b3c8 matches the published Collection 8 soybean
+colour). Adopting it leaves the MapBiomas reference rendering unchanged and
+moves the prediction and the frontend legend into agreement with it, so an
+overlay drawn by this application stays comparable to a published MapBiomas
+map.
+
+Not retroactive: class_statistics stamps the colour into every ClassStat and
+that is serialised into summary_json, so runs saved before this change keep
+their original colours. Each stored run stays internally consistent with its
+own overlay PNG; only a comparison across the two eras mixes palettes.
+
+frontend/src/lib/classPalette.ts mirrors these values for the static legend and
+must be edited in step.
+"""
+
+from __future__ import annotations
+
+# Full MapBiomas legend used by the reference path.
+MAPBIOMAS_LEGEND = {
+    3: "Forest Formation",
+    4: "Savanna Formation",
+    9: "Forest Plantation",
+    11: "Wetland",
+    15: "Pasture",
+    20: "Sugar Cane",
+    21: "Agriculture-Pasture Mosaic",
+    24: "Urban Area",
+    25: "Non-vegetated Area",
+    33: "Water",
+    39: "Soybean",
+    41: "Other Temporary Crops",
+    46: "Coffee",
+}
+
+MAPBIOMAS_COLORS = {
+    3: "#006400",
+    4: "#00ff00",
+    9: "#ad4400",
+    11: "#45c2a5",
+    15: "#ffd966",
+    20: "#c59ff4",
+    21: "#fff3bf",
+    24: "#d4271e",
+    25: "#ffa07a",
+    33: "#0000ff",
+    39: "#f5b3c8",
+    41: "#e974ed",
+    46: "#d082de",
+}
+
+# The closed set the classifier can emit. There is no reject class, so every
+# pixel is assigned to whichever of these five is nearest in feature space.
+CLASSIFIER_CLASS_IDS = (3, 21, 25, 39, 41)
+
+CLASSIFIER_LEGEND = {cid: MAPBIOMAS_LEGEND[cid] for cid in CLASSIFIER_CLASS_IDS}
+CLASSIFIER_COLORS = {cid: MAPBIOMAS_COLORS[cid] for cid in CLASSIFIER_CLASS_IDS}

--- a/sidecar/infer.py
+++ b/sidecar/infer.py
@@ -58,22 +58,12 @@ warnings.filterwarnings('ignore')
 SOJA_CLASS_ID = 39
 
 # Class metadata used for labels and the overlay palette (MapBiomas classes,
-# English labels).
-MAPBIOMAS_LEGEND = {
-    3: 'Forest Formation',
-    21: 'Agriculture-Pasture Mosaic',
-    25: 'Non-vegetated Area',
-    39: 'Soybean',
-    41: 'Other Temporary Crops',
-}
-
-MAPBIOMAS_COLORS = {
-    3: '#006d2c',
-    21: '#fee391',
-    25: '#d73027',
-    39: '#4292c6',
-    41: '#9e9ac8',
-}
+# English labels). Shared with the reference path so a prediction and the
+# MapBiomas map it is compared against use one palette; see class_palette.py.
+from class_palette import (  # noqa: E402
+    CLASSIFIER_COLORS as MAPBIOMAS_COLORS,
+    CLASSIFIER_LEGEND as MAPBIOMAS_LEGEND,
+)
 
 
 def emit_progress(progress, msg):

--- a/sidecar/lulc.py
+++ b/sidecar/lulc.py
@@ -17,37 +17,11 @@ from shapely.ops import transform as shp_transform
 from pyproj import Transformer
 
 # Extended MapBiomas Coleção 10 legend (classes seen on PR farms + study targets).
-MAPBIOMAS_LEGEND = {
-    3: "Forest Formation",
-    4: "Savanna Formation",
-    9: "Forest Plantation",
-    11: "Wetland",
-    15: "Pasture",
-    20: "Sugar Cane",
-    21: "Agriculture-Pasture Mosaic",
-    24: "Urban Area",
-    25: "Non-vegetated Area",
-    33: "Water",
-    39: "Soybean",
-    41: "Other Temporary Crops",
-    46: "Coffee",
-}
+from class_palette import MAPBIOMAS_LEGEND  # noqa: E402,F401
 
-MAPBIOMAS_COLORS = {
-    3: "#006400",
-    4: "#00ff00",
-    9: "#ad4400",
-    11: "#45c2a5",
-    15: "#ffd966",
-    20: "#c59ff4",
-    21: "#fff3bf",
-    24: "#d4271e",
-    25: "#ffa07a",
-    33: "#0000ff",
-    39: "#f5b3c8",
-    41: "#e974ed",
-    46: "#d082de",
-}
+# Shared with the classification path so both render a class id identically;
+# see class_palette.py.
+from class_palette import MAPBIOMAS_COLORS  # noqa: E402,F401
 
 LULC_GROUP = {
     3: "Natural vegetation",


### PR DESCRIPTION
> Replaces #26, which GitHub closed automatically when its base branch was deleted on merge. Same branch, same content, now targeting `main` directly.

## Summary

One rendering correctness fix and a set of display changes that use data already on the wire. The projects page was rendering a spatial-temporal catalogue as a file browser.

## Changes

### Palette (correctness, not cosmetics)

`infer.py` and `lulc.py` each carried their own `MAPBIOMAS_COLORS` literal, and the two **disagreed on every class they share**:

| class | infer.py | lulc.py |
|---|---|---|
| 3 Forest Formation | `#006d2c` | `#006400` |
| 21 Agriculture-Pasture | `#fee391` | `#fff3bf` |
| 25 Non-vegetated | `#d73027` | `#ffa07a` |
| 39 Soybean | `#4292c6` | `#f5b3c8` |
| 41 Other Temporary Crops | `#9e9ac8` | `#e974ed` |

The static legend mirrored the `infer.py` values, so in the **Analyze LULC** path the tile titled "MapBiomas reference" showed an image rendered by `lulc.py` while the legend beside it described a different palette: soybean drawn pink, labelled blue. Reading the legend to interpret that reference map gave the wrong class.

Both modules now import `sidecar/class_palette.py`; the frontend legend moves to `lib/classPalette.ts`. The reference-path values were adopted because they follow MapBiomas conventions (class 39 `#f5b3c8` matches the published Collection 8 soybean colour), so the reference rendering is unchanged and the prediction and legend move into agreement with it.

**Not retroactive.** `class_statistics` stamps the colour into every `ClassStat`, serialised into `summary_json`, so runs saved before this change keep their original colours. Each stored run stays internally consistent with its own overlay; only a comparison across the two eras mixes palettes.

### AOI footprint on project cards

Cards rendered the same folder glyph while `ListProjects` already selects `polygon_geojson` for every row. They now draw the boundary as inline SVG — no map instance, no tile request, no image bytes in the payload — with longitude scaled by cos(latitude) so parcels are not stretched, paired with an area figure since an outline normalised to its own bounds carries no scale.

`geometry.ts` gained `polygonParts` (every part and ring — `polygonOuterRing` keeps only the first part of a MultiPolygon, and rural properties here are routinely split by a road or riparian buffer), `geometryBounds`, `geometryAreaM2` and `resolveProjectGeometry`.

The area uses a shoelace on an equirectangular projection about the geometry's own latitude and **agrees with the spherical-excess formula to 0.0003%** on the bundled AOIs. Both axes take one metres-per-degree constant with longitude scaled by cos(latitude); mixing the usual 111320/110540 pair biases the result by **0.48%, which is 0.34 ha on a 71 ha parcel**.

Projects with neither a polygon nor an area id render an explicit "No AOI" state — normal rather than exceptional, since `CreateProject` from the hub stores no geometry.

### Run and composition rows

- Run rows show the dominant class with its swatch and the classified area, from the summary JSON `ListRuns` already returns. Labelled "classified", not AOI area: the qualifying-pixel mask differs per model, so the same AOI classified twice reports two values and neither equals the polygon area.
- Run rows show the observed acquisition extent from `date_range` instead of the requested window, keeping the request as secondary. A requested window is a query, not an extent.
- Composition tiles gained a caption with scene date and band triplet. The modal already assembled this string; it moves to a shared helper.
- The sidebar badge stopped summing `run_count` and `overlay_count` into one integer.
- `model_kind` renders through one shared display name; the list printed the raw enum while the detail header printed the formatted one.

## Testing

- `tsc --noEmit` clean; `npm run build` and `wails build` succeed
- `go test ./backend/...` passes; `pytest sidecar/tests -q` — 25 passed
- Re-verified after merging current `main` into this branch
- Palette unification verified: all five shared classes now resolve identically from both modules
- Area verified against the spherical-excess reference on the real AOIs (error 0.0001 ha); multi-part geometries sum their parts, interior rings subtract, null degrades to 0 without `NaN`
- Generated SVG paths inspected: coordinates land exactly in `[0, 100]` and vertex counts match the source rings (7, 13, 46)

## Checklist

- [ ] Tests added/updated — no frontend test suite exists; geometry was validated against the bundled AOI fixtures and a Python reference implementation
- [x] Documentation updated — `class_palette.py` documents the divergence it resolves and the non-retroactivity
- [x] No console errors/warnings
- [x] Code follows project standards

---
Merge before #27.