### PR TITLE
feat: surface water mapping, and report the MapBiomas sample size in native cells

### DIFF
--- a/app.go
+++ b/app.go
@@ -232,6 +232,15 @@ func (a *App) RenderComposite(req backend.CompositeRequest) (*backend.CompositeR
 	return a.runner.RenderComposite(a.ctx, req)
 }
 
+// AnalyzeWater maps surface water over a period from spectral water indices.
+// Descriptive: a thresholded index, with no model and no trained legend.
+func (a *App) AnalyzeWater(req backend.WaterRequest) (*backend.WaterAnalysis, error) {
+	if a.runner == nil {
+		return nil, errors.New("runner not initialized")
+	}
+	return a.runner.AnalyzeWater(a.ctx, req)
+}
+
 // ExportClassification copies the classification GeoTIFF to a user-chosen path.
 func (a *App) ExportClassification(rasterPath string) (string, error) {
 	return a.ExportOverlayFile(rasterPath, "terra_classification.tif")

--- a/app.go
+++ b/app.go
@@ -238,7 +238,91 @@ func (a *App) AnalyzeWater(req backend.WaterRequest) (*backend.WaterAnalysis, er
 	if a.runner == nil {
 		return nil, errors.New("runner not initialized")
 	}
-	return a.runner.AnalyzeWater(a.ctx, req)
+	res, err := a.runner.AnalyzeWater(a.ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	a.persistWaterRun(req, res)
+	return res, nil
+}
+
+// persistWaterRun saves a surface-water run so it survives the session and is
+// listed, opened and exported like a classification. Best effort: failing to
+// record a run must not discard the result the user is looking at.
+func (a *App) persistWaterRun(req backend.WaterRequest, res *backend.WaterAnalysis) {
+	a.mu.RLock()
+	user := a.currentUser
+	st := a.store
+	a.mu.RUnlock()
+	if st == nil || res == nil {
+		return
+	}
+	userID := store.LocalUserID
+	if user != nil {
+		userID = user.ID
+	}
+
+	runID := uuid.NewString()
+	assetsRel := filepath.Join("runs", runID)
+	assetsDir := st.RunsDir(runID)
+	_ = os.MkdirAll(assetsDir, 0o700)
+	_ = store.WriteDataURIFile(res.OccurrenceURI, filepath.Join(assetsDir, "water_occurrence.png"))
+
+	// Store without the bulky data URI; the asset is restored on load.
+	stored := *res
+	stored.OccurrenceURI = ""
+	resultBytes, _ := json.Marshal(stored)
+
+	poly := ""
+	if req.PolygonGeoJSON != nil {
+		if b, err := json.Marshal(req.PolygonGeoJSON); err == nil {
+			poly = string(b)
+		}
+	} else if req.AreaID != "" {
+		poly = fmt.Sprintf(`{"area_id":%q}`, req.AreaID)
+	}
+
+	label := strings.TrimSpace(req.Label)
+	if label == "" {
+		label = "Custom AOI"
+	}
+	runLabel := strings.TrimSpace(req.RunLabel)
+	if runLabel == "" {
+		runLabel = makeRunLabel(label)
+	}
+	if !strings.HasPrefix(strings.ToLower(runLabel), "run-") {
+		runLabel = "run-" + runLabel
+	}
+
+	summary, _ := json.Marshal(map[string]any{
+		"water_index":             res.Index,
+		"n_dates":                 res.NDates,
+		"date_range":              res.DateRange,
+		"peak_date":               res.PeakDate,
+		"peak_water_fraction_pct": res.PeakWaterPct,
+		"ephemeral_area_ha":       res.EphemeralAreaHa,
+		"persistent_area_ha":      res.PersistentAreaHa,
+		"aoi_area_ha":             res.AOIAreaHa,
+		"aoi_label":               label,
+	})
+
+	_, _ = st.SaveRun(store.InferenceRun{
+		ID:     runID,
+		UserID: userID,
+		Kind:   store.RunKindWater,
+		// No model produced this: the index name carries the method instead.
+		ModelKind:      res.Index,
+		PeriodStart:    req.Start,
+		PeriodEnd:      req.End,
+		PolygonGeoJSON: poly,
+		Status:         "ok",
+		SummaryJSON:    string(summary),
+		ResultJSON:     string(resultBytes),
+		AssetsRelPath:  assetsRel,
+		NDates:         res.NDates,
+		Label:          runLabel,
+		ProjectID:      strings.TrimSpace(req.ProjectID),
+	})
 }
 
 // ExportClassification copies the classification GeoTIFF to a user-chosen path.
@@ -511,11 +595,30 @@ func (a *App) LoadAnalysis(runID string) (*backend.PredictResult, error) {
 			return nil, mapStoreErr(err)
 		}
 	}
+	assetsDir := a.store.RunsDir(run.ID)
+
+	// A water run stores a WaterAnalysis, not a PredictResult. It is returned
+	// attached to an otherwise empty result so the analysis view and the export
+	// see it through the same field a live run uses. The classification fields
+	// are deliberately left at zero: no classification was made, and filling
+	// n_dates here would make the page present one.
+	if run.Kind == store.RunKindWater {
+		var water backend.WaterAnalysis
+		if run.ResultJSON != "" && run.ResultJSON != "{}" {
+			_ = json.Unmarshal([]byte(run.ResultJSON), &water)
+		}
+		if uri, err := store.ReadFileDataURI(
+			filepath.Join(assetsDir, "water_occurrence.png"), "image/png",
+		); err == nil {
+			water.OccurrenceURI = uri
+		}
+		return &backend.PredictResult{Water: &water}, nil
+	}
+
 	var res backend.PredictResult
 	if run.ResultJSON != "" && run.ResultJSON != "{}" {
 		_ = json.Unmarshal([]byte(run.ResultJSON), &res)
 	}
-	assetsDir := a.store.RunsDir(run.ID)
 	if uri, err := store.ReadFileDataURI(filepath.Join(assetsDir, "overlay.png"), "image/png"); err == nil {
 		res.OverlayURI = uri
 	}

--- a/backend/export_research.go
+++ b/backend/export_research.go
@@ -39,6 +39,13 @@ func BuildResearchPackZIP(meta ResearchExportMeta, result *PredictResult, dataDi
 		"mean_confidence": result.MeanConfidence,
 		"extent":          result.Extent,
 	}
+	// Sample size of the MapBiomas comparison. The reference is native at 30 m
+	// and is resampled onto the 10 m grid, so the pixel count overstates the
+	// number of independent label observations by roughly nine times.
+	if result.LULC != nil && result.LULC.CompareReferenceCells > 0 {
+		manifest["compare_pixels"] = result.LULC.ComparePixels
+		manifest["compare_reference_cells"] = result.LULC.CompareReferenceCells
+	}
 	if err := writeZipJSON(zw, "manifest.json", manifest); err != nil {
 		_ = zw.Close()
 		return nil, err
@@ -218,7 +225,13 @@ func BuildResearchPackZIP(meta ResearchExportMeta, result *PredictResult, dataDi
 		}
 
 		if len(lulc.PredVsRef) > 0 {
-			rows := [][]string{{"class_id", "name", "color", "pct_ref", "pct_pred"}}
+			// pixels_ref counts 10 m pixels; n_reference_cells counts the native
+			// 30 m MapBiomas cells behind them. An agreement statistic computed
+			// from this table must use the cell count as its denominator.
+			rows := [][]string{{
+				"class_id", "name", "color", "pct_ref", "pct_pred",
+				"pixels_ref", "n_reference_cells",
+			}}
 			for _, r := range lulc.PredVsRef {
 				rows = append(rows, []string{
 					strconv.Itoa(r.ClassID),
@@ -226,6 +239,8 @@ func BuildResearchPackZIP(meta ResearchExportMeta, result *PredictResult, dataDi
 					r.Color,
 					formatFloat(r.PctRef),
 					formatFloat(r.PctPred),
+					strconv.Itoa(r.PixelsRef),
+					strconv.Itoa(r.NReferenceCells),
 				})
 			}
 			if err := writeZipCSV(zw, "lulc_pred_vs_ref.csv", rows); err != nil {

--- a/backend/export_research.go
+++ b/backend/export_research.go
@@ -42,6 +42,16 @@ func BuildResearchPackZIP(meta ResearchExportMeta, result *PredictResult, dataDi
 	// Sample size of the MapBiomas comparison. The reference is native at 30 m
 	// and is resampled onto the 10 m grid, so the pixel count overstates the
 	// number of independent label observations by roughly nine times.
+	if w := result.Water; w != nil && len(w.Series) > 0 {
+		manifest["water_index"] = w.Index
+		manifest["water_threshold"] = w.ThresholdFixed
+		manifest["water_n_dates"] = w.NDates
+		manifest["water_peak_date"] = w.PeakDate
+		manifest["water_peak_fraction_pct"] = w.PeakWaterPct
+		manifest["water_ephemeral_area_ha"] = w.EphemeralAreaHa
+		manifest["water_persistent_area_ha"] = w.PersistentAreaHa
+		manifest["water_aoi_area_ha"] = w.AOIAreaHa
+	}
 	if result.LULC != nil && result.LULC.CompareReferenceCells > 0 {
 		manifest["compare_pixels"] = result.LULC.ComparePixels
 		manifest["compare_reference_cells"] = result.LULC.CompareReferenceCells
@@ -250,6 +260,38 @@ func BuildResearchPackZIP(meta ResearchExportMeta, result *PredictResult, dataDi
 		}
 	}
 
+	if w := result.Water; w != nil && len(w.Series) > 0 {
+		// observed_pixels is the denominator of water_fraction_pct: the AOI
+		// pixels actually seen on that date. A fraction cannot be recomputed
+		// against the AOI area without it.
+		rows := [][]string{{
+			"date", "scene_id", "cloud_cover", "observed_pixels",
+			"threshold_fixed", "threshold_otsu", "threshold_clipped",
+			"threshold_degenerate", "water_fraction_pct",
+			"water_fraction_otsu_pct", "water_pixels", "area_ha",
+		}}
+		for _, d := range w.Series {
+			rows = append(rows, []string{
+				d.Date,
+				d.SceneID,
+				formatFloat(d.CloudCover),
+				strconv.Itoa(d.ObservedPixels),
+				formatFloat(d.ThresholdFixed),
+				formatFloat(d.ThresholdOtsu),
+				strconv.FormatBool(d.ThresholdClipped),
+				strconv.FormatBool(d.ThresholdDegenerate),
+				formatFloat(d.WaterFractionPct),
+				formatFloat(d.WaterFractionOtsu),
+				strconv.Itoa(d.WaterPixels),
+				formatFloat(d.AreaHa),
+			})
+		}
+		if err := writeZipCSV(zw, "water_series.csv", rows); err != nil {
+			_ = zw.Close()
+			return nil, err
+		}
+	}
+
 	if rasterPath := ResolveRasterPath(result.RasterTIF, dataDir); rasterPath != "" {
 		if err := writeZipFile(zw, "rasters/classification.tif", rasterPath); err != nil {
 			_ = zw.Close()
@@ -336,9 +378,9 @@ func normalizeAOIGeoJSON(raw string) ([]byte, error) {
 	// Geometry → wrap as Feature.
 	if _, hasCoords := m["coordinates"]; hasCoords || m["type"] != nil {
 		feat := map[string]any{
-			"type":     "Feature",
+			"type":       "Feature",
 			"properties": map[string]any{},
-			"geometry": m,
+			"geometry":   m,
 		}
 		return json.MarshalIndent(feat, "", "  ")
 	}

--- a/backend/sidecar.go
+++ b/backend/sidecar.go
@@ -479,13 +479,15 @@ func convertLULC(raw *lulcSidecarPayload) *LULCAnalysis {
 		return nil
 	}
 	out := &LULCAnalysis{
-		Year:        raw.Year,
-		Source:      raw.Source,
-		Extent:      raw.Extent,
-		Metrics:     raw.Metrics,
-		Composition: raw.Composition,
-		Groups:      raw.Groups,
-		PredVsRef:   raw.PredVsRef,
+		Year:                  raw.Year,
+		Source:                raw.Source,
+		Extent:                raw.Extent,
+		Metrics:               raw.Metrics,
+		Composition:           raw.Composition,
+		Groups:                raw.Groups,
+		PredVsRef:             raw.PredVsRef,
+		ComparePixels:         raw.ComparePixels,
+		CompareReferenceCells: raw.CompareReferenceCells,
 	}
 	if out.Composition == nil {
 		out.Composition = []LULCClassRow{}

--- a/backend/sidecar.go
+++ b/backend/sidecar.go
@@ -1031,6 +1031,9 @@ func (r *Runner) AnalyzeWater(ctx context.Context, req WaterRequest) (*WaterAnal
 	if err != nil {
 		return nil, fmt.Errorf("failed to create work dir: %w", err)
 	}
+	// The occurrence PNG is read into a data URI before this returns, so the
+	// directory is not needed afterwards.
+	defer os.RemoveAll(workDir)
 
 	sReq := sidecarRequest{
 		Action:         "water",

--- a/backend/sidecar.go
+++ b/backend/sidecar.go
@@ -995,3 +995,191 @@ func promoteExportFile(src, basename string) (string, error) {
 	}
 	return dest, nil
 }
+
+// AnalyzeWater maps surface water over a period from spectral water indices.
+//
+// Descriptive: the result is a thresholded index, so it carries none of the
+// fixed-legend domain-shift limitation that applies to the classifier.
+func (r *Runner) AnalyzeWater(ctx context.Context, req WaterRequest) (*WaterAnalysis, error) {
+	if _, err := os.Stat(r.sidecar); err != nil {
+		return nil, fmt.Errorf("sidecar not found at %s", r.sidecar)
+	}
+	if strings.TrimSpace(req.Start) == "" || strings.TrimSpace(req.End) == "" {
+		return nil, fmt.Errorf("set the acquisition period (start and end dates)")
+	}
+
+	var polygon *GeoJSONGeometry
+	if req.AreaID != "" {
+		area, ok := r.loadArea(req.AreaID)
+		if !ok {
+			return nil, fmt.Errorf("unknown area: %s", req.AreaID)
+		}
+		geom := area.Geometry
+		polygon = &geom
+	} else if req.PolygonGeoJSON != nil {
+		polygon = req.PolygonGeoJSON
+	} else {
+		return nil, fmt.Errorf("no area or polygon provided")
+	}
+
+	maxCloud := req.MaxCloud
+	if maxCloud <= 0 {
+		maxCloud = 100
+	}
+
+	workDir, err := os.MkdirTemp("", "geosense-water-")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create work dir: %w", err)
+	}
+
+	sReq := sidecarRequest{
+		Action:         "water",
+		ModelDir:       r.modelDir, // unused here, kept for schema
+		PolygonGeoJSON: polygon,
+		Start:          req.Start,
+		End:            req.End,
+		MaxCloud:       maxCloud,
+		MonthlyBest:    req.MonthlyBest,
+		Index:          req.Index,
+		WorkDir:        workDir,
+	}
+	reqBytes, err := json.Marshal(sReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode request: %w", err)
+	}
+
+	raw, err := r.runSidecarJSON(ctx, reqBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	var wrapped struct {
+		Water *waterSidecarPayload `json:"water"`
+	}
+	if err := json.Unmarshal([]byte(raw), &wrapped); err != nil {
+		return nil, fmt.Errorf("failed to parse water result: %w", err)
+	}
+	if wrapped.Water == nil {
+		return nil, fmt.Errorf("sidecar returned empty water payload")
+	}
+	return convertWater(wrapped.Water), nil
+}
+
+func convertWater(raw *waterSidecarPayload) *WaterAnalysis {
+	if raw == nil {
+		return nil
+	}
+	out := &WaterAnalysis{
+		Index:            raw.Index,
+		ThresholdMethod:  raw.ThresholdMethod,
+		ThresholdFixed:   raw.ThresholdFixed,
+		OtsuClip:         raw.OtsuClip,
+		NDates:           raw.NDates,
+		DateRange:        raw.DateRange,
+		AOIPixels:        raw.AOIPixels,
+		AOIAreaHa:        raw.AOIAreaHa,
+		Series:           raw.Series,
+		PeakDate:         raw.PeakDate,
+		PeakWaterPct:     raw.PeakWaterPct,
+		EphemeralPixels:  raw.EphemeralPixels,
+		EphemeralAreaHa:  raw.EphemeralAreaHa,
+		PersistentPixels: raw.PersistentPixels,
+		PersistentAreaHa: raw.PersistentAreaHa,
+		MeanAnomaly:      raw.MeanAnomaly,
+		Extent:           raw.Extent,
+	}
+	if out.Series == nil {
+		out.Series = []WaterDate{}
+	}
+	if out.DateRange == nil {
+		out.DateRange = []string{}
+	}
+	if raw.OccurrencePNG != "" {
+		if uri, err := pngToDataURI(raw.OccurrencePNG); err == nil {
+			out.OccurrenceURI = uri
+		}
+	}
+	return out
+}
+
+// runSidecarJSON runs the sidecar with a marshalled request, relaying progress
+// events to the UI, and returns its stdout payload. Shared by the actions whose
+// only difference is the request and the shape they unmarshal.
+func (r *Runner) runSidecarJSON(ctx context.Context, reqBytes []byte) (string, error) {
+	cmd := exec.CommandContext(ctx, r.pythonPath, r.sidecar)
+	cmd.Stdin = strings.NewReader(string(reqBytes))
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return "", err
+	}
+	if err := cmd.Start(); err != nil {
+		return "", fmt.Errorf("failed to start sidecar: %w", err)
+	}
+
+	var wg sync.WaitGroup
+	var lastError string
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		scanner := bufio.NewScanner(stderr)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+			var ev struct {
+				Progress *int   `json:"progress"`
+				Msg      string `json:"msg"`
+				Error    string `json:"error"`
+			}
+			if err := json.Unmarshal([]byte(line), &ev); err != nil {
+				wruntime.EventsEmit(ctx, "predict:progress", ProgressEvent{Progress: -1, Msg: line})
+				continue
+			}
+			if ev.Error != "" {
+				lastError = ev.Error
+				continue
+			}
+			p := -1
+			if ev.Progress != nil {
+				p = *ev.Progress
+			}
+			wruntime.EventsEmit(ctx, "predict:progress", ProgressEvent{Progress: p, Msg: ev.Msg})
+		}
+	}()
+
+	var out strings.Builder
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		scanner := bufio.NewScanner(stdout)
+		scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+		for scanner.Scan() {
+			out.WriteString(scanner.Text())
+		}
+	}()
+
+	wg.Wait()
+	if waitErr := cmd.Wait(); waitErr != nil {
+		if lastError != "" {
+			return "", fmt.Errorf("%s", lastError)
+		}
+		return "", fmt.Errorf("sidecar failed: %w", waitErr)
+	}
+
+	raw := strings.TrimSpace(out.String())
+	if raw == "" {
+		if lastError != "" {
+			return "", fmt.Errorf("%s", lastError)
+		}
+		return "", fmt.Errorf("sidecar produced no output")
+	}
+	return raw, nil
+}

--- a/backend/store/projects.go
+++ b/backend/store/projects.go
@@ -221,7 +221,7 @@ func (s *Store) ListRunsByProject(userID, projectID string, limit int) ([]Infere
 			`SELECT id, user_id, created_at, model_kind, period_start, period_end, polygon_geojson,
 			        status, summary_json, COALESCE(overlay_relpath,''), n_dates,
 			        COALESCE(result_json,'{}'), COALESCE(assets_relpath,''), COALESCE(label,''),
-			        COALESCE(project_id,'')
+			        COALESCE(project_id,''), COALESCE(kind,'classification')
 			 FROM inference_runs
 			 WHERE user_id = ? AND (project_id IS NULL OR project_id = '')
 			 ORDER BY created_at DESC LIMIT ?`,
@@ -232,7 +232,7 @@ func (s *Store) ListRunsByProject(userID, projectID string, limit int) ([]Infere
 			`SELECT id, user_id, created_at, model_kind, period_start, period_end, polygon_geojson,
 			        status, summary_json, COALESCE(overlay_relpath,''), n_dates,
 			        COALESCE(result_json,'{}'), COALESCE(assets_relpath,''), COALESCE(label,''),
-			        COALESCE(project_id,'')
+			        COALESCE(project_id,''), COALESCE(kind,'classification')
 			 FROM inference_runs
 			 WHERE user_id = ? AND project_id = ?
 			 ORDER BY created_at DESC LIMIT ?`,
@@ -249,7 +249,7 @@ func (s *Store) ListRunsByProject(userID, projectID string, limit int) ([]Infere
 		if err := rows.Scan(
 			&r.ID, &r.UserID, &r.CreatedAt, &r.ModelKind, &r.PeriodStart, &r.PeriodEnd,
 			&r.PolygonGeoJSON, &r.Status, &r.SummaryJSON, &r.OverlayRelPath, &r.NDates,
-			&r.ResultJSON, &r.AssetsRelPath, &r.Label, &r.ProjectID,
+			&r.ResultJSON, &r.AssetsRelPath, &r.Label, &r.ProjectID, &r.Kind,
 		); err != nil {
 			return nil, err
 		}

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -17,11 +17,11 @@ import (
 )
 
 var (
-	ErrNotFound       = errors.New("not found")
-	ErrEmailTaken     = errors.New("email already registered")
-	ErrInvalidCreds   = errors.New("invalid email or password")
-	ErrUnauthorized   = errors.New("not authenticated")
-	ErrInvalidInput   = errors.New("invalid input")
+	ErrNotFound     = errors.New("not found")
+	ErrEmailTaken   = errors.New("email already registered")
+	ErrInvalidCreds = errors.New("invalid email or password")
+	ErrUnauthorized = errors.New("not authenticated")
+	ErrInvalidInput = errors.New("invalid input")
 )
 
 const sessionTTL = 30 * 24 * time.Hour
@@ -63,7 +63,17 @@ type InferenceRun struct {
 	NDates         int    `json:"n_dates"`
 	Label          string `json:"label,omitempty"`
 	ProjectID      string `json:"project_id,omitempty"`
+	// "classification" or "water". Empty on rows written before the column
+	// existed, which are all classifications; readers normalise it.
+	Kind string `json:"kind,omitempty"`
 }
+
+// Run kinds. A classification comes from a model; a descriptive product such as
+// surface water is a thresholded index with no model and no trained legend.
+const (
+	RunKindClassification = "classification"
+	RunKindWater          = "water"
+)
 
 // Project groups AOI, analyses, and overlay assets for an agronomist workflow.
 type Project struct {
@@ -186,6 +196,10 @@ CREATE INDEX IF NOT EXISTS idx_runs_user_created ON inference_runs(user_id, crea
 		`ALTER TABLE inference_runs ADD COLUMN assets_relpath TEXT`,
 		`ALTER TABLE inference_runs ADD COLUMN label TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE inference_runs ADD COLUMN project_id TEXT`,
+		// Distinguishes a classification from a descriptive product such as
+		// surface water, which has no model and no trained legend. Existing
+		// rows predate water and are all classifications.
+		`ALTER TABLE inference_runs ADD COLUMN kind TEXT NOT NULL DEFAULT 'classification'`,
 	} {
 		_, _ = s.db.Exec(stmt)
 	}
@@ -646,14 +660,19 @@ func (s *Store) SaveRun(run InferenceRun) (*InferenceRun, error) {
 	if !json.Valid([]byte(run.ResultJSON)) {
 		run.ResultJSON = "{}"
 	}
+	if run.Kind == "" {
+		run.Kind = RunKindClassification
+	}
 	_, err := s.db.Exec(
 		`INSERT INTO inference_runs
 		 (id, user_id, created_at, model_kind, period_start, period_end, polygon_geojson, status,
-		  summary_json, overlay_relpath, n_dates, result_json, assets_relpath, label, project_id)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		  summary_json, overlay_relpath, n_dates, result_json, assets_relpath, label, project_id,
+		  kind)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		run.ID, run.UserID, run.CreatedAt, run.ModelKind, run.PeriodStart, run.PeriodEnd,
 		run.PolygonGeoJSON, run.Status, run.SummaryJSON, nullIfEmpty(run.OverlayRelPath), run.NDates,
 		run.ResultJSON, nullIfEmpty(run.AssetsRelPath), run.Label, nullIfEmpty(run.ProjectID),
+		run.Kind,
 	)
 	if err != nil {
 		return nil, err
@@ -672,7 +691,7 @@ func (s *Store) ListRuns(userID string, limit int) ([]InferenceRun, error) {
 		`SELECT id, user_id, created_at, model_kind, period_start, period_end, polygon_geojson,
 		        status, summary_json, COALESCE(overlay_relpath,''), n_dates,
 		        COALESCE(result_json,'{}'), COALESCE(assets_relpath,''), COALESCE(label,''),
-		        COALESCE(project_id,'')
+		        COALESCE(project_id,''), COALESCE(kind,'classification')
 		 FROM inference_runs WHERE user_id = ?
 		 ORDER BY created_at DESC LIMIT ?`,
 		userID, limit,
@@ -687,7 +706,7 @@ func (s *Store) ListRuns(userID string, limit int) ([]InferenceRun, error) {
 		if err := rows.Scan(
 			&r.ID, &r.UserID, &r.CreatedAt, &r.ModelKind, &r.PeriodStart, &r.PeriodEnd,
 			&r.PolygonGeoJSON, &r.Status, &r.SummaryJSON, &r.OverlayRelPath, &r.NDates,
-			&r.ResultJSON, &r.AssetsRelPath, &r.Label, &r.ProjectID,
+			&r.ResultJSON, &r.AssetsRelPath, &r.Label, &r.ProjectID, &r.Kind,
 		); err != nil {
 			return nil, err
 		}
@@ -705,13 +724,13 @@ func (s *Store) GetRun(userID, runID string) (*InferenceRun, error) {
 		`SELECT id, user_id, created_at, model_kind, period_start, period_end, polygon_geojson,
 		        status, summary_json, COALESCE(overlay_relpath,''), n_dates,
 		        COALESCE(result_json,'{}'), COALESCE(assets_relpath,''), COALESCE(label,''),
-		        COALESCE(project_id,'')
+		        COALESCE(project_id,''), COALESCE(kind,'classification')
 		 FROM inference_runs WHERE id = ? AND user_id = ?`,
 		runID, userID,
 	).Scan(
 		&r.ID, &r.UserID, &r.CreatedAt, &r.ModelKind, &r.PeriodStart, &r.PeriodEnd,
 		&r.PolygonGeoJSON, &r.Status, &r.SummaryJSON, &r.OverlayRelPath, &r.NDates,
-		&r.ResultJSON, &r.AssetsRelPath, &r.Label, &r.ProjectID,
+		&r.ResultJSON, &r.AssetsRelPath, &r.Label, &r.ProjectID, &r.Kind,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrNotFound

--- a/backend/types.go
+++ b/backend/types.go
@@ -315,6 +315,9 @@ type PredictResult struct {
 	Phenology       PhenologyMetrics      `json:"phenology"`
 	PhenologyStates []PhenologyStatePoint `json:"phenology_states"`
 	LULC            *LULCAnalysis         `json:"lulc,omitempty"`
+	// Attached by the frontend when a surface-water run has been made over the
+	// same AOI. Produced by a separate action, so it is not filled by Predict.
+	Water *WaterAnalysis `json:"water,omitempty"`
 }
 
 // ProgressEvent is emitted to the frontend as "predict:progress".

--- a/backend/types.go
+++ b/backend/types.go
@@ -344,6 +344,10 @@ type WaterRequest struct {
 	MonthlyBest    bool             `json:"monthly_best"`
 	// One of NDWI, MNDWI, AWEI. Empty selects MNDWI.
 	Index string `json:"index,omitempty"`
+	// Recorded with the saved run, matching the classification request.
+	Label     string `json:"label,omitempty"`
+	RunLabel  string `json:"run_label,omitempty"`
+	ProjectID string `json:"project_id,omitempty"`
 }
 
 // WaterDate is one acquisition in the surface-water series.

--- a/backend/types.go
+++ b/backend/types.go
@@ -170,6 +170,12 @@ type LULCCompareRow struct {
 	Color   string  `json:"color"`
 	PctRef  float64 `json:"pct_ref"`
 	PctPred float64 `json:"pct_pred"`
+	// PixelsRef counts 10 m pixels. NReferenceCells counts the distinct native
+	// 30 m MapBiomas cells those pixels were resampled from, which is the number
+	// of independent label observations. The two are not interchangeable: about
+	// nine pixels share one cell. Zero when the cell mapping was unavailable.
+	PixelsRef       int `json:"pixels_ref"`
+	NReferenceCells int `json:"n_reference_cells,omitempty"`
 }
 
 // LULCAnalysis is the descriptive land cover / land use payload.
@@ -183,6 +189,12 @@ type LULCAnalysis struct {
 	Composition []LULCClassRow   `json:"composition"`
 	Groups      []LULCGroupRow   `json:"groups"`
 	PredVsRef   []LULCCompareRow `json:"pred_vs_ref"`
+	// Sample size of the pred-vs-ref comparison. ComparePixels counts 10 m
+	// pixels where both maps are valid; CompareReferenceCells counts the
+	// distinct native 30 m MapBiomas cells behind them, which is what an
+	// agreement statistic must be computed over. Zero when unavailable.
+	ComparePixels         int `json:"compare_pixels,omitempty"`
+	CompareReferenceCells int `json:"compare_reference_cells,omitempty"`
 }
 
 // LULCRequest selects an embedded area (or explicit polygon + MapBiomas path).
@@ -276,6 +288,12 @@ type lulcSidecarPayload struct {
 	Composition []LULCClassRow   `json:"composition"`
 	Groups      []LULCGroupRow   `json:"groups"`
 	PredVsRef   []LULCCompareRow `json:"pred_vs_ref"`
+	// Sample size of the pred-vs-ref comparison. ComparePixels counts 10 m
+	// pixels where both maps are valid; CompareReferenceCells counts the
+	// distinct native 30 m MapBiomas cells behind them, which is what an
+	// agreement statistic must be computed over. Zero when unavailable.
+	ComparePixels         int `json:"compare_pixels,omitempty"`
+	CompareReferenceCells int `json:"compare_reference_cells,omitempty"`
 }
 
 // PredictResult is returned to the frontend. The overlay is delivered as a

--- a/backend/types.go
+++ b/backend/types.go
@@ -217,12 +217,12 @@ type DataCubeRequest struct {
 
 // DataCubeScene is one STAC scene in the data-cube inventory.
 type DataCubeScene struct {
-	ID          string  `json:"id"`
-	Date        string  `json:"date"`
-	CloudCover  float64 `json:"cloud_cover"`
-	Tile        string  `json:"tile"`
-	Satellite   string  `json:"satellite"`
-	PreviewURI  string  `json:"preview_uri,omitempty"`
+	ID         string  `json:"id"`
+	Date       string  `json:"date"`
+	CloudCover float64 `json:"cloud_cover"`
+	Tile       string  `json:"tile"`
+	Satellite  string  `json:"satellite"`
+	PreviewURI string  `json:"preview_uri,omitempty"`
 }
 
 // DataCubeResult is the inventory returned by ListDataCube.
@@ -329,4 +329,88 @@ type ResearchExportMeta struct {
 	AreaID         string `json:"area_id"`
 	AoiLabel       string `json:"aoi_label"`
 	PolygonGeoJSON string `json:"polygon_geojson"` // raw GeoJSON geometry or Feature
+}
+
+// WaterRequest selects an AOI and period for surface water / flood mapping.
+type WaterRequest struct {
+	AreaID         string           `json:"area_id"`
+	PolygonGeoJSON *GeoJSONGeometry `json:"polygon_geojson,omitempty"`
+	Start          string           `json:"start"`
+	End            string           `json:"end"`
+	MaxCloud       float64          `json:"max_cloud"`
+	MonthlyBest    bool             `json:"monthly_best"`
+	// One of NDWI, MNDWI, AWEI. Empty selects MNDWI.
+	Index string `json:"index,omitempty"`
+}
+
+// WaterDate is one acquisition in the surface-water series.
+type WaterDate struct {
+	Date       string  `json:"date"`
+	SceneID    string  `json:"scene_id"`
+	CloudCover float64 `json:"cloud_cover"`
+	// Pixels of the AOI actually observed on this date. Water fractions are a
+	// percentage of this, not of the whole AOI, so a partly clouded date is not
+	// reported as dry.
+	ObservedPixels int `json:"observed_pixels"`
+	// The literature cut (zero) is the primary threshold. The Otsu value is
+	// reported alongside it for comparison, never silently substituted.
+	ThresholdFixed float64 `json:"threshold_fixed"`
+	ThresholdOtsu  float64 `json:"threshold_otsu"`
+	// ThresholdClipped means the Otsu value reached an empirical bound and is a
+	// bound rather than an estimate; ThresholdDegenerate means there were too
+	// few observations to threshold at all.
+	ThresholdClipped    bool    `json:"threshold_clipped"`
+	ThresholdDegenerate bool    `json:"threshold_degenerate"`
+	WaterFractionPct    float64 `json:"water_fraction_pct"`
+	WaterFractionOtsu   float64 `json:"water_fraction_otsu_pct"`
+	WaterPixels         int     `json:"water_pixels"`
+	AreaHa              float64 `json:"area_ha"`
+}
+
+// WaterAnalysis is a surface water / flood mapping result. Descriptive: a
+// thresholded spectral index, with no model and no trained legend.
+type WaterAnalysis struct {
+	Index           string      `json:"index"`
+	ThresholdMethod string      `json:"threshold_method"`
+	ThresholdFixed  float64     `json:"threshold_fixed"`
+	OtsuClip        []float64   `json:"otsu_clip"`
+	NDates          int         `json:"n_dates"`
+	DateRange       []string    `json:"date_range"`
+	AOIPixels       int         `json:"aoi_pixels"`
+	AOIAreaHa       float64     `json:"aoi_area_ha"`
+	Series          []WaterDate `json:"series"`
+	PeakDate        string      `json:"peak_date"`
+	PeakWaterPct    float64     `json:"peak_water_fraction_pct"`
+	// Occurrence bands. Ephemeral is water on some dates but not most, which is
+	// the flood signal; persistent is standing water.
+	EphemeralPixels  int     `json:"ephemeral_pixels"`
+	EphemeralAreaHa  float64 `json:"ephemeral_area_ha"`
+	PersistentPixels int     `json:"persistent_pixels"`
+	PersistentAreaHa float64 `json:"persistent_area_ha"`
+	MeanAnomaly      float64 `json:"mean_anomaly"`
+	// Occurrence raster as a base64 PNG data URI, on a fixed 0 to 1 scale.
+	OccurrenceURI string `json:"occurrence_uri"`
+	Extent        Bounds `json:"extent"`
+}
+
+// waterSidecarPayload is the raw water block from Python (PNG as a file path).
+type waterSidecarPayload struct {
+	Index            string      `json:"index"`
+	ThresholdMethod  string      `json:"threshold_method"`
+	ThresholdFixed   float64     `json:"threshold_fixed"`
+	OtsuClip         []float64   `json:"otsu_clip"`
+	NDates           int         `json:"n_dates"`
+	DateRange        []string    `json:"date_range"`
+	AOIPixels        int         `json:"aoi_pixels"`
+	AOIAreaHa        float64     `json:"aoi_area_ha"`
+	Series           []WaterDate `json:"series"`
+	PeakDate         string      `json:"peak_date"`
+	PeakWaterPct     float64     `json:"peak_water_fraction_pct"`
+	EphemeralPixels  int         `json:"ephemeral_pixels"`
+	EphemeralAreaHa  float64     `json:"ephemeral_area_ha"`
+	PersistentPixels int         `json:"persistent_pixels"`
+	PersistentAreaHa float64     `json:"persistent_area_ha"`
+	MeanAnomaly      float64     `json:"mean_anomaly"`
+	OccurrencePNG    string      `json:"occurrence_png"`
+	Extent           Bounds      `json:"extent"`
 }

--- a/docs/SOLAR_HANDOFF.md
+++ b/docs/SOLAR_HANDOFF.md
@@ -1,0 +1,283 @@
+# Solar analysis handoff — implementation brief
+
+Brief for adding solar resource and photovoltaic siting analysis to TERRA. The
+research is complete and externally validated; what follows is the port.
+
+Companion to [TIER1_HANDOFF.md](TIER1_HANDOFF.md), which covers the Sentinel-2
+derived capabilities. This document is independent of it: the two can be built in
+either order.
+
+Source of truth for the surfaces described here: [`app.go`](../app.go),
+[`backend/types.go`](../backend/types.go), [`backend/sidecar.go`](../backend/sidecar.go),
+[`sidecar/infer.py`](../sidecar/infer.py). See also [ARCHITECTURE.md](ARCHITECTURE.md)
+and [API.md](API.md).
+
+---
+
+## 1. Why this is architecturally different
+
+Every analysis TERRA performs today starts from a Sentinel-2 scene stack. Solar
+does not. It is a parallel axis with three consequences that are product
+advantages, not caveats:
+
+- **It never fails on scene availability.** No usable scenes, permanent cloud, or
+  an AOI outside the archive are not failure modes here. Any AOI on Earth returns
+  an answer.
+- **The fixed-legend limitation does not apply.** The crop models emit only
+  `{3, 21, 25, 39, 41}` and are semantically wrong outside western Parana
+  (see the Limitations section of the README). Solar is physics with no trained
+  head, so there is no domain to shift out of.
+- **It is fast.** A complete analysis runs in well under a minute (section 6),
+  against minutes for a classification run.
+
+It therefore belongs as its own action alongside `predict` and `lulc`, not as an
+extension of either.
+
+## 2. Research source
+
+Reference implementation: `mestrado/experiments/solar_resource/` in the research
+repository, with `report.md` documenting method, results and limitations.
+
+| Module | Role |
+|--------|------|
+| `power_api.py` | NASA POWER client, caching, grid-redundancy test |
+| `solar_model.py` | Solar geometry, clear-sky indices, Perez transposition, PVWatts |
+| `solar_terrain_map.py` | Terrain from DEM, POA lookup, horizon shading, suitability |
+| `sentinel_crosscheck.py` | Scene cloud cover against the clear-sky index |
+| `benchmark_gsa.py` | Comparison against the Global Solar Atlas |
+
+### Validation status
+
+Two independent checks, both in `report.md`:
+
+| Check | Result |
+|-------|--------|
+| Clear-sky index against Sentinel-2 scene cloud cover | Spearman rho = -0.850, n = 134 |
+| GHI against Global Solar Atlas (Solargis) | within 1.8% to 2.6% |
+| Optimum tilt against Global Solar Atlas | identical (25 degrees) |
+| Specific yield against Global Solar Atlas | **high by 2.8% to 6.7%** |
+
+The first validates temporal behaviour, the second the absolute level. The yield
+discrepancy is understood and must be corrected before shipping — see section 7.
+
+## 3. New dependencies
+
+Only one new external service, and it needs no key.
+
+| Dependency | Status |
+|------------|--------|
+| NASA POWER REST API | **New.** `https://power.larc.nasa.gov/api/temporal/{daily,hourly}/point`. No authentication, no quota published. |
+| Copernicus DEM GLO-30 | **Already available.** Collection `cop-dem-glo-30` in the Planetary Computer STAC catalog TERRA already queries, served as a COG `data` asset. Verified: one item covers a study-area AOI, `gsd: 30`. |
+| MapBiomas | **Already in app** via `sidecar/lulc.py`. |
+| `pvlib` | **New Python package.** Pure Python, 19 MB wheel, depends only on numpy/pandas/scipy/requests which are already present. Add to `requirements.txt`, not to `requirements-prithvi.txt`: this is a light dependency and must not sit behind the torch install. |
+
+The DEM point matters: terrain analysis needs no new imagery infrastructure. It
+uses the same `/vsicurl` COG path as Sentinel-2.
+
+## 4. Features to port
+
+### 4.1 Solar resource card (start here)
+
+**Source:** `power_api.py`, `solar_model.py`, `run_solar_analysis.py`.
+**Target:** new `sidecar/solar.py`, `action: 'solar_resource'`.
+
+Point analysis at the AOI centroid: 30-year monthly climatology of GHI, DNI and
+DHI; interannual variability with trend; clear-sky index; optimum tilt and
+azimuth; photovoltaic specific yield.
+
+```jsonc
+// request
+{
+  "action": "solar_resource",
+  "polygon_geojson": { },
+  "climatology_years": 30,
+  "hourly_years": 10,
+  "surface_azimuth": 0,      // 0 = north; the southern-hemisphere default
+  "performance_ratio": null, // null = model it; a number overrides (section 7)
+  "work_dir": "/tmp/geosense-solar-xxxx"
+}
+
+// response
+{
+  "solar": {
+    "resource": {
+      "ghi_annual_kwh_m2": 1772, "ghi_std": 61, "ghi_cv_pct": 3.4,
+      "ghi_p10": 1695, "ghi_p90": 1849, "n_years": 30,
+      "trend_per_year": 0.83, "trend_p_value": 0.531,
+      "monthly": [{"month": 1, "ghi": 6.37, "dni": 4.97, "dhi": 2.71, "kt": 0.540}]
+    },
+    "geometry": {
+      "optimal_tilt_deg": 25.0, "optimal_poa_kwh_m2_year": 1883,
+      "gain_over_horizontal_pct": 8.1,
+      "tilt_tolerance": [{"deviation_deg": 10, "loss_pct": 1.23}]
+    },
+    "pv": {
+      "specific_yield_kwh_kwp_year": 1553, "performance_ratio": 0.80,
+      "capacity_factor_pct": 17.7, "monthly_yield": [ ]
+    },
+    "grid_note": "radiation resolved at 1 degree; the AOI is not resolved internally"
+  }
+}
+```
+
+**Mandatory in the response:** the resolution note. The radiation product resolves
+a single 1 degree cell, so every point inside an AOI returns the same value. A
+user who sees a per-AOI number without that note will assume it is local.
+
+**Acceptance:** for the study-area AOIs, GHI within 3% of 1772 kWh m-2 year-1 and
+optimum tilt of 25 degrees (`mestrado/experiments/solar_resource/report.md`,
+sections 5 to 7).
+
+### 4.2 Terrain-resolved irradiation overlay
+
+**Source:** `solar_terrain_map.py` (`load_terrain`, `horn_slope_aspect`,
+`build_poa_lookup`, `interpolate_poa`, `horizon_angles`, `shading_loss_fraction`).
+**Target:** `sidecar/solar.py`, `action: 'solar_terrain'`.
+
+The atmospheric resource has no spatial structure at AOI scale, but the
+irradiation reaching an inclined surface does, because the surface is terrain.
+This is the mappable quantity.
+
+Pipeline: fetch the DEM tile from `cop-dem-glo-30`, reproject onto the AOI grid,
+derive slope and aspect by Horn (1981), build the POA lookup table over
+(slope, aspect), interpolate onto pixels, apply horizon shading.
+
+Delivered as a PNG data URI positioned by `ImageOverlay`, matching the existing
+classification overlay path, plus a GeoTIFF for export.
+
+**Acceptance:** annual POA between roughly 1300 and 1880 kWh m-2 year-1 over the
+study areas, with spatial standard deviation of 3% to 4% (report section 10).
+
+### 4.3 Seasonal maps and anisotropy
+
+**Source:** `solar_terrain_map.py` (`SEASONS`, `season_mask`), `run_seasonal_maps.py`.
+**Target:** a `season` parameter on `solar_terrain`.
+
+The annual map averages a geometry that reverses within the year. North minus
+south irradiation at 25 degrees of slope:
+
+| Season | Contrast |
+|--------|---------:|
+| Annual | +35.4% |
+| Winter crop cycle (May-Sep) | +105.4% |
+| Winter (Jun-Aug) | **+132.4%** |
+| Summer (Dec-Feb) | **-1.9%** |
+
+The spatial standard deviation of the map is 0.8% in summer and 8.2% in winter.
+Shipping only the annual map hides that entirely.
+
+The anisotropy raster (winter divided by summer, 0.33 to 0.83 over the study
+areas) carries the seasonal information in a single layer and is the better
+default for a map view that has room for one.
+
+### 4.4 Photovoltaic siting map
+
+**Source:** `solar_terrain_map.py` (`suitability_map`, `SUITABILITY_LEGEND`).
+**Target:** `action: 'solar_siting'`.
+
+Five classes from slope limits and MapBiomas land-cover eligibility. Structurally
+identical to the classification raster TERRA already renders, so it reuses the
+overlay, legend and export paths.
+
+```
+0  Excluded - protected or occupied cover   (MapBiomas 3, 9, 24, 33, 46, 47, 48)
+1  Excluded - slope above 15 degrees
+2  Restrictive - slope 10 to 15 degrees
+3  Suitable - conflicts with annual cropping (MapBiomas 20, 39, 40, 41, 62)
+4  Suitable - no land-use conflict
+```
+
+**Two requirements, both non-negotiable.**
+
+Cropland stays its own class and is **never summed into the suitable area**. Over
+the three study areas that distinction is 280 ha against 1740 ha — a pixel that is
+geometrically fine but currently produces soybean carries a trade-off a binary map
+would hide.
+
+The slope thresholds and the excluded-cover list are **project conventions, not
+verified legal restrictions**. They must be user-editable in the UI, and the
+response must carry the values used. Legal reserve, permanent preservation areas
+and municipal zoning require the CAR and local legislation, which this analysis
+does not consult.
+
+## 5. Suggested order
+
+1. **4.1 resource card** — no raster work, exercises the new data source alone.
+2. **4.2 terrain overlay** — adds the DEM path; reuses the existing overlay machinery.
+3. **4.3 seasonal** — a parameter on 4.2 once it works.
+4. **4.4 siting** — needs 4.2 plus the MapBiomas path that already exists.
+
+## 6. Performance budget
+
+Measured on the research hardware (Apple Silicon, `.venv` of the research repo):
+
+| Step | Cost |
+|------|------|
+| POWER daily, 30 years | seconds |
+| POWER hourly, 10 years | ~23 s (2.3 s per year) |
+| Perez transposition, 87 672 hours | 0.13 s |
+| POA lookup, research settings (10 y, 1/10 degree, 1116 pairs) | 54 s |
+| **POA lookup, product settings (10 y, 3/20 degree, 198 pairs)** | **5.0 s** |
+| DEM reprojection and Horn slope/aspect | sub-second |
+| Horizon model, 16 azimuths | sub-second |
+
+**Coarsen the grid, keep the period.** Error against the research configuration,
+over 5000 random (slope, aspect) samples:
+
+| Configuration | Mean error | Max error |
+|---------------|-----------:|----------:|
+| 10 years, 3/20 degree | **0.04%** | 0.31% |
+| 10 years, 2/15 degree | 0.02% | 0.15% |
+| 5 years, 3/20 degree | 0.56% | 1.06% |
+| 3 years, 3/20 degree | 2.86% | 3.41% |
+
+Coarsening the lookup grid is nearly free; shortening the period is what costs
+accuracy, and it barely saves time because the POWER fetch dominates. Ship
+10 years with the coarse grid.
+
+Cache the POWER series per rounded coordinate: the radiation grid is 1 degree, so
+neighbouring AOIs return byte-identical series and a cache keyed on the grid cell
+serves them all.
+
+## 7. Calibration requirement
+
+**Do not ship the yield model as it stands.**
+
+Against the Global Solar Atlas, the specific yield computed here is high by 2.8%
+to 6.7%, and the discrepancy sits entirely in the performance ratio: 0.877 against
+0.798. The research model omits soiling, inter-row shading, degradation,
+availability and cabling losses, which the reference includes.
+
+Two acceptable resolutions:
+
+1. Expose `performance_ratio` as a request parameter, defaulting to a reference
+   value near 0.80, and report which was used.
+2. Add the missing loss terms explicitly and let the modelled PR fall to the
+   reference range.
+
+Option 1 is smaller and honest as long as the response states the assumption.
+Option 2 is better if the app is meant to support system design rather than
+screening. Either way the response must carry the PR, so a user can see what
+produced the number.
+
+Reference: `benchmark_gsa.py` and section 9.1 of the research report.
+
+## 8. What stays in research
+
+| Item | Reason |
+|------|--------|
+| Class-41 terrain association | A hypothesis test, not a feature. Result was negative: terrain orientation does not explain the crop subgroups. See research report section 12. |
+| Sentinel-2 cloud cross-check | A validation of the data product, not a user capability. Could become a quality indicator later. |
+| Wind-driven module temperature | The MERRA-2 2 m wind field is implausible at one of the three study sites (97.3% of hours below 0.5 m/s). Until wind comes from another source, prefer a fixed reference wind. |
+| Fine-resolution resource | Would require geostationary retrieval at ~2 km or the Atlas Brasileiro de Energia Solar. The Global Solar Atlas shows the real spread between the three study sites is 0.82%, so this is low priority. |
+| Single-axis tracking | Not evaluated; would change the result appreciably at this DNI level. |
+
+## 9. Project constraints
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md) and [RELEASING.md](RELEASING.md):
+  SemVer, small reviewable pull requests.
+- No emoji in code, comments, logs, plots or UI strings.
+- Descriptive, non-promotional naming.
+- The repository-level `.claude/CLAUDE.md` style rules apply to TERRA as well.
+- Every response that reports a solar figure must also report the assumption that
+  produced it: the performance ratio, the tilt, and the resolution note of 4.1.

--- a/docs/TIER1_HANDOFF.md
+++ b/docs/TIER1_HANDOFF.md
@@ -1,0 +1,329 @@
+# Tier 1 handoff — research methods ready to ship
+
+Implementation brief for three capabilities whose research prototypes are
+validated and whose target code paths already exist in TERRA. Written to be
+self-contained: a contributor with no prior context should be able to work from
+this document plus the linked source.
+
+Scope of this document: **what to build and where**. It does not commit to a
+schedule, and it does not cover the Tier 2 / Tier 3 items listed at the end.
+
+Source of truth for the surfaces described here: [`app.go`](../app.go),
+[`backend/types.go`](../backend/types.go), [`backend/sidecar.go`](../backend/sidecar.go),
+[`sidecar/infer.py`](../sidecar/infer.py). See also [ARCHITECTURE.md](ARCHITECTURE.md)
+and [API.md](API.md).
+
+---
+
+## 1. Repository layout
+
+Both directories live in the same parent repository.
+
+| Role | Path |
+|------|------|
+| Research prototypes (reference implementations) | `mestrado/` |
+| TERRA desktop product (target) | `geosense-infer/` |
+
+Research code is not a dependency of TERRA. The prototypes are read and ported;
+they are not imported at runtime.
+
+## 2. Extension contract
+
+Follow the pattern used by the existing `lulc` action end to end.
+
+### 2.1 Python sidecar
+
+[`sidecar/infer.py`](../sidecar/infer.py), function `main()` (line ~854),
+dispatches on `action`:
+
+```python
+if action == 'ping':             # line 865
+if action == 'lulc':             # line 875   -> delegates to lulc.py
+if action == 'list_datacube':    # line 888
+if action == 'render_composite': # line 938   -> delegates to composite.py
+# default: predict
+```
+
+New capabilities get their own module and a thin dispatch branch. Existing
+delegated modules to use as structural models: [`sidecar/lulc.py`](../sidecar/lulc.py),
+[`sidecar/composite.py`](../sidecar/composite.py), [`sidecar/phenology.py`](../sidecar/phenology.py).
+
+### 2.2 Go bridge
+
+[`backend/sidecar.go`](../backend/sidecar.go) — one `Runner` method per action.
+Use `AnalyzeLULC` (line 509) as the reference: it resolves the AOI (embedded
+area or custom polygon), creates a temp work dir, marshals `sidecarRequest`,
+runs the subprocess and unmarshals the response.
+
+### 2.3 Request struct
+
+[`backend/types.go`](../backend/types.go) line 60. New fields are added here
+with `json:"...,omitempty"` tags:
+
+```go
+type sidecarRequest struct {
+    Action         string           `json:"action,omitempty"`
+    ModelDir       string           `json:"model_dir"`
+    Source         string           `json:"source"`
+    Start          string           `json:"start,omitempty"`
+    End            string           `json:"end,omitempty"`
+    MaxCloud       float64          `json:"max_cloud"`
+    MonthlyBest    bool             `json:"monthly_best"`
+    Tiles          []string         `json:"tiles"`
+    PolygonGeoJSON *GeoJSONGeometry `json:"polygon_geojson,omitempty"`
+    MapBiomasPath  string           `json:"mapbiomas_path,omitempty"`
+    Mode           string           `json:"mode"`
+    ModelKind      string           `json:"model_kind"`
+    PrithviMode    string           `json:"prithvi_mode"`
+    WorkDir        string           `json:"work_dir"`
+    // Composite / index render (action=render_composite)
+    SceneID    string    `json:"scene_id,omitempty"`
+    Kind       string    `json:"kind,omitempty"`
+    Bands      []string  `json:"bands,omitempty"`
+    Index      string    `json:"index,omitempty"`
+    StretchPct []float64 `json:"stretch_pct,omitempty"`
+}
+```
+
+### 2.4 Wails binding
+
+[`app.go`](../app.go) — public method delegating to the `Runner`, following
+`AnalyzeLULC` (line 212). Wails regenerates the TypeScript bindings under
+`frontend/wailsjs/`. Update [API.md](API.md) in the same change.
+
+### 2.5 Frontend
+
+`frontend/src/components/`. Existing panels for reference: `LulcSection.tsx`,
+`ResultsPanel.tsx`, `ControlPanel.tsx`, `OverlayToolsPanel.tsx`, `MapView.tsx`.
+Raster results reach the map as base64 PNG data URIs positioned by
+`ImageOverlay` with bounds from `get_map_extent`.
+
+### 2.6 Tests
+
+`sidecar/tests/` — every new module needs a matching test file, following
+`test_lulc.py`, `test_composite.py`, `test_phenology.py` and the fixtures in
+`conftest.py`.
+
+## 3. Existing helpers to reuse
+
+In [`sidecar/infer.py`](../sidecar/infer.py):
+
+| Function | Line | Purpose |
+|----------|-----:|---------|
+| `list_stac_products()` | 149 | STAC query, cloud filter, best-scene-per-month selection |
+| `load_band_to_reference_grid()` | 344 | Read a band and resample onto a reference grid (already mixes 10 m and 20 m) |
+| `polygon_from_geojson()` | 84 | Polygon from the UI GeoJSON |
+| `get_map_extent()` | 710 | Bounds for the Leaflet `ImageOverlay` |
+| `write_overlay_png()` | 729 | RGBA PNG delivered as a data URI |
+| `configure_gdal_for_cog()` | 844 | GDAL configuration for COG reads |
+| `emit_progress()` | 69 | Incremental progress to the UI |
+
+**SWIR is already plumbed.** `extra_bands = ['B8A', 'B11', 'B12']` (line 217)
+and the Temporal Transformer path already reads them at 20 m (lines 646-651).
+Items 1 and 2 need no new band infrastructure.
+
+---
+
+## 4. Item 1 — Surface water and flood mapping
+
+**Reference implementation:** `mestrado/flood_mapping_analysis.ipynb`
+(functions `compute_water_indices`, `otsu_threshold`, `water_masks`).
+
+**Target:** new `sidecar/water.py` plus an `action: 'water'` branch in `infer.py`.
+
+### Indices
+
+| Index | Formula | Reference |
+|-------|---------|-----------|
+| NDWI | `(green - nir) / (green + nir)` | McFeeters (1996) |
+| MNDWI | `(green - swir1) / (green + swir1)` | Xu (2006) |
+| AWEI | `4(green - swir1) - (0.25 nir + 2.75 swir2)` | Feyisa et al. (2014) |
+
+Bands: B03 (green), B08 (nir), B11 (swir1), B12 (swir2).
+
+Thresholding uses Otsu with a fixed fallback, both already implemented in the
+notebook. Port them directly — the computation is deterministic and adds no
+dependency.
+
+### Proposed contract
+
+```jsonc
+// request
+{
+  "action": "water",
+  "polygon_geojson": { },
+  "start": "2025-01-01",
+  "end": "2025-12-31",
+  "max_cloud": 30,
+  "monthly_best": true,
+  "index": "MNDWI",
+  "work_dir": "/tmp/geosense-water-xxxx"
+}
+
+// response
+{
+  "water": {
+    "index": "MNDWI",
+    "threshold_method": "otsu",
+    "series": [
+      {"date": "2025-01-09", "threshold": 0.12, "water_fraction_pct": 3.4, "area_ha": 4.2}
+    ],
+    "peak_scene": {"date": "2025-03-05", "overlay_uri": "data:image/png;base64,..."},
+    "extent": [[-25.1, -53.6], [-25.0, -53.5]]
+  }
+}
+```
+
+### Notes
+
+No model, no training, no trained legend — therefore no exposure to the
+fixed-legend domain-shift limitation documented in the README. This is the
+lowest-risk of the three items.
+
+### Acceptance
+
+Run over study area A and compare the water fraction series against
+`mestrado/output/flood_mapping_water_fraction_series.csv` and
+`flood_mapping_summary_abc.csv`. Exact equality is not expected: TERRA selects
+scenes monthly from STAC while the notebook used 22 curated dates. Check
+magnitude and signal shape, not identity.
+
+---
+
+## 5. Item 2 — Change detection
+
+**Reference implementation:** `mestrado/change_detection_analysis.ipynb`
+(functions `compute_indices`, `cloud_shadow_mask`, `aoi_mask_from_stack`).
+
+**Target:** new `sidecar/change.py` plus an `action: 'change'` branch.
+
+### Indices
+
+```python
+ndvi = (nir - red)   / (nir + red)
+nbr  = (nir - swir2) / (nir + swir2)
+ndmi = (nir - swir1) / (nir + swir1)
+```
+
+### Outputs
+
+| Output | Definition |
+|--------|------------|
+| NDVI difference | `NDVI_t2 - NDVI_t1` (vegetation gain / loss) |
+| CVA magnitude | `sqrt(dNDVI^2 + dNBR^2)` (change intensity) |
+| CVA direction | `arctan2(dNBR, dNDVI)`; the quadrant gives the change type |
+| Consecutive series | `dNDVI` between adjacent dates |
+
+### Prerequisite: SCL asset
+
+The notebook's `cloud_shadow_mask()` prefers the L2A Scene Classification Layer,
+removing classes 3 (cloud shadow), 8 and 9 (cloud medium / high probability) and
+10 (thin cirrus), and falls back to a spectral screen when SCL is absent.
+
+The sidecar does not currently fetch SCL: `required_bands = ['B02','B03','B04','B08']`
+and `extra_bands = ['B8A','B11','B12']` (lines 216-217). The Planetary Computer
+`sentinel-2-l2a` item exposes an `SCL` asset. **Adding SCL to the resolvable
+assets is part of this item** — change detected between two dates is sensitive to
+residual cloud, and the spectral fallback is weaker than the SCL mask.
+
+### Proposed contract
+
+```jsonc
+{
+  "action": "change",
+  "polygon_geojson": { },
+  "date_a": "2024-05-04",
+  "date_b": "2025-01-09",
+  "method": "cva",
+  "work_dir": "/tmp/geosense-change-xxxx"
+}
+```
+
+Response carries the overlay PNG as a data URI, a magnitude histogram, the
+composition by direction quadrant, and the consecutive `dNDVI` series.
+
+### Acceptance
+
+Compare against `mestrado/output/output_change_detection/`.
+
+---
+
+## 6. Item 3 — MapBiomas reference-cell accounting
+
+**Reference implementation:** `mestrado/experiments/class41_decomposition/build_wide_aoi.py`,
+function `native_cell_ids()`.
+
+**Target:** [`sidecar/lulc.py`](../sidecar/lulc.py) and the `class_stats` block of
+the `predict` path in [`sidecar/infer.py`](../sidecar/infer.py) (line 763).
+
+### The issue
+
+MapBiomas Collection rasters are native at **30 m**. `lulc.py` reprojects them
+onto the 10 m classification grid and counts with `px_ha_override` of 0.01 ha
+(see the docstring at line 324). Area figures are correct — area is area.
+
+Sample sizes are not. Each native reference cell becomes about nine 10 m pixels,
+so any `n` or agreement statistic in the pred-vs-ref comparison treats nine
+replicates of one label observation as nine independent observations. A 100 ha
+AOI reports on the order of 10 000 reference observations where it has
+approximately 1 100.
+
+### The fix
+
+For each pixel of the 10 m grid, compute the index of the 30 m cell it was
+resampled from, and report the number of distinct cells alongside the pixel
+count:
+
+```python
+# adapted from build_wide_aoi.py:native_cell_ids
+xs, ys = rasterio.transform.xy(ref_transform, rows, cols, offset="center")
+lon, lat = Transformer.from_crs(ref_crs, mb_crs, always_xy=True).transform(xs, ys)
+mb_rows, mb_cols = rasterio.transform.rowcol(mb_transform, lon, lat)
+cell_ids = np.asarray(mb_rows) * mb_width + np.asarray(mb_cols)
+n_reference_cells = int(len(np.unique(cell_ids)))
+```
+
+### Surfaces to update
+
+- `ClassStat` in [`backend/types.go`](../backend/types.go) line 84: add
+  `n_reference_cells` next to `pixels`.
+- `class_stats.csv` in the research export package.
+- `manifest.json` in the same package.
+- The pred-vs-ref view in the UI, so the reported sample size is the cell count.
+
+### Notes
+
+This item adds no feature. It corrects a number the app already displays, and it
+is the smallest of the three — a reasonable first change for validating the edit
+and review cycle.
+
+---
+
+## 7. Suggested order
+
+1. **Item 3** — smallest, isolated, no new UI.
+2. **Item 1** — no new dependency, no model risk.
+3. **Item 2** — largest, because it carries the SCL work.
+
+Items 1 and 2 already appear in [ROADMAP.md](ROADMAP.md) under
+*Product analysis (desktop)*.
+
+## 8. Project constraints
+
+- [CONTRIBUTING.md](../CONTRIBUTING.md) and [RELEASING.md](RELEASING.md):
+  SemVer, small reviewable pull requests.
+- No emoji in code, comments, logs, plots or UI strings.
+- Descriptive, non-promotional naming.
+- The repository-level `.claude/CLAUDE.md` style rules apply to TERRA as well.
+
+## 9. Out of scope for this handoff
+
+Assessed and deliberately excluded, with the reason:
+
+| Item | Reason |
+|------|--------|
+| Class-41 unsupervised decomposition | The supported number of subgroups varies by site (2, 6 and 2 across three nearby farms); it requires training a self-supervised encoder on the local agricultural pixels; and the partition is only interpretable with its stability measurements attached. See `mestrado/experiments/class41_decomposition/report.md`. |
+| Out-of-distribution warning | Ready in substance but needs a UI decision on how to surface it; see the Piauí case in `mestrado/exports/analysis_report.md`. Tier 2. |
+| Crop stress diagnostics | Mature as indicators, not as diagnosis — the stress thresholds have no field validation. Ship as labelled proxies only. Tier 2. |
+| Topography | Needs a new data source (Copernicus DEM GLO-30, available in the same STAC catalog). Not blocked by science. Tier 3. |
+| Domain adaptation / LEM+ | Incomplete: no source-trained baseline, and the offset estimator compares field-occupancy fraction against mean NDVI, which are quantities of different nature. Tier 3. |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1273,6 +1273,18 @@ function AppBody(props: {
     return props.customPolygon ? "Custom AOI" : undefined
   }, [props.analysisLabel, props.activeExample, props.areas, props.customPolygon])
 
+  /**
+   * The analysis payload as the Analysis screen and the exporter see it.
+   *
+   * Water comes from its own action, so it is merged at render time rather
+   * than written into the classification result: either can be produced first,
+   * and neither must overwrite the other.
+   */
+  const resultWithWater = useMemo(
+    () => (props.result ? { ...props.result, water } : null),
+    [props.result, water]
+  )
+
   const analysisPolygonGeoJSON = useMemo(() => {
     if (props.customPolygon) return JSON.stringify(props.customPolygon)
     if (props.activeExample) {
@@ -1487,7 +1499,7 @@ function AppBody(props: {
                 transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
               >
                 <AnalysisPage
-                  result={props.result}
+                  result={resultWithWater}
                   areas={props.areas}
                   modelKind={props.modelKind}
                   areaLabel={areaLabel}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -486,6 +486,61 @@ function AppBody(props: {
     [savePrefs]
   )
 
+  /**
+   * Remember where the map was left, so the next session resumes there.
+   *
+   * The map emits on every pan and zoom frame, so this is debounced and only
+   * writes once the view has settled. Failures are ignored: this is a
+   * convenience, and losing it must never interrupt work.
+   */
+  const viewSaveTimer = useRef<number | undefined>(undefined)
+  /**
+   * Live map position, so returning to the map screen resumes exactly where it
+   * was left rather than at whatever the debounced write last committed.
+   */
+  const liveViewRef = useRef<{ lat: number; lon: number; zoom: number } | null>(
+    null
+  )
+  const persistMapView = useCallback(
+    (v: { lat: number; lon: number; zoom: number }) => {
+      if (viewSaveTimer.current) window.clearTimeout(viewSaveTimer.current)
+      viewSaveTimer.current = window.setTimeout(() => {
+        const current = prefsRef.current
+        if (!current) return
+        const extras = parsePreferenceExtras(current.extras_json)
+        const last = extras.map_view
+        // Skip a write when nothing meaningful moved.
+        if (
+          last &&
+          Math.abs(last.lat - v.lat) < 1e-4 &&
+          Math.abs(last.lon - v.lon) < 1e-4 &&
+          last.zoom === v.zoom
+        ) {
+          return
+        }
+        extras.map_view = {
+          lat: Number(v.lat.toFixed(5)),
+          lon: Number(v.lon.toFixed(5)),
+          zoom: v.zoom,
+        }
+        void savePrefs(
+          { ...current, extras_json: JSON.stringify(extras) },
+          { silent: true }
+        ).catch(() => {
+          /* best-effort */
+        })
+      }, 1200)
+    },
+    [savePrefs]
+  )
+
+  useEffect(
+    () => () => {
+      if (viewSaveTimer.current) window.clearTimeout(viewSaveTimer.current)
+    },
+    []
+  )
+
   const persistActiveProjectId = useCallback(
     async (id: string | null) => {
       setActiveProjectId(id)
@@ -1218,6 +1273,11 @@ function AppBody(props: {
                 transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
               >
                 <MapScreen
+                  initialView={
+                    liveViewRef.current ??
+                    parsePreferenceExtras(prefs?.extras_json).map_view ??
+                    null
+                  }
                   areas={props.areas}
                   activeExample={props.activeExample}
                   customPolygon={props.customPolygon}
@@ -1266,7 +1326,11 @@ function AppBody(props: {
                   composeStretchLow={composeStretchLow}
                   composeStretchHigh={composeStretchHigh}
                   composeOpacity={composeOpacity}
-                  onViewChange={props.setView}
+                  onViewChange={(v) => {
+                    liveViewRef.current = v
+                    props.setView(v)
+                    persistMapView(v)
+                  }}
                   onPolygonDrawn={(geom) => {
                     props.setCustomPolygon(geom)
                     if (geom) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -961,6 +961,12 @@ function AppBody(props: {
     props.setProgress(0)
     props.setProgressMsg("starting")
     try {
+      const aoiLabel =
+        props.analysisLabel?.trim() ||
+        (useExample
+          ? props.areas.find((a) => a.id === props.activeExample)?.label
+          : undefined) ||
+        (useExample ? props.activeExample : "Custom AOI")
       const req: WaterRequest = {
         area_id: useExample ? props.activeExample : "",
         polygon_geojson: useExample ? null : props.customPolygon,
@@ -969,14 +975,21 @@ function AppBody(props: {
         max_cloud: props.maxCloud,
         monthly_best: props.monthlyBest,
         index: waterIndex,
+        label: aoiLabel,
+        run_label: makeRunLabel(aoiLabel),
+        project_id: activeProjectId || undefined,
       }
       const res = (await AnalyzeWater(req as never)) as unknown as WaterAnalysis
       waterAoiRef.current = aoiSignature
       setWater(res)
       setShowWaterOverlay(true)
       notifySuccess(
-        `Surface water mapped: ${res.n_dates} dates, peak ${res.peak_water_fraction_pct.toFixed(1)}%.`
+        `Surface water mapped: ${res.n_dates} dates, peak ${res.peak_water_fraction_pct.toFixed(1)}% (saved).`,
+        undefined,
+        { action: { label: "View analysis", onClick: () => goAnalysis() } }
       )
+      void refreshRuns()
+      void refreshProjects()
     } catch (e) {
       notifyError("Surface water error", e)
     } finally {
@@ -1189,6 +1202,21 @@ function AppBody(props: {
         const aoi = parseRunPolygon(run.polygon_geojson, props.areas)
         props.setActiveExample(aoi.exampleId)
         props.setCustomPolygon(aoi.polygon)
+        // A water run carries its raster in the same field a live run uses, so
+        // opening one puts the occurrence overlay back on the map. The AOI it
+        // was measured on is recorded first, otherwise the invalidation effect
+        // sees a mismatch and drops the raster that was just restored.
+        if (res.water) {
+          waterAoiRef.current = aoi.exampleId
+            ? `area:${aoi.exampleId}`
+            : aoi.polygon
+              ? `poly:${JSON.stringify(aoi.polygon)}`
+              : ""
+          setWater(res.water)
+          setShowWaterOverlay(true)
+        } else {
+          setWater(null)
+        }
         const centroid = geometryCentroid(aoi.polygon)
         if (centroid) {
           props.setFlyTo({

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -917,6 +917,34 @@ function AppBody(props: {
     }
   }
 
+  /**
+   * Identity of the AOI currently on the map. Changes whenever the drawn
+   * polygon or the selected example changes.
+   */
+  const aoiSignature = useMemo(() => {
+    if (props.activeExample) return `area:${props.activeExample}`
+    return props.customPolygon ? `poly:${JSON.stringify(props.customPolygon)}` : ""
+  }, [props.activeExample, props.customPolygon])
+
+  /** The AOI the current water result was computed over. */
+  const waterAoiRef = useRef<string>("")
+
+  /**
+   * A water result belongs to the AOI it was measured on. When the AOI changes
+   * the raster no longer describes what is on the map, so it is dropped.
+   *
+   * Done by comparing against the AOI the run was made on rather than by
+   * clearing at each call site: the AOI changes from drawing, from loading an
+   * example, from opening a project and from opening a composition, and a
+   * missed path leaves a raster from one field painted over another.
+   */
+  useEffect(() => {
+    if (!water) return
+    if (aoiSignature === waterAoiRef.current) return
+    setWater(null)
+    setShowWaterOverlay(true)
+  }, [aoiSignature, water])
+
   const handleRunWater = async () => {
     if (!props.start || !props.end) {
       notifyError("Set the acquisition period.")
@@ -943,6 +971,7 @@ function AppBody(props: {
         index: waterIndex,
       }
       const res = (await AnalyzeWater(req as never)) as unknown as WaterAnalysis
+      waterAoiRef.current = aoiSignature
       setWater(res)
       setShowWaterOverlay(true)
       notifySuccess(
@@ -1397,6 +1426,11 @@ function AppBody(props: {
                     if (geom) {
                       props.setActiveExample("")
                       props.setAnalysisLabel(undefined)
+                      // A composition was rendered for the previous AOI and
+                      // does not describe this one. Water is dropped by the
+                      // AOI-change effect above.
+                      setComposition(null)
+                      setShowCompositionOverlay(true)
                     }
                   }}
                   onSelectExample={props.onSelectExample}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import {
   GetProject,
   UpdateProjectAOI,
   CreateProject,
+  AnalyzeWater,
 } from "../wailsjs/go/main/App"
 import { EventsOn, EventsOff } from "../wailsjs/runtime/runtime"
 import type {
@@ -40,6 +41,9 @@ import type {
   Project,
   ProjectOverlay,
   SaveProjectOverlayRequest,
+  WaterAnalysis,
+  WaterIndex,
+  WaterRequest,
 } from "@/lib/types"
 import { leftDockTabsModeFromPrefs, parsePreferenceExtras } from "@/lib/preferenceExtras"
 import { makeRunLabel, resolveAoiDisplayLabel, aoiLabelFromRunSummary } from "@/lib/aoiLabel"
@@ -451,6 +455,10 @@ function AppBody(props: {
   const [composeStretchLow, setComposeStretchLow] = useState(2)
   const [composeStretchHigh, setComposeStretchHigh] = useState(98)
   const [composeOpacity, setComposeOpacity] = useState(0.85)
+  const [water, setWater] = useState<WaterAnalysis | null>(null)
+  const [waterIndex, setWaterIndex] = useState<WaterIndex>("MNDWI")
+  const [waterRunning, setWaterRunning] = useState(false)
+  const [showWaterOverlay, setShowWaterOverlay] = useState(true)
   const didRestoreProjectRef = useRef(false)
   const prefsRef = useRef(prefs)
   prefsRef.current = prefs
@@ -840,6 +848,46 @@ function AppBody(props: {
       notifyError("Composition error", e)
     } finally {
       setComposeRunning(false)
+    }
+  }
+
+  const handleRunWater = async () => {
+    if (!props.start || !props.end) {
+      notifyError("Set the acquisition period.")
+      return
+    }
+    const useExample = usesExampleArea(props.activeExample, props.areas)
+    if (!useExample && !props.customPolygon) {
+      notifyError("Define an area: draw, search, or load an example.")
+      return
+    }
+    setWaterRunning(true)
+    // The sidecar emits on the shared predict:progress channel and only one
+    // action runs at a time, so the panel reads the shared progress.
+    props.setProgress(0)
+    props.setProgressMsg("starting")
+    try {
+      const req: WaterRequest = {
+        area_id: useExample ? props.activeExample : "",
+        polygon_geojson: useExample ? null : props.customPolygon,
+        start: props.start,
+        end: props.end,
+        max_cloud: props.maxCloud,
+        monthly_best: props.monthlyBest,
+        index: waterIndex,
+      }
+      const res = (await AnalyzeWater(req as never)) as unknown as WaterAnalysis
+      setWater(res)
+      setShowWaterOverlay(true)
+      notifySuccess(
+        `Surface water mapped: ${res.n_dates} dates, peak ${res.peak_water_fraction_pct.toFixed(1)}%.`
+      )
+    } catch (e) {
+      notifyError("Surface water error", e)
+    } finally {
+      setWaterRunning(false)
+      props.setProgress(0)
+      props.setProgressMsg("")
     }
   }
 
@@ -1338,6 +1386,19 @@ function AppBody(props: {
                     setDataCubeOpen(false)
                     setDataCubeError(null)
                   }}
+                  water={water}
+                  waterIndex={waterIndex}
+                  waterRunning={waterRunning}
+                  waterProgress={props.progress}
+                  waterProgressMsg={props.progressMsg}
+                  showWaterOverlay={showWaterOverlay}
+                  onWaterIndexChange={setWaterIndex}
+                  onRunWater={() => void handleRunWater()}
+                  onClearWater={() => {
+                    setWater(null)
+                    setShowWaterOverlay(true)
+                  }}
+                  onShowWaterOverlayChange={setShowWaterOverlay}
                   leftDockTabs={props.leftDockTabs}
                 />
               </motion.div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -594,7 +594,15 @@ function AppBody(props: {
   )
 
   const activateProject = useCallback(
-    async (id: string | null) => {
+    async (
+      id: string | null,
+      opts?: { userInitiated?: boolean }
+    ) => {
+      // Opening a project is an explicit action and draws its AOI and most
+      // recent composition on the map. Restoring one at startup is not, and
+      // must not: a session that begins with an AOI outline and an overlay the
+      // user did not ask for in that session leaves them clearing both by hand.
+      const userInitiated = opts?.userInitiated ?? true
       await persistActiveProjectId(id)
       if (!id) {
         setComposition(null)
@@ -608,13 +616,13 @@ function AppBody(props: {
           p.label?.trim() ||
           parsePreferenceExtras(prefs?.extras_json).aoi_label?.trim() ||
           ""
-        if (p.area_id) {
+        if (userInitiated && p.area_id) {
           props.setActiveExample(p.area_id)
           props.setCustomPolygon(null)
           const label = savedLabel || p.name
           props.setAnalysisLabel(label)
           void persistAoiLabel(label)
-        } else if (p.polygon_geojson) {
+        } else if (userInitiated && p.polygon_geojson) {
           const aoi = parseRunPolygon(p.polygon_geojson, props.areas)
           props.setActiveExample(aoi.exampleId)
           props.setCustomPolygon(aoi.polygon)
@@ -636,9 +644,11 @@ function AppBody(props: {
         const gallery = overlays
           .map(projectOverlayToComposition)
           .filter((x): x is CompositionOverlay => !!x)
+        // The gallery is always loaded so the compositions stay one click away
+        // in Overlay Tools; only the display is conditional.
         setCompositionGallery(gallery)
-        setComposition(gallery[0] ?? null)
-        setShowCompositionOverlay(!!gallery[0])
+        setComposition(userInitiated ? gallery[0] ?? null : null)
+        setShowCompositionOverlay(userInitiated && !!gallery[0])
       } catch (e) {
         notifyError("Could not open project", e)
       }
@@ -662,7 +672,7 @@ function AppBody(props: {
     if (!id) return
     if (!projects.some((p) => p.id === id)) return
     didRestoreProjectRef.current = true
-    void activateProject(id)
+    void activateProject(id, { userInitiated: false })
   }, [prefs?.extras_json, projects, activateProject])
 
   const handleCreateProjectFromMap = useCallback(async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -459,6 +459,7 @@ function AppBody(props: {
   const [waterIndex, setWaterIndex] = useState<WaterIndex>("MNDWI")
   const [waterRunning, setWaterRunning] = useState(false)
   const [showWaterOverlay, setShowWaterOverlay] = useState(true)
+  const [waterOpacity, setWaterOpacity] = useState(0.8)
   const didRestoreProjectRef = useRef(false)
   const prefsRef = useRef(prefs)
   prefsRef.current = prefs
@@ -1485,6 +1486,8 @@ function AppBody(props: {
                     setShowWaterOverlay(true)
                   }}
                   onShowWaterOverlayChange={setShowWaterOverlay}
+                  waterOpacity={waterOpacity}
+                  onWaterOpacityChange={setWaterOpacity}
                   leftDockTabs={props.leftDockTabs}
                 />
               </motion.div>

--- a/frontend/src/components/LeftDockRail.tsx
+++ b/frontend/src/components/LeftDockRail.tsx
@@ -2,11 +2,12 @@ import { forwardRef } from "react"
 import { motion } from "motion/react"
 import { cn } from "@/lib/utils"
 
-export type LeftDockPanel = "classify" | "compose"
+export type LeftDockPanel = "classify" | "compose" | "water"
 
 const TABS: { id: LeftDockPanel; label: string }[] = [
   { id: "classify", label: "New classification" },
   { id: "compose", label: "Compositions" },
+  { id: "water", label: "Surface water" },
 ]
 
 interface LeftDockRailProps {

--- a/frontend/src/components/LulcSection.tsx
+++ b/frontend/src/components/LulcSection.tsx
@@ -100,7 +100,29 @@ export function LulcSection({ lulc, areaId }: LulcSectionProps) {
         </div>
         {hasCompare && (
           <div className="ar-raised p-3 md:col-span-2 xl:col-span-1">
-            <p className="eyebrow mb-2.5">MapBiomas vs predicted (shared pixels)</p>
+            <p className="eyebrow mb-1">MapBiomas vs predicted (shared pixels)</p>
+            {/*
+              The reference is native at 30 m and is resampled onto the 10 m
+              classification grid, so roughly nine pixels carry one label
+              observation. The sample size stated here is the distinct native
+              cell count, not the pixel count.
+            */}
+            <p className="mb-2.5 text-[10px] text-muted-foreground">
+              {typeof lulc.compare_reference_cells === "number" ? (
+                <>
+                  n = {lulc.compare_reference_cells.toLocaleString()} reference
+                  cells at 30 m
+                  {typeof lulc.compare_pixels === "number"
+                    ? ` (${lulc.compare_pixels.toLocaleString()} pixels at 10 m)`
+                    : ""}
+                </>
+              ) : typeof lulc.compare_pixels === "number" ? (
+                <>
+                  {lulc.compare_pixels.toLocaleString()} shared pixels at 10 m ·
+                  reference cell count unavailable
+                </>
+              ) : null}
+            </p>
             <div className="flex flex-col gap-1.5">
               {lulc.pred_vs_ref.map((r) => (
                 <div

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -57,7 +57,11 @@ interface MapViewProps {
   showCompositionOverlay?: boolean
   composition?: CompositionOverlay | null
   /** Surface-water occurrence raster, rendered above the basemap. */
-  waterOverlay?: { uri: string; extent: PredictResult["extent"] } | null
+  waterOverlay?: {
+    uri: string
+    extent: PredictResult["extent"]
+    opacity: number
+  } | null
   /** Vertical wipe: left = basemap, right = prediction. */
   swipeCompare: boolean
   swipeRatio: number
@@ -1098,7 +1102,7 @@ export function MapView({
         key="water"
         url={waterOverlay.uri}
         bounds={waterBounds}
-        opacity={0.8}
+        opacity={waterOverlay.opacity}
         smooth={false}
         zIndex={360}
         // null disables the swipe clip. A ratio of 1 would put the clip line at

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -50,6 +50,8 @@ interface MapViewProps {
   /** When false, hide the band composition overlay. */
   showCompositionOverlay?: boolean
   composition?: CompositionOverlay | null
+  /** Surface-water occurrence raster, rendered above the basemap. */
+  waterOverlay?: { uri: string; extent: PredictResult["extent"] } | null
   /** Vertical wipe: left = basemap, right = prediction. */
   swipeCompare: boolean
   swipeRatio: number
@@ -966,6 +968,7 @@ export function MapView({
   showPredictionOverlay = true,
   showCompositionOverlay = true,
   composition = null,
+  waterOverlay = null,
   swipeCompare,
   swipeRatio,
   onSwipeRatioChange,
@@ -1052,6 +1055,36 @@ export function MapView({
   const predictionOpacity = swipeActive
     ? Math.max(overlayOpacity, 0.88)
     : overlayOpacity
+
+  // Surface-water occurrence sits above the composition and below the
+  // prediction, so a classification run stays readable over it.
+  const waterBounds: LatLngBoundsExpression | null =
+    waterOverlay &&
+    waterOverlay.extent &&
+    !(
+      waterOverlay.extent.lon_min === 0 &&
+      waterOverlay.extent.lon_max === 0 &&
+      waterOverlay.extent.lat_min === 0 &&
+      waterOverlay.extent.lat_max === 0
+    )
+      ? [
+          [waterOverlay.extent.lat_min, waterOverlay.extent.lon_min],
+          [waterOverlay.extent.lat_max, waterOverlay.extent.lon_max],
+        ]
+      : null
+
+  const waterLayer =
+    waterOverlay && waterBounds && waterOverlay.uri ? (
+      <PredictionOverlay
+        key="water"
+        url={waterOverlay.uri}
+        bounds={waterBounds}
+        opacity={0.8}
+        smooth={false}
+        zIndex={360}
+        swipeRatio={1}
+      />
+    ) : null
 
   const compositionLayer = compositionVisible ? (
     <PredictionOverlay
@@ -1167,6 +1200,7 @@ export function MapView({
         ))}
 
       {compositionLayer}
+      {waterLayer}
       {predictionLayer}
       {confidenceLayer}
 

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -1101,7 +1101,9 @@ export function MapView({
         opacity={0.8}
         smooth={false}
         zIndex={360}
-        swipeRatio={1}
+        // null disables the swipe clip. A ratio of 1 would put the clip line at
+        // the right edge of the map and hide the layer entirely.
+        swipeRatio={null}
       />
     ) : null
 

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -33,6 +33,12 @@ import {
 } from "@/components/AoiContextMenu"
 
 interface MapViewProps {
+  /**
+   * Where the map was left last session. Read once on mount: Leaflet treats
+   * center and zoom as initial values, and rebinding them would fight the
+   * user's own panning.
+   */
+  initialView?: { lat: number; lon: number; zoom: number } | null
   areas: Area[]
   activeExample: string
   customPolygon: GeoJSONGeometry | null
@@ -952,6 +958,7 @@ function AoiEdgeLabel({
 }
 
 export function MapView({
+  initialView = null,
   areas,
   activeExample,
   customPolygon,
@@ -976,7 +983,19 @@ export function MapView({
   onClearArea,
   onViewChange,
 }: MapViewProps) {
-  const center = useMemo<[number, number]>(() => [-14.5, -52], [])
+  // Continental default, used only when there is no remembered view.
+  const center = useMemo<[number, number]>(
+    () =>
+      initialView ? [initialView.lat, initialView.lon] : [-14.5, -52],
+    // Mount-time only: see initialView.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
+  const initialZoom = useMemo(
+    () => initialView?.zoom ?? 4,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
   const containerRef = useRef<HTMLDivElement | null>(null)
   const [swipeDragging, setSwipeDragging] = useState(false)
   const [aoiMenu, setAoiMenu] = useState<AoiContextMenuState | null>(null)
@@ -1124,7 +1143,12 @@ export function MapView({
   return (
     // z-0 keeps swipe chrome inside this stacking context, under Result/Control panels
     <div ref={containerRef} className="absolute inset-0 z-0">
-    <MapContainer center={center} zoom={4} className="h-full w-full" zoomControl={false}>
+    <MapContainer
+      center={center}
+      zoom={initialZoom}
+      className="h-full w-full"
+      zoomControl={false}
+    >
       <ZoomControl position="bottomright" />
       <LayersControl position="topright">
         <LayersControl.BaseLayer checked name="Satellite (Esri)">

--- a/frontend/src/components/OverlayToolsPanel.tsx
+++ b/frontend/src/components/OverlayToolsPanel.tsx
@@ -20,6 +20,7 @@ import type {
   CompositionOverlay,
   ModelKind,
   PredictResult,
+  WaterAnalysis,
 } from "@/lib/types"
 import {
   AOI_CONTOUR_SCHEMES,
@@ -42,6 +43,12 @@ export interface OverlayToolsPanelProps {
   onShowPredictionOverlayChange: (v: boolean) => void
   showCompositionOverlay: boolean
   onShowCompositionOverlayChange: (v: boolean) => void
+  /** Surface-water occurrence raster, when a water run has been made. */
+  water?: WaterAnalysis | null
+  showWaterOverlay?: boolean
+  onShowWaterOverlayChange?: (v: boolean) => void
+  waterOpacity?: number
+  onWaterOpacityChange?: (v: number) => void
   showConfidence: boolean
   onShowConfidenceChange: (v: boolean) => void
   confidenceOnTop: boolean
@@ -242,6 +249,11 @@ export function OverlayToolsPanel(props: OverlayToolsPanelProps) {
     onShowPredictionOverlayChange,
     showCompositionOverlay,
     onShowCompositionOverlayChange,
+    water = null,
+    showWaterOverlay = true,
+    onShowWaterOverlayChange,
+    waterOpacity = 0.8,
+    onWaterOpacityChange,
     showConfidence,
     onShowConfidenceChange,
     confidenceOnTop,
@@ -538,6 +550,18 @@ export function OverlayToolsPanel(props: OverlayToolsPanelProps) {
               <label className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
                 <input
                   type="checkbox"
+                  checked={showWaterOverlay}
+                  disabled={!water || !onShowWaterOverlayChange}
+                  onChange={(e) =>
+                    onShowWaterOverlayChange?.(e.target.checked)
+                  }
+                  className="accent-primary"
+                />
+                Show surface water overlay
+              </label>
+              <label className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                <input
+                  type="checkbox"
                   checked={swipeCompare}
                   onChange={(e) => onSwipeCompareChange(e.target.checked)}
                   className="accent-primary"
@@ -604,6 +628,21 @@ export function OverlayToolsPanel(props: OverlayToolsPanelProps) {
                   disabled={!composition}
                   onChange={(e) =>
                     onComposeOpacityChange(Number(e.target.value))
+                  }
+                  className="w-full accent-primary"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-[11px] text-muted-foreground">
+                Surface water opacity {Math.round(waterOpacity * 100)}%
+                <input
+                  type="range"
+                  min={0.15}
+                  max={1}
+                  step={0.05}
+                  value={waterOpacity}
+                  disabled={!water || !onWaterOpacityChange}
+                  onChange={(e) =>
+                    onWaterOpacityChange?.(Number(e.target.value))
                   }
                   className="w-full accent-primary"
                 />

--- a/frontend/src/components/ResearchPackModal.tsx
+++ b/frontend/src/components/ResearchPackModal.tsx
@@ -148,6 +148,9 @@ export function ResearchPackModal({
       // Strip the bulky data URIs, matching what the analysis page sends.
       const pack = {
         ...result,
+        water: result.water
+          ? { ...result.water, occurrence_uri: "" }
+          : result.water,
         overlay_uri: "",
         confidence_uri: "",
         ndvi_mean_uri: "",

--- a/frontend/src/components/WaterPanel.tsx
+++ b/frontend/src/components/WaterPanel.tsx
@@ -1,0 +1,261 @@
+import { forwardRef } from "react"
+import { motion } from "motion/react"
+import { ChevronLeft, CheckCircle2, Loader2, Play, Trash2, Waves } from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { WaterIndex } from "@/lib/types"
+
+const INDICES: { id: WaterIndex; label: string; detail: string }[] = [
+  {
+    id: "MNDWI",
+    label: "MNDWI",
+    detail: "green + SWIR1 · Xu (2006)",
+  },
+  {
+    id: "NDWI",
+    label: "NDWI",
+    detail: "green + NIR · McFeeters (1996)",
+  },
+  {
+    id: "AWEI",
+    label: "AWEI",
+    detail: "4 bands, unbounded · Feyisa (2014)",
+  },
+]
+
+function Section({
+  step,
+  title,
+  children,
+}: {
+  step: string
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <span className="telemetry text-[10px] text-primary">{step}</span>
+        <span className="eyebrow !text-foreground">{title}</span>
+      </div>
+      {children}
+    </div>
+  )
+}
+
+export interface WaterPanelProps {
+  panelOffsetClass?: string
+  hasArea: boolean
+  start: string
+  end: string
+  onStartChange: (v: string) => void
+  onEndChange: (v: string) => void
+  maxCloud: number
+  onMaxCloudChange: (v: number) => void
+  monthlyBest: boolean
+  onMonthlyBestChange: (v: boolean) => void
+  index: WaterIndex
+  onIndexChange: (i: WaterIndex) => void
+  running: boolean
+  progress: number
+  progressMsg: string
+  hasResult: boolean
+  onRun: () => void
+  onClear: () => void
+  onCollapse: () => void
+}
+
+/**
+ * Surface water / flood mapping over a period.
+ *
+ * The product is a thresholded spectral index, with no model and no trained
+ * legend, so it carries none of the fixed-legend domain-shift limitation that
+ * applies to the classifier.
+ */
+export const WaterPanel = forwardRef<HTMLDivElement, WaterPanelProps>(
+  function WaterPanel(props, ref) {
+    const {
+      hasArea,
+      start,
+      end,
+      onStartChange,
+      onEndChange,
+      maxCloud,
+      onMaxCloudChange,
+      monthlyBest,
+      onMonthlyBestChange,
+      index,
+      onIndexChange,
+      running,
+      progress,
+      progressMsg,
+      hasResult,
+      onRun,
+      onClear,
+      onCollapse,
+    } = props
+
+    return (
+      <motion.div
+        ref={ref}
+        className={`panel app-no-drag panel-scroll absolute ${props.panelOffsetClass ?? "left-3"} top-3 bottom-3 z-[1000] flex w-[19rem] flex-col gap-4 overflow-y-auto rounded-md p-4`}
+        initial={{ opacity: 0, x: -28 }}
+        animate={{ opacity: 1, x: 0 }}
+        exit={{ opacity: 0, x: -28 }}
+        transition={{ type: "spring", stiffness: 360, damping: 34 }}
+      >
+        <div className="flex items-center justify-between">
+          <h1 className="text-sm font-semibold">Surface water</h1>
+          <button
+            type="button"
+            onClick={onCollapse}
+            className="text-muted-foreground hover:text-foreground"
+            title="Hide panel"
+          >
+            <ChevronLeft className="size-4" />
+          </button>
+        </div>
+
+        <Section step="01" title="Area">
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Uses the same AOI as classification. Draw or import from the Classify
+            panel if needed.
+          </p>
+          <div
+            className={cn(
+              "flex items-center gap-2 rounded-sm border px-3 py-2 text-xs",
+              hasArea
+                ? "border-primary/40 text-foreground"
+                : "border-border/60 text-muted-foreground"
+            )}
+          >
+            <CheckCircle2
+              className={cn("size-3.5", hasArea ? "text-primary" : "opacity-40")}
+            />
+            {hasArea ? "AOI ready" : "No AOI defined"}
+          </div>
+        </Section>
+
+        <Section step="02" title="Period">
+          <div className="grid grid-cols-2 gap-2">
+            <label className="flex flex-col gap-1 text-[11px] text-muted-foreground">
+              Start
+              <input
+                type="date"
+                value={start}
+                onChange={(e) => onStartChange(e.target.value)}
+                className="ar-inset px-2 py-1 text-xs text-foreground outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-[11px] text-muted-foreground">
+              End
+              <input
+                type="date"
+                value={end}
+                onChange={(e) => onEndChange(e.target.value)}
+                className="ar-inset px-2 py-1 text-xs text-foreground outline-none"
+              />
+            </label>
+          </div>
+          <label className="flex flex-col gap-1 text-[11px] text-muted-foreground">
+            Max cloud %
+            <input
+              type="number"
+              min={0}
+              max={100}
+              value={maxCloud}
+              onChange={(e) => onMaxCloudChange(Number(e.target.value))}
+              className="ar-inset px-2 py-1 text-xs text-foreground outline-none"
+            />
+          </label>
+          <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={monthlyBest}
+              onChange={(e) => onMonthlyBestChange(e.target.checked)}
+              className="accent-primary"
+            />
+            Best scene per month
+          </label>
+        </Section>
+
+        <Section step="03" title="Index">
+          <div className="flex flex-col gap-1.5">
+            {INDICES.map((opt) => {
+              const active = index === opt.id
+              return (
+                <button
+                  key={opt.id}
+                  type="button"
+                  onClick={() => onIndexChange(opt.id)}
+                  className={cn(
+                    "flex flex-col items-start gap-0.5 rounded-sm border px-3 py-2 text-left transition-colors",
+                    active
+                      ? "border-primary/50 bg-primary/10 text-foreground"
+                      : "border-border/60 text-muted-foreground hover:text-foreground"
+                  )}
+                >
+                  <span className="text-xs font-medium">{opt.label}</span>
+                  <span className="telemetry text-[10px] opacity-80">
+                    {opt.detail}
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+          <p className="text-[10px] leading-relaxed text-muted-foreground">
+            Water is the high tail of the index, cut at zero — the literature
+            threshold for all three. An Otsu threshold is reported alongside for
+            comparison but is not applied.
+          </p>
+        </Section>
+
+        <Section step="04" title="Run">
+          {running && (
+            <div className="flex flex-col gap-1">
+              <div className="ar-track h-1 overflow-hidden rounded-sm">
+                <div
+                  className="h-full rounded-sm bg-primary transition-[width]"
+                  style={{ width: `${Math.max(0, Math.min(100, progress))}%` }}
+                />
+              </div>
+              <span className="telemetry text-[10px] text-muted-foreground">
+                {progressMsg}
+              </span>
+            </div>
+          )}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={!hasArea || running}
+              onClick={onRun}
+              className="flex h-9 flex-1 items-center justify-center gap-1.5 rounded-sm bg-primary text-xs font-semibold text-primary-foreground disabled:opacity-50"
+            >
+              {running ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <Play className="size-3.5" />
+              )}
+              {running ? "Mapping…" : "Map water"}
+            </button>
+            {hasResult && (
+              <button
+                type="button"
+                onClick={onClear}
+                disabled={running}
+                className="ar-ghost flex h-9 items-center gap-1.5 rounded-sm border px-3 text-xs text-muted-foreground hover:text-foreground disabled:opacity-50"
+              >
+                <Trash2 className="size-3.5" />
+                Clear
+              </button>
+            )}
+          </div>
+          <p className="flex items-start gap-1.5 text-[10px] leading-relaxed text-muted-foreground">
+            <Waves className="mt-0.5 size-3 shrink-0 opacity-70" />
+            Descriptive product: a thresholded spectral index, with no model and
+            no trained legend.
+          </p>
+        </Section>
+      </motion.div>
+    )
+  }
+)

--- a/frontend/src/components/WaterStatusPanel.tsx
+++ b/frontend/src/components/WaterStatusPanel.tsx
@@ -201,7 +201,8 @@ export const WaterStatusPanel = forwardRef<
             )}
 
             <p className="text-[10px] text-muted-foreground">
-              Visibility and opacity live in Overlay Tools.
+              Visibility and opacity for this layer live in Overlay Tools,
+              alongside the prediction and composition overlays.
             </p>
           </div>
         </>

--- a/frontend/src/components/WaterStatusPanel.tsx
+++ b/frontend/src/components/WaterStatusPanel.tsx
@@ -1,105 +1,34 @@
+import { forwardRef, useState } from "react"
 import { motion } from "motion/react"
-import { AlertTriangle, X } from "lucide-react"
+import { AlertTriangle, ChevronDown, ChevronUp, Trash2, X } from "lucide-react"
 import type { WaterAnalysis } from "@/lib/types"
+import { BLUES_STOPS } from "@/lib/compositeCatalog"
 
-/**
- * Summary of a surface-water run, anchored bottom-right like the other status
- * panels.
- *
- * Every figure is stated against what it was measured on. Water fractions are a
- * percentage of the pixels observed on that date, not of the AOI, so a partly
- * clouded date cannot read as dry.
- */
-export function WaterStatusPanel({
-  water,
-  onClose,
+interface WaterStatusPanelProps {
+  water: WaterAnalysis | null
+  onClear: () => void
+}
+
+function Ramp({
+  stops,
+  lowLabel,
+  highLabel,
 }: {
-  water: WaterAnalysis
-  onClose: () => void
+  stops: string[]
+  lowLabel: string
+  highLabel: string
 }) {
-  const peak = water.series.find((d) => d.date === water.peak_date)
-  const clippedDates = water.series.filter((d) => d.threshold_clipped).length
-  const degenerate = water.series.filter((d) => d.threshold_degenerate).length
-
   return (
-    <motion.div
-      className="panel app-no-drag absolute bottom-3 right-3 z-[1000] flex w-[19rem] flex-col gap-3 rounded-md p-4"
-      initial={{ opacity: 0, y: 18 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: 18 }}
-      transition={{ type: "spring", stiffness: 360, damping: 34 }}
-    >
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
-          <p className="telemetry text-[10px] text-primary">SURFACE WATER</p>
-          <h2 className="mt-0.5 truncate text-sm font-semibold">
-            {water.index} · {water.n_dates}{" "}
-            {water.n_dates === 1 ? "date" : "dates"}
-          </h2>
-          <p className="telemetry mt-0.5 text-[10px] text-muted-foreground">
-            {water.date_range[0]} → {water.date_range[1]}
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={onClose}
-          className="text-muted-foreground hover:text-foreground"
-          title="Close"
-        >
-          <X className="size-4" />
-        </button>
+    <div className="flex flex-col gap-1">
+      <div
+        className="h-2 w-full rounded-full"
+        style={{ background: `linear-gradient(90deg, ${stops.join(", ")})` }}
+      />
+      <div className="flex justify-between text-[10px] text-muted-foreground">
+        <span>{lowLabel}</span>
+        <span>{highLabel}</span>
       </div>
-
-      <div className="grid grid-cols-2 gap-2">
-        <Metric
-          label="Peak water"
-          value={`${water.peak_water_fraction_pct.toFixed(1)}%`}
-          sub={water.peak_date}
-        />
-        <Metric
-          label="Peak area"
-          value={peak ? `${peak.area_ha.toFixed(2)} ha` : "—"}
-          sub={peak ? `${peak.water_pixels.toLocaleString()} px` : undefined}
-        />
-        <Metric
-          label="Ephemeral"
-          value={`${water.ephemeral_area_ha.toFixed(2)} ha`}
-          sub="wet on some dates"
-        />
-        <Metric
-          label="Persistent"
-          value={`${water.persistent_area_ha.toFixed(2)} ha`}
-          sub="standing water"
-        />
-      </div>
-
-      <p className="text-[10px] leading-relaxed text-muted-foreground">
-        Fractions are a percentage of the pixels observed on each date, not of
-        the {water.aoi_area_ha.toFixed(1)} ha AOI, so a partly clouded date is
-        not reported as dry.
-      </p>
-
-      {(clippedDates > 0 || degenerate > 0) && (
-        <p className="flex items-start gap-1.5 text-[10px] leading-relaxed text-muted-foreground">
-          <AlertTriangle className="mt-0.5 size-3 shrink-0 text-primary/80" />
-          <span>
-            {clippedDates > 0 && (
-              <>
-                The comparison Otsu threshold hit its bound on {clippedDates} of{" "}
-                {water.n_dates} dates and is a bound there, not an estimate.{" "}
-              </>
-            )}
-            {degenerate > 0 && (
-              <>
-                {degenerate}{" "}
-                {degenerate === 1 ? "date had" : "dates had"} too few
-                observations to threshold.
-              </>
-            )}
-          </span>
-        </p>
-      )}
-    </motion.div>
+    </div>
   )
 }
 
@@ -113,12 +42,170 @@ function Metric({
   sub?: string
 }) {
   return (
-    <div className="ar-raised px-2.5 py-1.5">
+    <div className="min-w-0">
       <div className="eyebrow !text-[9px]">{label}</div>
-      <div className="telemetry mt-0.5 text-sm text-foreground">{value}</div>
+      <div className="telemetry mt-0.5 truncate text-sm text-foreground">
+        {value}
+      </div>
       {sub && (
-        <div className="telemetry text-[9px] text-muted-foreground">{sub}</div>
+        <div className="telemetry truncate text-[10px] text-muted-foreground">
+          {sub}
+        </div>
       )}
     </div>
   )
 }
+
+/**
+ * Surface-water run summary.
+ *
+ * Uses the same bottom bar as the classification and composition results, so
+ * the three products read as one family rather than three conventions.
+ *
+ * Every figure is stated against what it was measured on: water fractions are a
+ * percentage of the pixels observed on that date, not of the AOI, so a partly
+ * clouded date cannot read as dry.
+ */
+export const WaterStatusPanel = forwardRef<
+  HTMLDivElement,
+  WaterStatusPanelProps
+>(function WaterStatusPanel({ water, onClear }, ref) {
+  const [collapsed, setCollapsed] = useState(false)
+  const hasResult = !!water
+
+  const peak = water?.series.find((d) => d.date === water.peak_date)
+  const clipped = water?.series.filter((d) => d.threshold_clipped).length ?? 0
+  const degenerate =
+    water?.series.filter((d) => d.threshold_degenerate).length ?? 0
+
+  const subtitle = water
+    ? `${water.n_dates} ${water.n_dates === 1 ? "date" : "dates"} · ${water.date_range[0]} → ${water.date_range[1]}`
+    : ""
+
+  return (
+    <motion.div
+      ref={ref}
+      className="panel app-no-drag absolute bottom-3 left-[23.5rem] right-16 z-[1000] mx-auto max-w-[36rem] rounded-md"
+      initial={{ opacity: 0, y: 24 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 24 }}
+      transition={{ type: "spring", stiffness: 380, damping: 32 }}
+    >
+      <div className="flex items-center justify-between px-3 py-2">
+        <div className="flex min-w-0 flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-2">
+          <span className="eyebrow shrink-0 !text-foreground">
+            Surface water
+          </span>
+          <span className="telemetry truncate text-[11px] text-muted-foreground">
+            {water ? `${water.index} · ${subtitle}` : ""}
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <button
+            type="button"
+            onClick={onClear}
+            disabled={!hasResult}
+            className="flex items-center gap-1 rounded-sm px-2 py-1 text-[11px] text-muted-foreground hover:bg-secondary hover:text-foreground disabled:opacity-40"
+            title="Clear surface water from map"
+          >
+            <Trash2 className="size-3.5" />
+            Clear
+          </button>
+          <button
+            type="button"
+            onClick={() => setCollapsed((c) => !c)}
+            className="text-muted-foreground hover:text-foreground"
+            title={collapsed ? "Expand" : "Collapse"}
+          >
+            {collapsed ? (
+              <ChevronUp className="size-4" />
+            ) : (
+              <ChevronDown className="size-4" />
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={onClear}
+            disabled={!hasResult}
+            className="text-muted-foreground hover:text-foreground disabled:opacity-40"
+            title="Clear surface water"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+      </div>
+
+      {!collapsed && water && (
+        <>
+          <hr className="hairline" />
+          <div className="flex flex-col gap-3 p-3">
+            <p className="text-[11px] leading-relaxed text-muted-foreground">
+              Water is the high tail of the index, cut at zero. Fractions are a
+              percentage of the pixels observed on each date, not of the{" "}
+              {water.aoi_area_ha.toFixed(1)} ha AOI, so a partly clouded date is
+              not reported as dry.
+            </p>
+
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <Metric
+                label="Peak water"
+                value={`${water.peak_water_fraction_pct.toFixed(1)}%`}
+                sub={water.peak_date}
+              />
+              <Metric
+                label="Peak area"
+                value={peak ? `${peak.area_ha.toFixed(2)} ha` : "—"}
+                sub={
+                  peak ? `${peak.water_pixels.toLocaleString()} px` : undefined
+                }
+              />
+              <Metric
+                label="Ephemeral"
+                value={`${water.ephemeral_area_ha.toFixed(2)} ha`}
+                sub="wet on some dates"
+              />
+              <Metric
+                label="Persistent"
+                value={`${water.persistent_area_ha.toFixed(2)} ha`}
+                sub="standing water"
+              />
+            </div>
+
+            {/* Same ramp the occurrence raster is drawn with, so the legend
+                describes the image on the map. */}
+            <Ramp
+              stops={BLUES_STOPS}
+              lowLabel="never water"
+              highLabel="water on every observed date"
+            />
+
+            {(clipped > 0 || degenerate > 0) && (
+              <p className="flex items-start gap-1.5 text-[10px] leading-relaxed text-muted-foreground">
+                <AlertTriangle className="mt-0.5 size-3 shrink-0 text-primary/80" />
+                <span>
+                  {clipped > 0 && (
+                    <>
+                      The comparison Otsu threshold hit its bound on {clipped} of{" "}
+                      {water.n_dates} dates and is a bound there, not an
+                      estimate.{" "}
+                    </>
+                  )}
+                  {degenerate > 0 && (
+                    <>
+                      {degenerate} {degenerate === 1 ? "date" : "dates"} had too
+                      few observations to threshold.
+                    </>
+                  )}
+                </span>
+              </p>
+            )}
+
+            <p className="text-[10px] text-muted-foreground">
+              Visibility and opacity live in Overlay Tools.
+            </p>
+          </div>
+        </>
+      )}
+    </motion.div>
+  )
+})

--- a/frontend/src/components/WaterStatusPanel.tsx
+++ b/frontend/src/components/WaterStatusPanel.tsx
@@ -1,0 +1,124 @@
+import { motion } from "motion/react"
+import { AlertTriangle, X } from "lucide-react"
+import type { WaterAnalysis } from "@/lib/types"
+
+/**
+ * Summary of a surface-water run, anchored bottom-right like the other status
+ * panels.
+ *
+ * Every figure is stated against what it was measured on. Water fractions are a
+ * percentage of the pixels observed on that date, not of the AOI, so a partly
+ * clouded date cannot read as dry.
+ */
+export function WaterStatusPanel({
+  water,
+  onClose,
+}: {
+  water: WaterAnalysis
+  onClose: () => void
+}) {
+  const peak = water.series.find((d) => d.date === water.peak_date)
+  const clippedDates = water.series.filter((d) => d.threshold_clipped).length
+  const degenerate = water.series.filter((d) => d.threshold_degenerate).length
+
+  return (
+    <motion.div
+      className="panel app-no-drag absolute bottom-3 right-3 z-[1000] flex w-[19rem] flex-col gap-3 rounded-md p-4"
+      initial={{ opacity: 0, y: 18 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 18 }}
+      transition={{ type: "spring", stiffness: 360, damping: 34 }}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="telemetry text-[10px] text-primary">SURFACE WATER</p>
+          <h2 className="mt-0.5 truncate text-sm font-semibold">
+            {water.index} · {water.n_dates}{" "}
+            {water.n_dates === 1 ? "date" : "dates"}
+          </h2>
+          <p className="telemetry mt-0.5 text-[10px] text-muted-foreground">
+            {water.date_range[0]} → {water.date_range[1]}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-muted-foreground hover:text-foreground"
+          title="Close"
+        >
+          <X className="size-4" />
+        </button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <Metric
+          label="Peak water"
+          value={`${water.peak_water_fraction_pct.toFixed(1)}%`}
+          sub={water.peak_date}
+        />
+        <Metric
+          label="Peak area"
+          value={peak ? `${peak.area_ha.toFixed(2)} ha` : "—"}
+          sub={peak ? `${peak.water_pixels.toLocaleString()} px` : undefined}
+        />
+        <Metric
+          label="Ephemeral"
+          value={`${water.ephemeral_area_ha.toFixed(2)} ha`}
+          sub="wet on some dates"
+        />
+        <Metric
+          label="Persistent"
+          value={`${water.persistent_area_ha.toFixed(2)} ha`}
+          sub="standing water"
+        />
+      </div>
+
+      <p className="text-[10px] leading-relaxed text-muted-foreground">
+        Fractions are a percentage of the pixels observed on each date, not of
+        the {water.aoi_area_ha.toFixed(1)} ha AOI, so a partly clouded date is
+        not reported as dry.
+      </p>
+
+      {(clippedDates > 0 || degenerate > 0) && (
+        <p className="flex items-start gap-1.5 text-[10px] leading-relaxed text-muted-foreground">
+          <AlertTriangle className="mt-0.5 size-3 shrink-0 text-primary/80" />
+          <span>
+            {clippedDates > 0 && (
+              <>
+                The comparison Otsu threshold hit its bound on {clippedDates} of{" "}
+                {water.n_dates} dates and is a bound there, not an estimate.{" "}
+              </>
+            )}
+            {degenerate > 0 && (
+              <>
+                {degenerate}{" "}
+                {degenerate === 1 ? "date had" : "dates had"} too few
+                observations to threshold.
+              </>
+            )}
+          </span>
+        </p>
+      )}
+    </motion.div>
+  )
+}
+
+function Metric({
+  label,
+  value,
+  sub,
+}: {
+  label: string
+  value: string
+  sub?: string
+}) {
+  return (
+    <div className="ar-raised px-2.5 py-1.5">
+      <div className="eyebrow !text-[9px]">{label}</div>
+      <div className="telemetry mt-0.5 text-sm text-foreground">{value}</div>
+      {sub && (
+        <div className="telemetry text-[9px] text-muted-foreground">{sub}</div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/lib/analysisTables.ts
+++ b/frontend/src/lib/analysisTables.ts
@@ -11,6 +11,7 @@
  */
 import type {
   ClassStat,
+  WaterAnalysis,
   LULCAnalysis,
   PhenologyMetrics,
   PhenologyStatePoint,
@@ -307,6 +308,10 @@ export function lulcPredVsRefTable(
       { key: "color", swatch: true },
       num("pct_ref"),
       num("pct_pred"),
+      // pixels_ref counts 10 m pixels; n_reference_cells counts the native 30 m
+      // MapBiomas cells behind them, which is the agreement sample size.
+      num("pixels_ref"),
+      num("n_reference_cells"),
     ],
     (lulc?.pred_vs_ref ?? []).map((r) => [
       r.class_id,
@@ -314,6 +319,46 @@ export function lulcPredVsRefTable(
       r.color,
       r.pct_ref,
       r.pct_pred,
+      r.pixels_ref ?? 0,
+      r.n_reference_cells ?? 0,
+    ])
+  )
+}
+
+export function waterSeriesTable(
+  water?: WaterAnalysis | null
+): DataTable | null {
+  return table(
+    "water_series",
+    "water_series.csv",
+    [
+      { key: "date" },
+      { key: "scene_id" },
+      num("cloud_cover"),
+      // The denominator of water_fraction_pct: AOI pixels seen on that date.
+      num("observed_pixels"),
+      num("threshold_fixed"),
+      num("threshold_otsu"),
+      { key: "threshold_clipped" },
+      { key: "threshold_degenerate" },
+      num("water_fraction_pct"),
+      num("water_fraction_otsu_pct"),
+      num("water_pixels"),
+      num("area_ha"),
+    ],
+    (water?.series ?? []).map((d) => [
+      d.date,
+      d.scene_id,
+      d.cloud_cover,
+      d.observed_pixels,
+      d.threshold_fixed,
+      d.threshold_otsu,
+      String(d.threshold_clipped),
+      String(d.threshold_degenerate),
+      d.water_fraction_pct,
+      d.water_fraction_otsu_pct,
+      d.water_pixels,
+      d.area_ha,
     ])
   )
 }
@@ -330,6 +375,7 @@ export function allAnalysisTables(result: PredictResult): DataTable[] {
     lulcCompositionTable(result.lulc),
     lulcGroupsTable(result.lulc),
     lulcPredVsRefTable(result.lulc),
+    waterSeriesTable(result.water),
   ].filter((t): t is DataTable => t !== null)
 }
 

--- a/frontend/src/lib/preferenceExtras.ts
+++ b/frontend/src/lib/preferenceExtras.ts
@@ -9,6 +9,11 @@ export interface PreferenceExtras {
   aoi_label?: string
   /** Last product version for which What’s New was shown (or silently seeded). */
   last_seen_version?: string
+  /**
+   * Where the map was left. Restored on start so a session resumes at the last
+   * place worked on rather than at the continental default.
+   */
+  map_view?: { lat: number; lon: number; zoom: number }
 }
 
 export function parsePreferenceExtras(

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -228,6 +228,8 @@ export interface InferenceRun {
   n_dates: number
   label?: string
   project_id?: string
+  /** "classification" or "water"; empty on rows written before the column. */
+  kind?: string
 }
 
 export interface Project {
@@ -393,4 +395,7 @@ export interface WaterRequest {
   max_cloud: number
   monthly_best: boolean
   index: WaterIndex
+  label?: string
+  run_label?: string
+  project_id?: string
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -336,3 +336,59 @@ export interface CompositionOverlay {
   /** Local GeoTIFF path for export (when available). */
   raster_tif?: string
 }
+
+export type WaterIndex = "NDWI" | "MNDWI" | "AWEI"
+
+export interface WaterDate {
+  date: string
+  scene_id: string
+  cloud_cover: number
+  /**
+   * AOI pixels actually observed on this date. Water fractions are a percentage
+   * of this, not of the whole AOI, so a partly clouded date is not read as dry.
+   */
+  observed_pixels: number
+  threshold_fixed: number
+  threshold_otsu: number
+  /** The Otsu value hit an empirical bound and is a bound, not an estimate. */
+  threshold_clipped: boolean
+  /** Too few observations to threshold at all. */
+  threshold_degenerate: boolean
+  water_fraction_pct: number
+  water_fraction_otsu_pct: number
+  water_pixels: number
+  area_ha: number
+}
+
+export interface WaterAnalysis {
+  index: WaterIndex
+  threshold_method: string
+  threshold_fixed: number
+  otsu_clip: number[]
+  n_dates: number
+  date_range: string[]
+  aoi_pixels: number
+  aoi_area_ha: number
+  series: WaterDate[]
+  peak_date: string
+  peak_water_fraction_pct: number
+  /** Water on some dates but not most: the flood signal rather than a pond. */
+  ephemeral_pixels: number
+  ephemeral_area_ha: number
+  persistent_pixels: number
+  persistent_area_ha: number
+  mean_anomaly: number
+  /** Occurrence raster as a data URI, coloured on a fixed 0 to 1 scale. */
+  occurrence_uri: string
+  extent: Bounds
+}
+
+export interface WaterRequest {
+  area_id: string
+  polygon_geojson: GeoJSONGeometry | null
+  start: string
+  end: string
+  max_cloud: number
+  monthly_best: boolean
+  index: WaterIndex
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -175,6 +175,8 @@ export interface PredictResult {
   phenology: PhenologyMetrics
   phenology_states: PhenologyStatePoint[]
   lulc?: LULCAnalysis | null
+  /** Attached when a surface-water run was made over the same AOI. */
+  water?: WaterAnalysis | null
 }
 
 export interface ProgressEvent {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -127,6 +127,14 @@ export interface LULCCompareRow {
   color: string
   pct_ref: number
   pct_pred: number
+  /** 10 m pixels of this class in the reference, on the classification grid. */
+  pixels_ref?: number
+  /**
+   * Distinct native 30 m MapBiomas cells behind those pixels. This is the
+   * number of independent label observations; the pixel count is about nine
+   * times larger and is not a sample size.
+   */
+  n_reference_cells?: number
 }
 
 export interface LULCAnalysis {
@@ -138,6 +146,10 @@ export interface LULCAnalysis {
   composition: LULCClassRow[]
   groups: LULCGroupRow[]
   pred_vs_ref: LULCCompareRow[]
+  /** Valid 10 m pixels shared by both maps. */
+  compare_pixels?: number
+  /** Distinct native reference cells behind them; the comparison sample size. */
+  compare_reference_cells?: number
 }
 
 export interface LULCRequest {

--- a/frontend/src/pages/AnalysisPage.tsx
+++ b/frontend/src/pages/AnalysisPage.tsx
@@ -100,6 +100,25 @@ function WaterFigure({
   )
 }
 
+/** Peak water and occurrence areas from a saved water run's summary. */
+function waterSummaryLine(summary?: string | null): string {
+  if (!summary?.trim()) return "surface water"
+  try {
+    const j = JSON.parse(summary) as Record<string, unknown>
+    const peak =
+      typeof j.peak_water_fraction_pct === "number"
+        ? `peak ${j.peak_water_fraction_pct.toFixed(1)}%`
+        : ""
+    const eph =
+      typeof j.ephemeral_area_ha === "number"
+        ? `${j.ephemeral_area_ha.toFixed(2)} ha ephemeral`
+        : ""
+    return [peak, eph].filter(Boolean).join(" · ") || "surface water"
+  } catch {
+    return "surface water"
+  }
+}
+
 function modelDisplayName(kind: string): string {
   if (kind === "temporal_transformer") return "Temporal Transformer"
   if (kind === "prithvi") return "Prithvi-EO 2.0"
@@ -1813,7 +1832,14 @@ function SavedRunsPanel({
                     </div>
                     {/* What the run produced, from summary already in memory —
                         saves a LoadAnalysis round trip just to see the result. */}
-                    {dominant && (
+                    {r.kind === "water" ? (
+                      <div className="mt-1 flex items-center gap-1.5">
+                        <span className="size-2.5 shrink-0 rounded-[2px] bg-[#3182bd]" />
+                        <span className="truncate text-foreground">
+                          {waterSummaryLine(r.summary)}
+                        </span>
+                      </div>
+                    ) : dominant && (
                       <div className="mt-1 flex items-center gap-1.5">
                         <span
                           className="size-2.5 shrink-0 rounded-[2px]"
@@ -1835,7 +1861,9 @@ function SavedRunsPanel({
                     {/* The requested window is a query; date_range is the extent
                         actually observed. Older runs have no date_range. */}
                     <div className="mt-0.5 text-muted-foreground">
-                      {modelDisplayName(r.model_kind)}
+                      {r.kind === "water"
+                        ? `Surface water · ${r.model_kind || "index"}`
+                        : modelDisplayName(r.model_kind)}
                       {" · "}
                       {summary.dateRange ? (
                         <>

--- a/frontend/src/pages/AnalysisPage.tsx
+++ b/frontend/src/pages/AnalysisPage.tsx
@@ -76,6 +76,30 @@ const PROJECT_TABS: { id: ProjectTab; label: string }[] = [
  * Display name for a model_kind enum. Shared so the run list and the detail
  * header cannot disagree; the list previously printed the raw enum.
  */
+function WaterFigure({
+  label,
+  value,
+  sub,
+}: {
+  label: string
+  value: string
+  sub?: string
+}) {
+  return (
+    <div className="min-w-0">
+      <div className="eyebrow !text-[9px]">{label}</div>
+      <div className="telemetry mt-0.5 truncate text-sm text-foreground">
+        {value}
+      </div>
+      {sub && (
+        <div className="telemetry truncate text-[10px] text-muted-foreground">
+          {sub}
+        </div>
+      )}
+    </div>
+  )
+}
+
 function modelDisplayName(kind: string): string {
   if (kind === "temporal_transformer") return "Temporal Transformer"
   if (kind === "prithvi") return "Prithvi-EO 2.0"
@@ -846,6 +870,7 @@ export function AnalysisPage({
   }
 
   const canExportTables =
+    (result.water?.series?.length ?? 0) > 0 ||
     (result.class_stats?.length ?? 0) > 0 ||
     (result.vi_series?.length ?? 0) > 0 ||
     !!result.lulc ||
@@ -866,6 +891,9 @@ export function AnalysisPage({
         lulc: result.lulc
           ? { ...result.lulc, map_uri: "", map_png: "" }
           : result.lulc,
+        water: result.water
+          ? { ...result.water, occurrence_uri: "" }
+          : result.water,
       }
       const dest = await ExportResearchPack(
         {
@@ -1299,6 +1327,86 @@ export function AnalysisPage({
               )}
             </div>
           ) : null}
+
+          {/*
+            Surface water over the period. Fractions are a percentage of the
+            pixels observed on each date, so the series is not comparable to a
+            fraction of the AOI area.
+          */}
+          {result.water && result.water.series.length > 0 && (
+            <section className="ar-section p-4">
+              <div className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
+                <p className="eyebrow">
+                  Surface water · {result.water.index}
+                </p>
+                <p className="telemetry text-[10px] text-muted-foreground">
+                  {result.water.n_dates} dates ·{" "}
+                  {result.water.date_range[0]} → {result.water.date_range[1]}
+                </p>
+              </div>
+              <ResponsiveContainer width="100%" height={200}>
+                <LineChart
+                  data={result.water.series.map((d) => ({
+                    date: d.date,
+                    water: d.water_fraction_pct,
+                  }))}
+                  margin={{ top: 5, right: 12, left: -12, bottom: 0 }}
+                >
+                  <CartesianGrid strokeDasharray="2 4" stroke="var(--ar-border)" />
+                  <XAxis
+                    dataKey="date"
+                    tick={{ fontSize: 9, fill: "var(--muted-foreground)" }}
+                    tickFormatter={(d: string) => d.slice(2, 7)}
+                    interval="preserveStartEnd"
+                    minTickGap={24}
+                  />
+                  <YAxis
+                    tick={{ fontSize: 9, fill: "var(--muted-foreground)" }}
+                    unit="%"
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: "var(--ar-raised)",
+                      border: "1px solid var(--ar-border)",
+                      borderRadius: 4,
+                      fontSize: 11,
+                    }}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="water"
+                    name="Water fraction"
+                    stroke="#3182bd"
+                    strokeWidth={1.8}
+                    dot={{ r: 2 }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+              <div className="mt-3 grid grid-cols-2 gap-3 border-t pt-3 sm:grid-cols-4"
+                   style={{ borderColor: "var(--ar-border)" }}>
+                <WaterFigure
+                  label="Peak"
+                  value={`${result.water.peak_water_fraction_pct.toFixed(1)}%`}
+                  sub={result.water.peak_date}
+                />
+                <WaterFigure
+                  label="Ephemeral"
+                  value={`${result.water.ephemeral_area_ha.toFixed(2)} ha`}
+                  sub="wet on some dates"
+                />
+                <WaterFigure
+                  label="Persistent"
+                  value={`${result.water.persistent_area_ha.toFixed(2)} ha`}
+                  sub="standing water"
+                />
+                <WaterFigure
+                  label="AOI"
+                  value={`${result.water.aoi_area_ha.toFixed(1)} ha`}
+                  sub="fraction denominator is per date"
+                />
+              </div>
+            </section>
+          )}
 
           {runsPanel}
         </div>

--- a/frontend/src/pages/MapScreen.tsx
+++ b/frontend/src/pages/MapScreen.tsx
@@ -146,10 +146,14 @@ export function MapScreen(props: MapScreenProps) {
     setLeftPanel((cur) => (cur === id ? null : id))
   }
 
+  // The three status panels share one slot at the bottom of the map, so only
+  // the one matching the open tool is shown.
+  const showWaterStatus = leftPanel === "water" && !!props.water
   const showCompositionStatus =
-    leftPanel === "compose" || (!props.result && !!props.composition)
+    !showWaterStatus &&
+    (leftPanel === "compose" || (!props.result && !!props.composition))
   const showPredictionStatus =
-    !showCompositionStatus && !!props.result
+    !showWaterStatus && !showCompositionStatus && !!props.result
 
   const selectedSceneDate =
     props.composeScenes.find((s) => s.id === props.selectedSceneId)?.date ??
@@ -346,7 +350,13 @@ export function MapScreen(props: MapScreenProps) {
       </AnimatePresence>
 
       <AnimatePresence mode="wait" initial={false}>
-        {showCompositionStatus ? (
+        {showWaterStatus ? (
+          <WaterStatusPanel
+            key="water-status"
+            water={props.water ?? null}
+            onClear={props.onClearWater}
+          />
+        ) : showCompositionStatus ? (
           <CompositionStatusPanel
             key="composition-status"
             composition={props.composition}
@@ -362,16 +372,6 @@ export function MapScreen(props: MapScreenProps) {
             onNewClassification={props.onNewClassification}
           />
         ) : null}
-      </AnimatePresence>
-
-      <AnimatePresence initial={false}>
-        {props.water && leftPanel === "water" && (
-          <WaterStatusPanel
-            key="water-status"
-            water={props.water}
-            onClose={props.onClearWater}
-          />
-        )}
       </AnimatePresence>
 
       <DataCubeModal

--- a/frontend/src/pages/MapScreen.tsx
+++ b/frontend/src/pages/MapScreen.tsx
@@ -131,6 +131,8 @@ export interface MapScreenProps {
   onRunWater: () => void
   onClearWater: () => void
   onShowWaterOverlayChange: (v: boolean) => void
+  waterOpacity: number
+  onWaterOpacityChange: (v: number) => void
   leftDockTabs?: LeftDockTabsMode
 }
 
@@ -179,7 +181,11 @@ export function MapScreen(props: MapScreenProps) {
         composition={props.composition}
         waterOverlay={
           props.water && props.showWaterOverlay
-            ? { uri: props.water.occurrence_uri, extent: props.water.extent }
+            ? {
+                uri: props.water.occurrence_uri,
+                extent: props.water.extent,
+                opacity: props.waterOpacity,
+              }
             : null
         }
         swipeCompare={props.swipeCompare}
@@ -217,6 +223,11 @@ export function MapScreen(props: MapScreenProps) {
         onShowPredictionOverlayChange={props.onShowPredictionOverlayChange}
         showCompositionOverlay={props.showCompositionOverlay}
         onShowCompositionOverlayChange={props.onShowCompositionOverlayChange}
+        water={props.water}
+        showWaterOverlay={props.showWaterOverlay}
+        onShowWaterOverlayChange={props.onShowWaterOverlayChange}
+        waterOpacity={props.waterOpacity}
+        onWaterOpacityChange={props.onWaterOpacityChange}
         showConfidence={props.showConfidence}
         onShowConfidenceChange={props.onShowConfidenceChange}
         confidenceOnTop={props.confidenceOnTop}

--- a/frontend/src/pages/MapScreen.tsx
+++ b/frontend/src/pages/MapScreen.tsx
@@ -11,12 +11,16 @@ import type {
   LeftDockTabsMode,
   ModelKind,
   PredictResult,
+  WaterAnalysis,
+  WaterIndex,
 } from "@/lib/types"
 import type { AoiContourSchemeId } from "@/lib/aoiStyle"
 import { MapView } from "@/components/MapView"
 import { SearchBar } from "@/components/SearchBar"
 import { ControlPanel } from "@/components/ControlPanel"
 import { CompositionPanel } from "@/components/CompositionPanel"
+import { WaterPanel } from "@/components/WaterPanel"
+import { WaterStatusPanel } from "@/components/WaterStatusPanel"
 import { LeftDockRail, type LeftDockPanel } from "@/components/LeftDockRail"
 import { ResultsPanel } from "@/components/ResultsPanel"
 import { CompositionStatusPanel } from "@/components/CompositionStatusPanel"
@@ -115,6 +119,16 @@ export interface MapScreenProps {
   dataCubeError?: string | null
   dataCubeResult?: DataCubeResult | null
   onCloseDataCube: () => void
+  water?: WaterAnalysis | null
+  waterIndex: WaterIndex
+  waterRunning: boolean
+  waterProgress: number
+  waterProgressMsg: string
+  showWaterOverlay: boolean
+  onWaterIndexChange: (i: WaterIndex) => void
+  onRunWater: () => void
+  onClearWater: () => void
+  onShowWaterOverlayChange: (v: boolean) => void
   leftDockTabs?: LeftDockTabsMode
 }
 
@@ -156,6 +170,11 @@ export function MapScreen(props: MapScreenProps) {
         showPredictionOverlay={props.showPredictionOverlay}
         showCompositionOverlay={props.showCompositionOverlay}
         composition={props.composition}
+        waterOverlay={
+          props.water && props.showWaterOverlay
+            ? { uri: props.water.occurrence_uri, extent: props.water.extent }
+            : null
+        }
         swipeCompare={props.swipeCompare}
         swipeRatio={props.swipeRatio}
         onSwipeRatioChange={props.onSwipeRatioChange}
@@ -261,6 +280,29 @@ export function MapScreen(props: MapScreenProps) {
             dataCubeLoading={props.dataCubeLoading}
             onCollapse={() => setLeftPanel(null)}
           />
+        ) : leftPanel === "water" ? (
+          <WaterPanel
+            key="water"
+            panelOffsetClass={panelOffsetClass}
+            hasArea={props.hasArea}
+            start={props.start}
+            end={props.end}
+            onStartChange={props.onStartChange}
+            onEndChange={props.onEndChange}
+            maxCloud={props.maxCloud}
+            onMaxCloudChange={props.onMaxCloudChange}
+            monthlyBest={props.monthlyBest}
+            onMonthlyBestChange={props.onMonthlyBestChange}
+            index={props.waterIndex}
+            onIndexChange={props.onWaterIndexChange}
+            running={props.waterRunning}
+            progress={props.waterProgress}
+            progressMsg={props.waterProgressMsg}
+            hasResult={!!props.water}
+            onRun={props.onRunWater}
+            onClear={props.onClearWater}
+            onCollapse={() => setLeftPanel(null)}
+          />
         ) : leftPanel === "compose" ? (
           <CompositionPanel
             key="compose"
@@ -317,6 +359,16 @@ export function MapScreen(props: MapScreenProps) {
             onNewClassification={props.onNewClassification}
           />
         ) : null}
+      </AnimatePresence>
+
+      <AnimatePresence initial={false}>
+        {props.water && leftPanel === "water" && (
+          <WaterStatusPanel
+            key="water-status"
+            water={props.water}
+            onClose={props.onClearWater}
+          />
+        )}
       </AnimatePresence>
 
       <DataCubeModal

--- a/frontend/src/pages/MapScreen.tsx
+++ b/frontend/src/pages/MapScreen.tsx
@@ -28,6 +28,8 @@ import {
 } from "@/components/OverlayToolsPanel"
 
 export interface MapScreenProps {
+  /** Where the map was left last session; null starts at the default view. */
+  initialView?: { lat: number; lon: number; zoom: number } | null
   areas: Area[]
   activeExample: string
   customPolygon: GeoJSONGeometry | null
@@ -142,6 +144,7 @@ export function MapScreen(props: MapScreenProps) {
   return (
     <div className="relative h-full min-h-0 w-full">
       <MapView
+        initialView={props.initialView}
         areas={props.areas}
         activeExample={props.activeExample}
         customPolygon={props.customPolygon}

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -6,6 +6,8 @@ import {main} from '../models';
 
 export function AnalyzeLULC(arg1:backend.LULCRequest):Promise<backend.LULCAnalysis>;
 
+export function AnalyzeWater(arg1:backend.WaterRequest):Promise<backend.WaterAnalysis>;
+
 export function ClearAvatar():Promise<store.User>;
 
 export function CreateProject(arg1:string,arg2:string):Promise<store.Project>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -6,6 +6,10 @@ export function AnalyzeLULC(arg1) {
   return window['go']['main']['App']['AnalyzeLULC'](arg1);
 }
 
+export function AnalyzeWater(arg1) {
+  return window['go']['main']['App']['AnalyzeWater'](arg1);
+}
+
 export function ClearAvatar() {
   return window['go']['main']['App']['ClearAvatar']();
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -825,6 +825,9 @@ export namespace backend {
 	    max_cloud: number;
 	    monthly_best: boolean;
 	    index?: string;
+	    label?: string;
+	    run_label?: string;
+	    project_id?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new WaterRequest(source);
@@ -839,6 +842,9 @@ export namespace backend {
 	        this.max_cloud = source["max_cloud"];
 	        this.monthly_best = source["monthly_best"];
 	        this.index = source["index"];
+	        this.label = source["label"];
+	        this.run_label = source["run_label"];
+	        this.project_id = source["project_id"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -907,6 +913,7 @@ export namespace store {
 	    n_dates: number;
 	    label?: string;
 	    project_id?: string;
+	    kind?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new InferenceRun(source);
@@ -929,6 +936,7 @@ export namespace store {
 	        this.n_dates = source["n_dates"];
 	        this.label = source["label"];
 	        this.project_id = source["project_id"];
+	        this.kind = source["kind"];
 	    }
 	}
 	export class Preferences {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -315,6 +315,8 @@ export namespace backend {
 	    color: string;
 	    pct_ref: number;
 	    pct_pred: number;
+	    pixels_ref: number;
+	    n_reference_cells?: number;
 	
 	    static createFrom(source: any = {}) {
 	        return new LULCCompareRow(source);
@@ -327,6 +329,8 @@ export namespace backend {
 	        this.color = source["color"];
 	        this.pct_ref = source["pct_ref"];
 	        this.pct_pred = source["pct_pred"];
+	        this.pixels_ref = source["pixels_ref"];
+	        this.n_reference_cells = source["n_reference_cells"];
 	    }
 	}
 	export class LULCGroupRow {
@@ -411,6 +415,8 @@ export namespace backend {
 	    composition: LULCClassRow[];
 	    groups: LULCGroupRow[];
 	    pred_vs_ref: LULCCompareRow[];
+	    compare_pixels?: number;
+	    compare_reference_cells?: number;
 	
 	    static createFrom(source: any = {}) {
 	        return new LULCAnalysis(source);
@@ -427,6 +433,8 @@ export namespace backend {
 	        this.composition = this.convertValues(source["composition"], LULCClassRow);
 	        this.groups = this.convertValues(source["groups"], LULCGroupRow);
 	        this.pred_vs_ref = this.convertValues(source["pred_vs_ref"], LULCCompareRow);
+	        this.compare_pixels = source["compare_pixels"];
+	        this.compare_reference_cells = source["compare_reference_cells"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -714,6 +714,148 @@ export namespace backend {
 	    }
 	}
 	
+	
+	export class WaterDate {
+	    date: string;
+	    scene_id: string;
+	    cloud_cover: number;
+	    observed_pixels: number;
+	    threshold_fixed: number;
+	    threshold_otsu: number;
+	    threshold_clipped: boolean;
+	    threshold_degenerate: boolean;
+	    water_fraction_pct: number;
+	    water_fraction_otsu_pct: number;
+	    water_pixels: number;
+	    area_ha: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new WaterDate(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.date = source["date"];
+	        this.scene_id = source["scene_id"];
+	        this.cloud_cover = source["cloud_cover"];
+	        this.observed_pixels = source["observed_pixels"];
+	        this.threshold_fixed = source["threshold_fixed"];
+	        this.threshold_otsu = source["threshold_otsu"];
+	        this.threshold_clipped = source["threshold_clipped"];
+	        this.threshold_degenerate = source["threshold_degenerate"];
+	        this.water_fraction_pct = source["water_fraction_pct"];
+	        this.water_fraction_otsu_pct = source["water_fraction_otsu_pct"];
+	        this.water_pixels = source["water_pixels"];
+	        this.area_ha = source["area_ha"];
+	    }
+	}
+	export class WaterAnalysis {
+	    index: string;
+	    threshold_method: string;
+	    threshold_fixed: number;
+	    otsu_clip: number[];
+	    n_dates: number;
+	    date_range: string[];
+	    aoi_pixels: number;
+	    aoi_area_ha: number;
+	    series: WaterDate[];
+	    peak_date: string;
+	    peak_water_fraction_pct: number;
+	    ephemeral_pixels: number;
+	    ephemeral_area_ha: number;
+	    persistent_pixels: number;
+	    persistent_area_ha: number;
+	    mean_anomaly: number;
+	    occurrence_uri: string;
+	    extent: Bounds;
+	
+	    static createFrom(source: any = {}) {
+	        return new WaterAnalysis(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.index = source["index"];
+	        this.threshold_method = source["threshold_method"];
+	        this.threshold_fixed = source["threshold_fixed"];
+	        this.otsu_clip = source["otsu_clip"];
+	        this.n_dates = source["n_dates"];
+	        this.date_range = source["date_range"];
+	        this.aoi_pixels = source["aoi_pixels"];
+	        this.aoi_area_ha = source["aoi_area_ha"];
+	        this.series = this.convertValues(source["series"], WaterDate);
+	        this.peak_date = source["peak_date"];
+	        this.peak_water_fraction_pct = source["peak_water_fraction_pct"];
+	        this.ephemeral_pixels = source["ephemeral_pixels"];
+	        this.ephemeral_area_ha = source["ephemeral_area_ha"];
+	        this.persistent_pixels = source["persistent_pixels"];
+	        this.persistent_area_ha = source["persistent_area_ha"];
+	        this.mean_anomaly = source["mean_anomaly"];
+	        this.occurrence_uri = source["occurrence_uri"];
+	        this.extent = this.convertValues(source["extent"], Bounds);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	
+	export class WaterRequest {
+	    area_id: string;
+	    polygon_geojson?: GeoJSONGeometry;
+	    start: string;
+	    end: string;
+	    max_cloud: number;
+	    monthly_best: boolean;
+	    index?: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new WaterRequest(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.area_id = source["area_id"];
+	        this.polygon_geojson = this.convertValues(source["polygon_geojson"], GeoJSONGeometry);
+	        this.start = source["start"];
+	        this.end = source["end"];
+	        this.max_cloud = source["max_cloud"];
+	        this.monthly_best = source["monthly_best"];
+	        this.index = source["index"];
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
 
 }
 

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -591,130 +591,6 @@ export namespace backend {
 		    return a;
 		}
 	}
-	export class VISeriesPoint {
-	    date: string;
-	    ndvi_mean: number;
-	    ndvi_std: number;
-	    evi_mean: number;
-	    evi_std: number;
-	    savi_mean: number;
-	    savi_std: number;
-	
-	    static createFrom(source: any = {}) {
-	        return new VISeriesPoint(source);
-	    }
-	
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.date = source["date"];
-	        this.ndvi_mean = source["ndvi_mean"];
-	        this.ndvi_std = source["ndvi_std"];
-	        this.evi_mean = source["evi_mean"];
-	        this.evi_std = source["evi_std"];
-	        this.savi_mean = source["savi_mean"];
-	        this.savi_std = source["savi_std"];
-	    }
-	}
-	export class TemporalPoint {
-	    date: string;
-	    n_dates_stack: number;
-	    soja_ndvi_mean?: number;
-	    soja_retention_pct?: number;
-	    dominant?: string;
-	
-	    static createFrom(source: any = {}) {
-	        return new TemporalPoint(source);
-	    }
-	
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.date = source["date"];
-	        this.n_dates_stack = source["n_dates_stack"];
-	        this.soja_ndvi_mean = source["soja_ndvi_mean"];
-	        this.soja_retention_pct = source["soja_retention_pct"];
-	        this.dominant = source["dominant"];
-	    }
-	}
-	export class PredictResult {
-	    extent: Bounds;
-	    overlay_uri: string;
-	    confidence_uri: string;
-	    ndvi_mean_uri: string;
-	    true_color_uri: string;
-	    reference_uri: string;
-	    raster_tif: string;
-	    mean_confidence: number;
-	    n_dates: number;
-	    date_range: string[];
-	    class_stats: ClassStat[];
-	    temporal: TemporalPoint[];
-	    vi_series: VISeriesPoint[];
-	    phenology: PhenologyMetrics;
-	    phenology_states: PhenologyStatePoint[];
-	    lulc?: LULCAnalysis;
-	
-	    static createFrom(source: any = {}) {
-	        return new PredictResult(source);
-	    }
-	
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.extent = this.convertValues(source["extent"], Bounds);
-	        this.overlay_uri = source["overlay_uri"];
-	        this.confidence_uri = source["confidence_uri"];
-	        this.ndvi_mean_uri = source["ndvi_mean_uri"];
-	        this.true_color_uri = source["true_color_uri"];
-	        this.reference_uri = source["reference_uri"];
-	        this.raster_tif = source["raster_tif"];
-	        this.mean_confidence = source["mean_confidence"];
-	        this.n_dates = source["n_dates"];
-	        this.date_range = source["date_range"];
-	        this.class_stats = this.convertValues(source["class_stats"], ClassStat);
-	        this.temporal = this.convertValues(source["temporal"], TemporalPoint);
-	        this.vi_series = this.convertValues(source["vi_series"], VISeriesPoint);
-	        this.phenology = this.convertValues(source["phenology"], PhenologyMetrics);
-	        this.phenology_states = this.convertValues(source["phenology_states"], PhenologyStatePoint);
-	        this.lulc = this.convertValues(source["lulc"], LULCAnalysis);
-	    }
-	
-		convertValues(a: any, classs: any, asMap: boolean = false): any {
-		    if (!a) {
-		        return a;
-		    }
-		    if (a.slice && a.map) {
-		        return (a as any[]).map(elem => this.convertValues(elem, classs));
-		    } else if ("object" === typeof a) {
-		        if (asMap) {
-		            for (const key of Object.keys(a)) {
-		                a[key] = new classs(a[key]);
-		            }
-		            return a;
-		        }
-		        return new classs(a);
-		    }
-		    return a;
-		}
-	}
-	export class ResearchExportMeta {
-	    model_kind: string;
-	    area_id: string;
-	    aoi_label: string;
-	    polygon_geojson: string;
-	
-	    static createFrom(source: any = {}) {
-	        return new ResearchExportMeta(source);
-	    }
-	
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.model_kind = source["model_kind"];
-	        this.area_id = source["area_id"];
-	        this.aoi_label = source["aoi_label"];
-	        this.polygon_geojson = source["polygon_geojson"];
-	    }
-	}
-	
-	
 	export class WaterDate {
 	    date: string;
 	    scene_id: string;
@@ -813,6 +689,133 @@ export namespace backend {
 		    return a;
 		}
 	}
+	export class VISeriesPoint {
+	    date: string;
+	    ndvi_mean: number;
+	    ndvi_std: number;
+	    evi_mean: number;
+	    evi_std: number;
+	    savi_mean: number;
+	    savi_std: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new VISeriesPoint(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.date = source["date"];
+	        this.ndvi_mean = source["ndvi_mean"];
+	        this.ndvi_std = source["ndvi_std"];
+	        this.evi_mean = source["evi_mean"];
+	        this.evi_std = source["evi_std"];
+	        this.savi_mean = source["savi_mean"];
+	        this.savi_std = source["savi_std"];
+	    }
+	}
+	export class TemporalPoint {
+	    date: string;
+	    n_dates_stack: number;
+	    soja_ndvi_mean?: number;
+	    soja_retention_pct?: number;
+	    dominant?: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new TemporalPoint(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.date = source["date"];
+	        this.n_dates_stack = source["n_dates_stack"];
+	        this.soja_ndvi_mean = source["soja_ndvi_mean"];
+	        this.soja_retention_pct = source["soja_retention_pct"];
+	        this.dominant = source["dominant"];
+	    }
+	}
+	export class PredictResult {
+	    extent: Bounds;
+	    overlay_uri: string;
+	    confidence_uri: string;
+	    ndvi_mean_uri: string;
+	    true_color_uri: string;
+	    reference_uri: string;
+	    raster_tif: string;
+	    mean_confidence: number;
+	    n_dates: number;
+	    date_range: string[];
+	    class_stats: ClassStat[];
+	    temporal: TemporalPoint[];
+	    vi_series: VISeriesPoint[];
+	    phenology: PhenologyMetrics;
+	    phenology_states: PhenologyStatePoint[];
+	    lulc?: LULCAnalysis;
+	    water?: WaterAnalysis;
+	
+	    static createFrom(source: any = {}) {
+	        return new PredictResult(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.extent = this.convertValues(source["extent"], Bounds);
+	        this.overlay_uri = source["overlay_uri"];
+	        this.confidence_uri = source["confidence_uri"];
+	        this.ndvi_mean_uri = source["ndvi_mean_uri"];
+	        this.true_color_uri = source["true_color_uri"];
+	        this.reference_uri = source["reference_uri"];
+	        this.raster_tif = source["raster_tif"];
+	        this.mean_confidence = source["mean_confidence"];
+	        this.n_dates = source["n_dates"];
+	        this.date_range = source["date_range"];
+	        this.class_stats = this.convertValues(source["class_stats"], ClassStat);
+	        this.temporal = this.convertValues(source["temporal"], TemporalPoint);
+	        this.vi_series = this.convertValues(source["vi_series"], VISeriesPoint);
+	        this.phenology = this.convertValues(source["phenology"], PhenologyMetrics);
+	        this.phenology_states = this.convertValues(source["phenology_states"], PhenologyStatePoint);
+	        this.lulc = this.convertValues(source["lulc"], LULCAnalysis);
+	        this.water = this.convertValues(source["water"], WaterAnalysis);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	export class ResearchExportMeta {
+	    model_kind: string;
+	    area_id: string;
+	    aoi_label: string;
+	    polygon_geojson: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new ResearchExportMeta(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.model_kind = source["model_kind"];
+	        this.area_id = source["area_id"];
+	        this.aoi_label = source["aoi_label"];
+	        this.polygon_geojson = source["polygon_geojson"];
+	    }
+	}
+	
+	
+	
 	
 	export class WaterRequest {
 	    area_id: string;

--- a/sidecar/infer.py
+++ b/sidecar/infer.py
@@ -934,6 +934,150 @@ def main():
         sys.stdout.flush()
         return
 
+    # Surface water / flood mapping from spectral water indices (no model).
+    if action == 'water':
+        import water as water_mod
+        import composite as comp
+
+        configure_gdal_for_cog()
+        start = req.get('start')
+        end = req.get('end')
+        max_cloud = float(req.get('max_cloud', 100.0))
+        monthly_best = bool(req.get('monthly_best', True))
+        tiles = req.get('tiles') or None
+        index_name = (req.get('index') or water_mod.PRIMARY_INDEX).upper()
+        if index_name not in water_mod.INDEX_NAMES:
+            fail(f'unknown water index: {index_name}')
+        if not start or not end:
+            fail('water requires start and end dates (YYYY-MM-DD)')
+        if not req.get('polygon_geojson'):
+            fail('no polygon provided (polygon_geojson required)')
+        polygon = polygon_from_geojson(req['polygon_geojson'])
+
+        emit_progress(10, 'querying STAC catalog (Planetary Computer)')
+        try:
+            products = list_stac_products(
+                polygon, start, end, tile_list=tiles, max_cloud=max_cloud,
+                monthly_best=monthly_best,
+            )
+        except Exception as e:
+            fail(f'STAC query failed: {e}')
+        if not products:
+            fail('no scenes found for this period and cloud filter')
+
+        # The reference grid comes from B04 at 10 m, as in the predict path.
+        ref_band, ref_profile = load_and_clip_band(products[0], 'B04', polygon)
+        aoi_valid = ref_band > 0
+        needed = water_mod.INDEX_BANDS[index_name]
+
+        series = []
+        masks = []
+        observed = []
+        frames = []
+        n = len(products)
+        for idx, product in enumerate(products):
+            pct = 15 + int(70 * (idx + 1) / n)
+            date_str = product['date'].strftime('%Y-%m-%d')
+            emit_progress(pct, f'water index {idx + 1}/{n} ({date_str})')
+            try:
+                bands = {}
+                for name in ('B03', 'B8A', 'B11', 'B12'):
+                    res = comp.BAND_RESOLUTION.get(name, '10m')
+                    bands[name] = load_band_to_reference_grid(
+                        product, name, polygon, ref_profile, resolution=res
+                    ) / 10000.0
+            except Exception as e:
+                sys.stderr.write(json.dumps({
+                    'progress': -1, 'msg': f'skipping {date_str}: {e}'
+                }) + '\n')
+                sys.stderr.flush()
+                continue
+
+            date_valid = water_mod.per_date_valid_mask(aoi_valid, bands, index_name)
+            if not date_valid.any():
+                continue
+            indices = water_mod.compute_water_indices(
+                bands['B03'], bands['B8A'], bands['B11'], bands['B12']
+            )
+            frame = indices[index_name]
+            vals = frame[date_valid]
+            thr_otsu, clipped, degenerate = water_mod.otsu_threshold_for_date(vals)
+            thr_fixed = water_mod.DEFAULT_THRESHOLD
+
+            mask_fixed = water_mod.water_mask_for_date(frame, date_valid, thr_fixed)
+            mask_otsu = water_mod.water_mask_for_date(frame, date_valid, thr_otsu)
+
+            masks.append(mask_fixed)
+            observed.append(date_valid)
+            frames.append(frame)
+            series.append({
+                'date': date_str,
+                'scene_id': product.get('id') or '',
+                'cloud_cover': round(float(product.get('cloud_cover', 0.0)), 2),
+                'observed_pixels': int(date_valid.sum()),
+                'threshold_fixed': thr_fixed,
+                'threshold_otsu': thr_otsu,
+                'threshold_clipped': bool(clipped),
+                'threshold_degenerate': bool(degenerate),
+                'water_fraction_pct': round(
+                    water_mod.water_fraction_pct(mask_fixed, date_valid), 4
+                ),
+                'water_fraction_otsu_pct': round(
+                    water_mod.water_fraction_pct(mask_otsu, date_valid), 4
+                ),
+                'water_pixels': int(mask_fixed.sum()),
+                'area_ha': round(float(int(mask_fixed.sum()) * 0.01), 4),
+            })
+
+        if not series:
+            fail('no scene produced a usable observation over the AOI')
+
+        emit_progress(88, 'building occurrence map')
+        occ = water_mod.occurrence_map(masks, observed)
+        bands_occ = water_mod.classify_occurrence(occ)
+        observed_cube = np.stack(observed, axis=0)
+        anomaly = water_mod.max_minus_median_index(np.stack(frames, axis=0), observed_cube)
+
+        px_ha = 0.01
+        peak = max(series, key=lambda r: r['water_fraction_pct'])
+
+        occ_png = Path(work_dir) / 'water_occurrence.png'
+        comp.write_rgba_png(water_mod.occurrence_to_rgba(occ), occ_png)
+
+        lon_min, lon_max, lat_min, lat_max = get_map_extent(ref_profile)
+        emit_progress(100, f'{len(series)} dates')
+        sys.stdout.write(json.dumps({
+            'water': {
+                'index': index_name,
+                'threshold_method': 'fixed',
+                'threshold_fixed': water_mod.DEFAULT_THRESHOLD,
+                'otsu_clip': [water_mod.OTSU_CLIP_LOW, water_mod.OTSU_CLIP_HIGH],
+                'n_dates': len(series),
+                'date_range': [series[0]['date'], series[-1]['date']],
+                'aoi_pixels': int(aoi_valid.sum()),
+                'aoi_area_ha': round(float(int(aoi_valid.sum()) * px_ha), 4),
+                'series': series,
+                'peak_date': peak['date'],
+                'peak_water_fraction_pct': peak['water_fraction_pct'],
+                'ephemeral_pixels': int(bands_occ['ephemeral'].sum()),
+                'ephemeral_area_ha': round(
+                    float(int(bands_occ['ephemeral'].sum()) * px_ha), 4
+                ),
+                'persistent_pixels': int(bands_occ['persistent'].sum()),
+                'persistent_area_ha': round(
+                    float(int(bands_occ['persistent'].sum()) * px_ha), 4
+                ),
+                'mean_anomaly': float(np.nanmean(anomaly)) if np.isfinite(anomaly).any() else 0.0,
+                'occurrence_png': str(occ_png),
+                'extent': {
+                    'lon_min': lon_min, 'lat_min': lat_min,
+                    'lon_max': lon_max, 'lat_max': lat_max,
+                },
+            }
+        }))
+        sys.stdout.flush()
+        return
+
     # RGB / false-color composite or spectral index for one STAC scene.
     if action == 'render_composite':
         import composite as comp

--- a/sidecar/infer.py
+++ b/sidecar/infer.py
@@ -1319,9 +1319,20 @@ def main():
                 ref_on_pred_grid=None,  # composition from native clip
             )
             if ref_grid is not None:
-                # Overlay comparison on Sentinel grid (10 m → 0.01 ha/px).
-                compare = lulc_mod.pred_vs_ref_composition(classification_map, ref_grid)
+                # Overlay comparison on Sentinel grid (10 m -> 0.01 ha/px).
+                # The reference was resampled from 30 m, so the pixel count is
+                # not the number of label observations; carry the native cell
+                # count alongside it as the sample size.
+                cell_ids = lulc_mod.reference_cell_grid(ref_profile, mapbiomas_path)
+                compare = lulc_mod.pred_vs_ref_composition(
+                    classification_map, ref_grid, cell_ids=cell_ids
+                )
                 lulc_payload['pred_vs_ref'] = compare
+                valid = (classification_map >= 0) & (ref_grid > 0)
+                lulc_payload['compare_pixels'] = int(valid.sum())
+                n_cells = lulc_mod.distinct_reference_cells(cell_ids, valid)
+                if n_cells is not None:
+                    lulc_payload['compare_reference_cells'] = n_cells
         except Exception as e:
             sys.stderr.write(json.dumps({
                 'progress': -1, 'msg': f'lulc analysis skipped: {e}'

--- a/sidecar/lulc.py
+++ b/sidecar/lulc.py
@@ -290,21 +290,105 @@ def write_lulc_png(arr: np.ndarray, out_path: Path) -> None:
             dst.write(rgba[:, :, i], i + 1)
 
 
-def pred_vs_ref_composition(pred_map: np.ndarray, ref_map: np.ndarray) -> list[dict]:
-    """Compare predicted vs MapBiomas composition on overlapping valid pixels."""
+def reference_cell_grid(
+    ref_profile: dict,
+    mapbiomas_path: str,
+) -> np.ndarray | None:
+    """
+    Flat index of the native MapBiomas cell each reference-grid pixel came from.
+
+    MapBiomas Collection rasters are native at 30 m. When one is reprojected onto
+    the 10 m classification grid, roughly nine destination pixels are filled from
+    a single source cell and therefore carry one label observation between them.
+    Areas stay correct because area is area, but a count of those pixels is not a
+    sample size: it counts each observation about nine times.
+
+    Returns an array shaped like the reference grid, where pixels sharing a value
+    were resampled from the same native cell. Adapted from
+    mestrado/experiments/class41_decomposition/build_wide_aoi.py.
+
+    Returns None when the MapBiomas raster cannot be opened, so callers keep
+    reporting pixel counts rather than an incorrect sample size.
+    """
+    from rasterio.transform import rowcol as rio_rowcol, xy as rio_xy
+
+    try:
+        with rasterio.open(mapbiomas_path) as src:
+            mb_transform = src.transform
+            mb_crs = src.crs
+            mb_width = int(src.width)
+    except Exception:
+        return None
+
+    height = int(ref_profile["height"])
+    width = int(ref_profile["width"])
+    rows, cols = np.meshgrid(
+        np.arange(height, dtype=np.int64),
+        np.arange(width, dtype=np.int64),
+        indexing="ij",
+    )
+    xs, ys = rio_xy(
+        ref_profile["transform"], rows.ravel(), cols.ravel(), offset="center"
+    )
+    tf = Transformer.from_crs(ref_profile["crs"], mb_crs, always_xy=True)
+    lon, lat = tf.transform(np.asarray(xs), np.asarray(ys))
+    mb_rows, mb_cols = rio_rowcol(mb_transform, lon, lat)
+    ids = np.asarray(mb_rows, dtype=np.int64) * mb_width + np.asarray(
+        mb_cols, dtype=np.int64
+    )
+    return ids.reshape(height, width)
+
+
+def distinct_reference_cells(
+    cell_ids: np.ndarray | None, mask: np.ndarray
+) -> int | None:
+    """
+    Number of distinct native reference cells covered by a boolean mask.
+
+    None when the cell mapping is unavailable, which callers report as an absent
+    sample size rather than substituting the pixel count.
+    """
+    if cell_ids is None:
+        return None
+    if not mask.any():
+        return 0
+    return int(np.unique(cell_ids[mask]).size)
+
+
+def pred_vs_ref_composition(
+    pred_map: np.ndarray,
+    ref_map: np.ndarray,
+    cell_ids: np.ndarray | None = None,
+) -> list[dict]:
+    """
+    Compare predicted vs MapBiomas composition on overlapping valid pixels.
+
+    Percentages are pixel fractions and are unaffected by resampling. The counts
+    reported alongside them are not interchangeable: `pixels_ref` counts 10 m
+    pixels, while `n_reference_cells` counts the distinct 30 m MapBiomas cells
+    those pixels were resampled from, which is the number of independent label
+    observations and therefore the denominator an agreement statistic needs.
+    """
     valid = (pred_map >= 0) & (ref_map > 0)
     n_tot = int(valid.sum())
     rows = []
     for cid in TARGET_COMPARE:
-        n_pred = int(((pred_map == cid) & valid).sum())
-        n_ref = int(((ref_map == cid) & valid).sum())
-        rows.append({
+        pred_mask = (pred_map == cid) & valid
+        ref_mask = (ref_map == cid) & valid
+        n_pred = int(pred_mask.sum())
+        n_ref = int(ref_mask.sum())
+        row = {
             "class_id": cid,
             "name": MAPBIOMAS_LEGEND.get(cid, f"Class {cid}"),
             "color": MAPBIOMAS_COLORS.get(cid, "#bbbbbb"),
             "pct_ref": float(round(100.0 * n_ref / n_tot, 2)) if n_tot else 0.0,
             "pct_pred": float(round(100.0 * n_pred / n_tot, 2)) if n_tot else 0.0,
-        })
+            "pixels_ref": n_ref,
+        }
+        cells = distinct_reference_cells(cell_ids, ref_mask)
+        if cells is not None:
+            row["n_reference_cells"] = cells
+        rows.append(row)
     return rows
 
 
@@ -315,6 +399,7 @@ def analyze_mapbiomas(
     pred_map: np.ndarray | None = None,
     ref_on_pred_grid: np.ndarray | None = None,
     px_ha_override: float | None = None,
+    cell_ids: np.ndarray | None = None,
 ) -> dict:
     """
     Build a full LULC analysis payload.
@@ -322,6 +407,10 @@ def analyze_mapbiomas(
     Prefer clipping the native MapBiomas raster to the polygon. When
     `ref_on_pred_grid` is provided (already reprojected to the Sentinel grid),
     composition uses that grid with `px_ha_override` (typically 0.01 ha @ 10 m).
+
+    `cell_ids` accompanies `ref_on_pred_grid`: on that grid the reference has
+    been resampled from 30 m, so pixel counts are not sample sizes. See
+    reference_cell_grid.
     """
     from rasterio.transform import array_bounds as rio_array_bounds
 
@@ -348,7 +437,9 @@ def analyze_mapbiomas(
 
     pred_vs_ref = []
     if pred_map is not None and ref_on_pred_grid is not None:
-        pred_vs_ref = pred_vs_ref_composition(pred_map, ref_on_pred_grid)
+        pred_vs_ref = pred_vs_ref_composition(
+            pred_map, ref_on_pred_grid, cell_ids=cell_ids
+        )
 
     # Prefer georeferenced raster bounds for map overlay; fall back to polygon.
     if transform is not None:

--- a/sidecar/tests/test_lulc.py
+++ b/sidecar/tests/test_lulc.py
@@ -66,3 +66,99 @@ def test_groups_from_composition():
     groups = lulc.groups_from_composition(composition)
     assert len(groups) == 2
     assert abs(sum(g["pct"] for g in groups) - 100.0) < 0.01
+
+
+def _write_reference_raster(path, *, res_deg, width, height, origin=(-53.6, -25.0)):
+    """Small georeferenced raster standing in for a MapBiomas Collection tile."""
+    import rasterio
+    from rasterio.transform import from_origin
+
+    transform = from_origin(origin[0], origin[1], res_deg, res_deg)
+    data = np.arange(width * height, dtype=np.uint8).reshape(height, width) % 250 + 1
+    profile = {
+        "driver": "GTiff",
+        "height": height,
+        "width": width,
+        "count": 1,
+        "dtype": "uint8",
+        "crs": "EPSG:4326",
+        "transform": transform,
+    }
+    with rasterio.open(path, "w", **profile) as dst:
+        dst.write(data, 1)
+    return transform
+
+
+def test_reference_cell_grid_groups_pixels_by_native_cell(tmp_path):
+    """
+    A 30 m reference resampled onto a 10 m grid gives about nine pixels per
+    native cell, so the distinct-cell count must be about one ninth of the
+    pixel count rather than equal to it.
+    """
+    from rasterio.transform import from_origin
+
+    mb_path = tmp_path / "reference.tif"
+    # 3x coarser than the target grid, in the same CRS, sharing an origin.
+    coarse_res = 0.0003
+    _write_reference_raster(mb_path, res_deg=coarse_res, width=8, height=8)
+
+    fine_res = coarse_res / 3.0
+    ref_profile = {
+        "height": 9,
+        "width": 9,
+        "crs": "EPSG:4326",
+        "transform": from_origin(-53.6, -25.0, fine_res, fine_res),
+    }
+
+    cell_ids = lulc.reference_cell_grid(ref_profile, str(mb_path))
+    assert cell_ids is not None
+    assert cell_ids.shape == (9, 9)
+
+    all_pixels = np.ones((9, 9), dtype=bool)
+    n_cells = lulc.distinct_reference_cells(cell_ids, all_pixels)
+    # 81 fine pixels fall inside a 3x3 block of native cells.
+    assert n_cells == 9
+    assert n_cells < int(all_pixels.sum())
+
+
+def test_distinct_reference_cells_edge_cases():
+    cell_ids = np.array([[1, 1], [2, 2]], dtype=np.int64)
+    assert lulc.distinct_reference_cells(cell_ids, np.ones((2, 2), bool)) == 2
+    assert lulc.distinct_reference_cells(cell_ids, np.zeros((2, 2), bool)) == 0
+    # Without a mapping the count is absent, never substituted by the pixel count.
+    assert lulc.distinct_reference_cells(None, np.ones((2, 2), bool)) is None
+
+
+def test_reference_cell_grid_missing_raster_returns_none(tmp_path):
+    ref_profile = {
+        "height": 2,
+        "width": 2,
+        "crs": "EPSG:4326",
+        "transform": __import__("rasterio").transform.from_origin(0, 0, 1, 1),
+    }
+    assert lulc.reference_cell_grid(ref_profile, str(tmp_path / "absent.tif")) is None
+
+
+def test_pred_vs_ref_reports_cells_and_pixels_separately():
+    pred = np.array([[39, 39, 39], [39, 39, 39], [3, 3, 3]], dtype=np.int32)
+    ref = np.array([[39, 39, 39], [39, 39, 39], [3, 3, 3]], dtype=np.int32)
+    # Each row of three pixels came from one native cell.
+    cell_ids = np.array([[10, 10, 10], [10, 10, 10], [20, 20, 20]], dtype=np.int64)
+
+    rows = lulc.pred_vs_ref_composition(pred, ref, cell_ids=cell_ids)
+    by_id = {r["class_id"]: r for r in rows}
+
+    assert by_id[39]["pixels_ref"] == 6
+    assert by_id[39]["n_reference_cells"] == 1
+    assert by_id[3]["pixels_ref"] == 3
+    assert by_id[3]["n_reference_cells"] == 1
+    # Percentages are pixel fractions and are unchanged by the cell accounting.
+    assert abs(by_id[39]["pct_ref"] - 66.67) < 0.01
+
+
+def test_pred_vs_ref_without_cell_ids_omits_the_field():
+    pred = np.array([[39, 3]], dtype=np.int32)
+    ref = np.array([[39, 3]], dtype=np.int32)
+    rows = lulc.pred_vs_ref_composition(pred, ref)
+    assert all("n_reference_cells" not in r for r in rows)
+    assert all("pixels_ref" in r for r in rows)

--- a/sidecar/tests/test_water.py
+++ b/sidecar/tests/test_water.py
@@ -1,0 +1,192 @@
+"""Unit tests for the surface water / flood mapping helpers (offline)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+import water
+
+
+def test_index_formulas_match_the_published_definitions():
+    green = np.array([[0.20]], dtype=np.float32)
+    nir = np.array([[0.10]], dtype=np.float32)
+    swir1 = np.array([[0.05]], dtype=np.float32)
+    swir2 = np.array([[0.04]], dtype=np.float32)
+
+    out = water.compute_water_indices(green, nir, swir1, swir2)
+
+    # McFeeters (1996)
+    assert abs(out["NDWI"][0, 0] - (0.20 - 0.10) / (0.20 + 0.10)) < 1e-6
+    # Xu (2006)
+    assert abs(out["MNDWI"][0, 0] - (0.20 - 0.05) / (0.20 + 0.05)) < 1e-6
+    # Feyisa et al. (2014), non-shadow variant
+    expected_awei = 4.0 * (0.20 - 0.05) - (0.25 * 0.10 + 2.75 * 0.04)
+    assert abs(out["AWEI"][0, 0] - expected_awei) < 1e-6
+
+
+def test_indices_are_not_clipped():
+    """AWEI is unbounded; clipping to [-1, 1] would silently distort it."""
+    green = np.array([[0.9]], dtype=np.float32)
+    nir = np.array([[0.0]], dtype=np.float32)
+    swir1 = np.array([[0.0]], dtype=np.float32)
+    swir2 = np.array([[0.0]], dtype=np.float32)
+    out = water.compute_water_indices(green, nir, swir1, swir2)
+    assert out["AWEI"][0, 0] > 1.0
+
+
+def test_no_data_pixels_are_not_reported_as_water():
+    """
+    The regression this module exists to avoid.
+
+    A pixel with no observation has every band at zero, so each ratio index
+    evaluates to exactly (0 - 0) / (0 + 0 + eps) = 0.0 and passes the fixed
+    threshold of `index >= 0`. Counting it as water measures missing data. The
+    per-date validity mask is what keeps it out.
+    """
+    green = np.array([[0.0, 0.20]], dtype=np.float32)
+    swir1 = np.array([[0.0, 0.05]], dtype=np.float32)
+    nir = np.zeros((1, 2), dtype=np.float32)
+    swir2 = np.zeros((1, 2), dtype=np.float32)
+    aoi = np.ones((1, 2), dtype=bool)
+
+    frame = water.compute_water_indices(green, nir, swir1, swir2)["MNDWI"]
+    # Left pixel is no-data yet its index is exactly at the threshold.
+    assert frame[0, 0] == 0.0
+
+    date_valid = water.per_date_valid_mask(
+        aoi, {"B03": green, "B11": swir1}, "MNDWI"
+    )
+    assert not date_valid[0, 0]
+    assert date_valid[0, 1]
+
+    mask = water.water_mask_for_date(frame, date_valid, water.DEFAULT_THRESHOLD)
+    assert not mask[0, 0], "no-data pixel must never be counted as water"
+
+
+def test_per_date_valid_mask_uses_only_the_bands_the_index_needs():
+    aoi = np.ones((1, 1), dtype=bool)
+    bands = {
+        "B03": np.array([[0.2]], dtype=np.float32),
+        "B11": np.array([[0.1]], dtype=np.float32),
+        "B8A": np.zeros((1, 1), dtype=np.float32),
+        "B12": np.zeros((1, 1), dtype=np.float32),
+    }
+    # MNDWI does not read NIR, so a zero NIR must not invalidate the pixel.
+    assert water.per_date_valid_mask(aoi, bands, "MNDWI")[0, 0]
+    # NDWI does read NIR.
+    assert not water.per_date_valid_mask(aoi, bands, "NDWI")[0, 0]
+    # AWEI reads all four.
+    assert not water.per_date_valid_mask(aoi, bands, "AWEI")[0, 0]
+
+
+def test_otsu_separates_a_bimodal_distribution():
+    values = np.concatenate([
+        np.full(500, -0.5, dtype=np.float32),
+        np.full(500, 0.5, dtype=np.float32),
+    ])
+    thr = water.otsu_threshold(values)
+    assert -0.5 < thr < 0.5
+
+
+def test_otsu_reports_degenerate_input_rather_than_guessing():
+    thr, clipped, degenerate = water.otsu_threshold_for_date(
+        np.array([0.1, 0.2], dtype=np.float32)
+    )
+    assert degenerate
+    assert thr == 0.0
+    assert not clipped
+
+
+def test_otsu_clip_is_flagged_when_it_binds():
+    """
+    The lower bound binds on most dates of the reference properties, so a
+    saturated value must be distinguishable from an estimated one.
+    """
+    values = np.concatenate([
+        np.full(500, -0.95, dtype=np.float32),
+        np.full(500, -0.85, dtype=np.float32),
+    ])
+    thr, clipped, degenerate = water.otsu_threshold_for_date(values)
+    assert not degenerate
+    assert clipped
+    assert thr == water.OTSU_CLIP_LOW
+
+
+def test_water_fraction_is_a_percentage_of_observed_pixels():
+    mask = np.array([[True, False, False, False]])
+    observed = np.array([[True, True, True, True]])
+    assert water.water_fraction_pct(mask, observed) == 25.0
+    # No observation at all yields zero rather than a division error.
+    assert water.water_fraction_pct(mask, np.zeros((1, 4), bool)) == 0.0
+
+
+def test_occurrence_divides_by_dates_the_pixel_was_observed_on():
+    """
+    A pixel seen twice and wet once is at 0.5, even when other dates exist that
+    it was absent from. Dividing by the total date count would conflate being
+    dry with not being seen.
+    """
+    masks = [
+        np.array([[True, False]]),
+        np.array([[False, False]]),
+        np.array([[False, False]]),
+    ]
+    observed = [
+        np.array([[True, True]]),
+        np.array([[True, True]]),
+        np.array([[False, True]]),  # first pixel not observed on the last date
+    ]
+    occ = water.occurrence_map(masks, observed)
+    assert abs(occ[0, 0] - 0.5) < 1e-9
+    assert occ[0, 1] == 0.0
+
+
+def test_occurrence_is_nan_where_never_observed():
+    masks = [np.array([[False]])]
+    observed = [np.array([[False]])]
+    occ = water.occurrence_map(masks, observed)
+    assert np.isnan(occ[0, 0])
+
+
+def test_classify_occurrence_bands():
+    occ = np.array([[0.0, 0.3, 0.9, np.nan]])
+    out = water.classify_occurrence(occ)
+    assert out["rarely_or_never"][0, 0]
+    assert out["ephemeral"][0, 1]
+    assert out["persistent"][0, 2]
+    # An unobserved pixel belongs to no band.
+    assert not any(out[k][0, 3] for k in out)
+
+
+def test_anomaly_ignores_unobserved_dates():
+    cube = np.array([
+        [[0.1]],
+        [[0.4]],
+        [[0.0]],  # unobserved; a raw median would be dragged toward zero
+    ], dtype=np.float32)
+    observed = np.array([[[True]], [[True]], [[False]]])
+    delta = water.max_minus_median_index(cube, observed)
+    # Median over the two observed dates is 0.25, max is 0.4.
+    assert abs(delta[0, 0] - (0.4 - 0.25)) < 1e-6
+
+
+def test_anomaly_needs_two_observations():
+    cube = np.array([[[0.1]], [[0.4]]], dtype=np.float32)
+    observed = np.array([[[True]], [[False]]])
+    delta = water.max_minus_median_index(cube, observed)
+    assert np.isnan(delta[0, 0])
+
+
+def test_occurrence_rgba_uses_a_fixed_scale():
+    """
+    Occurrence is an absolute fraction, so a percentile stretch would render an
+    AOI peaking at 0.2 identically to a permanently flooded one.
+    """
+    low = water.occurrence_to_rgba(np.array([[0.0, 0.2]]))
+    high = water.occurrence_to_rgba(np.array([[0.0, 1.0]]))
+    # Same input value, same colour, regardless of the rest of the array.
+    assert tuple(low[0, 0, :3]) == tuple(high[0, 0, :3])
+    # A higher occurrence is a different colour, not the same stretched one.
+    assert tuple(low[0, 1, :3]) != tuple(high[0, 1, :3])
+    # Unobserved pixels are transparent.
+    assert water.occurrence_to_rgba(np.array([[np.nan]]))[0, 0, 3] == 0

--- a/sidecar/water.py
+++ b/sidecar/water.py
@@ -1,0 +1,253 @@
+"""
+Surface water and flood mapping from Sentinel-2 spectral water indices.
+
+Descriptive, with no model and no trained legend: the output is a thresholded
+spectral index, so it carries none of the fixed-legend domain-shift limitation
+that applies to the classifier.
+
+Indices, with the paper each comes from:
+
+    NDWI  = (green - nir)   / (green + nir)                 McFeeters (1996)
+    MNDWI = (green - swir1) / (green + swir1)               Xu (2006)
+    AWEI  = 4(green - swir1) - (0.25 nir + 2.75 swir2)      Feyisa et al. (2014)
+
+AWEI here is the non-shadow variant, AWEI_nsh. Bands are B03 green, B8A narrow
+NIR, B11 swir1 and B12 swir2. B8A rather than B08 is deliberate: the research
+prototype this is ported from built its stack on the Prithvi band set, whose NIR
+slot is B8A (865 nm, 20 m). Using B08 would change NDWI and AWEI and would not
+reproduce the reference series.
+
+Ported from mestrado/flood_mapping_analysis.ipynb. The index algebra, the Otsu
+implementation and the threshold bounds are carried over unchanged. One thing is
+deliberately NOT carried over; see per_date_valid_mask.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+INDEX_NAMES = ("NDWI", "MNDWI", "AWEI")
+
+# The primary threshold, not a failure fallback. Zero is the literature cut for
+# NDWI (McFeeters 1996) and MNDWI (Xu 2006), and Feyisa et al. (2014) propose it
+# for AWEI_nsh as well. AWEI is on a different, unbounded scale.
+DEFAULT_THRESHOLD = 0.0
+
+PRIMARY_INDEX = "MNDWI"
+
+# Empirical guard keeping Otsu from wandering into a degenerate split when the
+# AOI is almost entirely land. No stated derivation in the source. The lower
+# bound binds often -- on the reference properties it saturates on 12 of 22,
+# 9 of 21 and 20 of 20 dates -- so a saturated threshold is flagged rather than
+# presented as an estimate.
+OTSU_CLIP_LOW = -0.2
+OTSU_CLIP_HIGH = 0.4
+
+# Occurrence band treated as ephemeral rather than permanent water.
+EPHEMERAL_OCC_LOW = 0.15
+EPHEMERAL_OCC_HIGH = 0.70
+
+# Bands each index consumes, used both to read rasters and to decide validity.
+INDEX_BANDS = {
+    "NDWI": ("B03", "B8A"),
+    "MNDWI": ("B03", "B11"),
+    "AWEI": ("B03", "B8A", "B11", "B12"),
+}
+
+_EPS = 1e-8
+
+
+def compute_water_indices(green, nir, swir1, swir2) -> dict:
+    """
+    The three indices for one date. Reflectance is expected in [0, 1].
+
+    The epsilon sits inside the denominator, as in the source. Do not substitute
+    a masked division: the value on a fully zero pixel is then exactly 0.0,
+    which the validity mask is responsible for excluding rather than the
+    arithmetic.
+
+    No clipping to [-1, 1]. composite.calculate_ndwi clips and uses a bare
+    denominator, so it is not equivalent and must not be reused here. AWEI is
+    unbounded by construction.
+    """
+    with np.errstate(divide="ignore", invalid="ignore"):
+        ndwi = (green - nir) / (green + nir + _EPS)
+        mndwi = (green - swir1) / (green + swir1 + _EPS)
+        awei = 4.0 * (green - swir1) - (0.25 * nir + 2.75 * swir2)
+    return {
+        "NDWI": np.nan_to_num(ndwi, nan=0.0),
+        "MNDWI": np.nan_to_num(mndwi, nan=0.0),
+        "AWEI": np.nan_to_num(awei, nan=0.0),
+    }
+
+
+def otsu_threshold(values: np.ndarray, nbins: int = 256) -> float:
+    """
+    Between-class-variance threshold (Otsu 1979), carried over unchanged.
+
+    Three details are load-bearing and must not be tidied away: the histogram is
+    binned over the actual data range of the values passed in, so the bin edges
+    move from date to date; the class means use bin centres; and the return value
+    is the midpoint of the winning bin.
+
+    Returns 0.0 for a degenerate input, which callers report as such rather than
+    presenting it as an estimated threshold.
+    """
+    v = values[np.isfinite(values)]
+    if v.size < 50:
+        return 0.0
+    hist, bin_edges = np.histogram(v, bins=nbins)
+    hist = hist.astype(float)
+    if hist.sum() == 0:
+        return 0.0
+    prob = hist / hist.sum()
+    omega = np.cumsum(prob)
+    mu = np.cumsum(prob * (bin_edges[:-1] + bin_edges[1:]) / 2.0)
+    mu_t = mu[-1]
+    sigma_b = (mu_t * omega - mu) ** 2 / (omega * (1.0 - omega) + 1e-12)
+    idx = int(np.nanargmax(sigma_b))
+    return float(0.5 * (bin_edges[idx] + bin_edges[idx + 1]))
+
+
+def otsu_threshold_for_date(values: np.ndarray) -> tuple[float, bool, bool]:
+    """
+    Otsu threshold with the empirical bounds applied.
+
+    Returns (threshold, clipped, degenerate). `clipped` means the bound was
+    reached and the value is a bound rather than an estimate; `degenerate` means
+    the histogram had too few finite samples to threshold at all.
+    """
+    finite = values[np.isfinite(values)]
+    degenerate = finite.size < 50
+    raw = otsu_threshold(values)
+    thr = float(np.clip(raw, OTSU_CLIP_LOW, OTSU_CLIP_HIGH))
+    clipped = (not degenerate) and thr != raw
+    return thr, clipped, degenerate
+
+
+def per_date_valid_mask(aoi_valid: np.ndarray, bands: dict, index: str) -> np.ndarray:
+    """
+    Pixels inside the AOI that were actually observed on this date.
+
+    THIS IS THE ONE DELIBERATE DEPARTURE FROM THE SOURCE. The prototype built a
+    single validity mask as a union over dates, so a pixel missing on one date
+    was still counted on that date. Its bands are then zero, every ratio index
+    evaluates to exactly (0 - 0) / (0 + 0 + eps) = 0.0, and the comparison is
+    `index >= 0.0`, so the pixel is counted as water. On the three reference
+    properties almost every pixel-date the prototype reported as water at the
+    fixed threshold is a no-data pixel rather than water: 906 of 909, 980 of 985
+    and 1171 of 1171.
+
+    Carrying that over would have produced a water product measuring missing
+    observations. Validity is therefore evaluated per date, from the bands the
+    selected index actually consumes.
+    """
+    mask = np.asarray(aoi_valid, dtype=bool)
+    for name in INDEX_BANDS.get(index, INDEX_BANDS[PRIMARY_INDEX]):
+        arr = bands.get(name)
+        if arr is None:
+            continue
+        mask = mask & (arr > 0)
+    return mask
+
+
+def water_mask_for_date(
+    index_frame: np.ndarray, date_valid: np.ndarray, threshold: float
+) -> np.ndarray:
+    """
+    Water is the high tail of the index. The comparison is >=, as in the source.
+
+    Validity is applied on both sides: the caller thresholds only observed
+    pixels, and the result is intersected with them again so an unobserved pixel
+    can never be reported as water.
+    """
+    return date_valid & (index_frame >= threshold)
+
+
+def water_fraction_pct(mask: np.ndarray, denominator: np.ndarray) -> float:
+    """Water as a percentage of the pixels the denominator marks."""
+    n = int(denominator.sum())
+    if n <= 0:
+        return 0.0
+    return float(100.0 * int(mask.sum()) / n)
+
+
+def occurrence_map(masks: list[np.ndarray], observed: list[np.ndarray]) -> np.ndarray:
+    """
+    Fraction of the dates a pixel was observed on which it was water.
+
+    The denominator is per pixel, so a pixel seen on four dates and wet on one
+    reads 0.25 whether or not other pixels were seen more often. The prototype
+    divided by the total number of dates, which mixes dryness with absence.
+
+    NaN where a pixel was never observed.
+    """
+    if not masks:
+        return np.zeros((0, 0), dtype=float)
+    wet = np.sum(np.stack(masks, axis=0), axis=0).astype(float)
+    seen = np.sum(np.stack(observed, axis=0), axis=0).astype(float)
+    out = np.full(wet.shape, np.nan, dtype=float)
+    np.divide(wet, seen, out=out, where=seen > 0)
+    return out
+
+
+def classify_occurrence(occ: np.ndarray) -> dict:
+    """
+    Split observed pixels into occurrence bands.
+
+    Ephemeral is the flood signal: water on some dates but not most. Above the
+    upper bound the pixel is standing water rather than a flood event.
+    """
+    seen = np.isfinite(occ)
+    o = np.where(seen, occ, -1.0)
+    ephemeral = seen & (o >= EPHEMERAL_OCC_LOW) & (o <= EPHEMERAL_OCC_HIGH)
+    persistent = seen & (o > EPHEMERAL_OCC_HIGH)
+    never = seen & (o < EPHEMERAL_OCC_LOW)
+    return {
+        "ephemeral": ephemeral,
+        "persistent": persistent,
+        "rarely_or_never": never,
+    }
+
+
+def occurrence_to_rgba(occ: np.ndarray) -> np.ndarray:
+    """
+    Colour the occurrence map on a fixed 0 to 1 scale.
+
+    composite.index_to_rgba cannot be reused: it always applies a percentile
+    stretch, which is right for an unbounded index but wrong here. Occurrence is
+    an absolute fraction, so a stretch would render an AOI peaking at 0.2 the
+    same as one that is permanently flooded, and any legend beside it would be
+    wrong. Unobserved pixels are transparent.
+    """
+    import composite as comp
+
+    seen = np.isfinite(occ)
+    t = np.clip(np.nan_to_num(occ, nan=0.0), 0.0, 1.0).astype(np.float32)
+    rgb = comp._lerp_cmap(t, comp._BLUES)
+    h, w = occ.shape
+    rgba = np.zeros((h, w, 4), dtype=np.uint8)
+    rgba[..., 0] = (rgb[..., 0] * 255).astype(np.uint8)
+    rgba[..., 1] = (rgb[..., 1] * 255).astype(np.uint8)
+    rgba[..., 2] = (rgb[..., 2] * 255).astype(np.uint8)
+    rgba[..., 3] = np.where(seen, 255, 0).astype(np.uint8)
+    return rgba
+
+
+def max_minus_median_index(
+    index_cube: np.ndarray, observed_cube: np.ndarray
+) -> np.ndarray:
+    """
+    Per-pixel anomaly: the wettest observation minus the typical one.
+
+    Computed only over dates the pixel was observed on, so an absent date cannot
+    pull the median down and manufacture an anomaly. NaN where a pixel has fewer
+    than two observations.
+    """
+    masked = np.where(observed_cube, index_cube, np.nan)
+    counts = observed_cube.sum(axis=0)
+    with np.errstate(invalid="ignore", all="ignore"):
+        med = np.nanmedian(masked, axis=0)
+        mx = np.nanmax(masked, axis=0)
+        delta = mx - med
+    return np.where(counts >= 2, delta, np.nan)


### PR DESCRIPTION
Implements items 1 and 3 of `docs/TIER1_HANDOFF.md`, plus the map-state fixes found while testing them. Item 2 (change detection) is not included.

## Item 1 — Surface water and flood mapping

New `sidecar/water.py`, an `action=water` branch, a Runner method, a Wails binding, a **Surface water** panel in the left dock, an occurrence overlay, a summary in the shared status bar, controls in Overlay Tools, a section in the analysis view, `water_series.csv` in the research pack, and persistence as a saved run.

Indices: NDWI (McFeeters 1996), MNDWI (Xu 2006), AWEI_nsh (Feyisa et al. 2014), thresholded at zero — the literature cut for all three. Ported from `mestrado/flood_mapping_analysis.ipynb`.

### Three deliberate departures from the reference implementation

**1. Per-date validity instead of a union over dates.** The prototype built one validity mask as a union, so a pixel missing on a given date was still counted on that date. Its bands are then zero, every ratio index evaluates to exactly `(0-0)/(0+0+eps) = 0.0`, and the test is `index >= 0` — so the pixel is reported as water.

On the three reference properties, almost every pixel-date the prototype called water at the fixed threshold is a no-data pixel rather than water: **906 of 909, 980 of 985, and 1171 of 1171.** Carried over unchanged this would have shipped a water product that measures missing observations. A test pins the regression.

**2. Occurrence divides by the dates a pixel was observed on**, not by the total date count, so being dry is not conflated with not being seen.

**3. The anomaly uses only observed dates**, so a missing date cannot pull the median down and manufacture a flood signal.

### Two corrections to the handoff document

- It names **B08** as the NIR band. The reference stack is built on the Prithvi band set, whose NIR slot is **B8A** at 20 m. B08 would change NDWI and AWEI and would not reproduce the reference series.
- Otsu is carried over verbatim but **reported rather than applied**: its empirical `[-0.2, 0.4]` bounds bind on most dates of the reference properties, and on one of the three every date saturates, so the curve carries no information there. Dates where the bound binds are flagged and the UI states how many.

Rendering does not reuse `composite.index_to_rgba`: it always applies a percentile stretch, which is right for an unbounded index but wrong for occurrence, an absolute fraction. An AOI peaking at 0.2 would otherwise render identically to a permanently flooded one.

No new dependency: PNGs go through `composite.write_rgba_png` over rasterio.

## Item 3 — MapBiomas comparison sample size

MapBiomas rasters are native at 30 m and are resampled onto the 10 m classification grid, so roughly nine pixels carry one label observation. The pred-vs-ref comparison counted those as nine independent observations: a 100 ha AOI reported on the order of 10 000 reference observations where it has approximately 1 100.

The comparison now carries both figures and labels which is which — `pixels_ref` / `compare_pixels` for the 10 m count, `n_reference_cells` / `compare_reference_cells` for the distinct native cells an agreement statistic must use. Percentages are unchanged: they are pixel fractions and resampling does not bias them.

**Scope correction:** the handoff points at `ClassStat` and `class_stats.csv`, but those carry the prediction, which is native at 10 m and has no reference cell behind it. The composition was already correct — it comes from the native 30 m clip. The inflation existed only in `pred_vs_ref`.

## Map state fixes found while testing

- Startup no longer paints a restored AOI and composition over the map, and reopens at the **last map position** instead of the continental default.
- Overlays that no longer describe the AOI on screen are dropped. A water raster measured over one field could otherwise sit over another after opening a saved composition, which activates its project and moves the AOI.
- The occurrence overlay was mounted and then clipped away: `swipeRatio` is the swipe line position, so `1` produced `inset(0 0 0 <full width>px)`.

## Testing

- `tsc --noEmit` clean; `npm run build` and `wails build` succeed
- `go build`, `go vet`, `go test ./backend/...` pass
- `pytest sidecar/tests -q` — 44 passed, 14 of them new for the water module
- Column parity between `analysisTables.ts` and `export_research.go` checked mechanically: **10 tables, 0 divergences**. This caught a real drift introduced mid-branch, where two columns were added to `lulc_pred_vs_ref.csv` on the Go side only.
- Area helpers verified against a spherical-excess reference on the bundled AOIs (error 0.0001 ha), including multi-part geometries and interior rings

## Checklist

- [x] Tests added/updated — 14 new sidecar tests for the water module; no frontend test suite exists in this repo
- [x] Documentation updated — rationale recorded in code comments and commit messages
- [x] No console errors/warnings
- [x] Code follows project standards

## Known limitation

The water result has not been validated against `mestrado/output/flood_mapping_water_fraction_series.csv`, because the corrected validity handling means it should **not** reproduce those numbers — the reference series is dominated by no-data pixels counted as water. Acceptance against that file needs the reference recomputed with per-date validity first.