### PR TITLE
fix(map): do not restore the previous AOI and composition at startup

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -486,6 +486,61 @@ function AppBody(props: {
     [savePrefs]
   )
 
+  /**
+   * Remember where the map was left, so the next session resumes there.
+   *
+   * The map emits on every pan and zoom frame, so this is debounced and only
+   * writes once the view has settled. Failures are ignored: this is a
+   * convenience, and losing it must never interrupt work.
+   */
+  const viewSaveTimer = useRef<number | undefined>(undefined)
+  /**
+   * Live map position, so returning to the map screen resumes exactly where it
+   * was left rather than at whatever the debounced write last committed.
+   */
+  const liveViewRef = useRef<{ lat: number; lon: number; zoom: number } | null>(
+    null
+  )
+  const persistMapView = useCallback(
+    (v: { lat: number; lon: number; zoom: number }) => {
+      if (viewSaveTimer.current) window.clearTimeout(viewSaveTimer.current)
+      viewSaveTimer.current = window.setTimeout(() => {
+        const current = prefsRef.current
+        if (!current) return
+        const extras = parsePreferenceExtras(current.extras_json)
+        const last = extras.map_view
+        // Skip a write when nothing meaningful moved.
+        if (
+          last &&
+          Math.abs(last.lat - v.lat) < 1e-4 &&
+          Math.abs(last.lon - v.lon) < 1e-4 &&
+          last.zoom === v.zoom
+        ) {
+          return
+        }
+        extras.map_view = {
+          lat: Number(v.lat.toFixed(5)),
+          lon: Number(v.lon.toFixed(5)),
+          zoom: v.zoom,
+        }
+        void savePrefs(
+          { ...current, extras_json: JSON.stringify(extras) },
+          { silent: true }
+        ).catch(() => {
+          /* best-effort */
+        })
+      }, 1200)
+    },
+    [savePrefs]
+  )
+
+  useEffect(
+    () => () => {
+      if (viewSaveTimer.current) window.clearTimeout(viewSaveTimer.current)
+    },
+    []
+  )
+
   const persistActiveProjectId = useCallback(
     async (id: string | null) => {
       setActiveProjectId(id)
@@ -1218,6 +1273,11 @@ function AppBody(props: {
                 transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
               >
                 <MapScreen
+                  initialView={
+                    liveViewRef.current ??
+                    parsePreferenceExtras(prefs?.extras_json).map_view ??
+                    null
+                  }
                   areas={props.areas}
                   activeExample={props.activeExample}
                   customPolygon={props.customPolygon}
@@ -1266,7 +1326,11 @@ function AppBody(props: {
                   composeStretchLow={composeStretchLow}
                   composeStretchHigh={composeStretchHigh}
                   composeOpacity={composeOpacity}
-                  onViewChange={props.setView}
+                  onViewChange={(v) => {
+                    liveViewRef.current = v
+                    props.setView(v)
+                    persistMapView(v)
+                  }}
                   onPolygonDrawn={(geom) => {
                     props.setCustomPolygon(geom)
                     if (geom) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -594,7 +594,15 @@ function AppBody(props: {
   )
 
   const activateProject = useCallback(
-    async (id: string | null) => {
+    async (
+      id: string | null,
+      opts?: { userInitiated?: boolean }
+    ) => {
+      // Opening a project is an explicit action and draws its AOI and most
+      // recent composition on the map. Restoring one at startup is not, and
+      // must not: a session that begins with an AOI outline and an overlay the
+      // user did not ask for in that session leaves them clearing both by hand.
+      const userInitiated = opts?.userInitiated ?? true
       await persistActiveProjectId(id)
       if (!id) {
         setComposition(null)
@@ -608,13 +616,13 @@ function AppBody(props: {
           p.label?.trim() ||
           parsePreferenceExtras(prefs?.extras_json).aoi_label?.trim() ||
           ""
-        if (p.area_id) {
+        if (userInitiated && p.area_id) {
           props.setActiveExample(p.area_id)
           props.setCustomPolygon(null)
           const label = savedLabel || p.name
           props.setAnalysisLabel(label)
           void persistAoiLabel(label)
-        } else if (p.polygon_geojson) {
+        } else if (userInitiated && p.polygon_geojson) {
           const aoi = parseRunPolygon(p.polygon_geojson, props.areas)
           props.setActiveExample(aoi.exampleId)
           props.setCustomPolygon(aoi.polygon)
@@ -636,9 +644,11 @@ function AppBody(props: {
         const gallery = overlays
           .map(projectOverlayToComposition)
           .filter((x): x is CompositionOverlay => !!x)
+        // The gallery is always loaded so the compositions stay one click away
+        // in Overlay Tools; only the display is conditional.
         setCompositionGallery(gallery)
-        setComposition(gallery[0] ?? null)
-        setShowCompositionOverlay(!!gallery[0])
+        setComposition(userInitiated ? gallery[0] ?? null : null)
+        setShowCompositionOverlay(userInitiated && !!gallery[0])
       } catch (e) {
         notifyError("Could not open project", e)
       }
@@ -662,7 +672,7 @@ function AppBody(props: {
     if (!id) return
     if (!projects.some((p) => p.id === id)) return
     didRestoreProjectRef.current = true
-    void activateProject(id)
+    void activateProject(id, { userInitiated: false })
   }, [prefs?.extras_json, projects, activateProject])
 
   const handleCreateProjectFromMap = useCallback(async () => {

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -33,6 +33,12 @@ import {
 } from "@/components/AoiContextMenu"
 
 interface MapViewProps {
+  /**
+   * Where the map was left last session. Read once on mount: Leaflet treats
+   * center and zoom as initial values, and rebinding them would fight the
+   * user's own panning.
+   */
+  initialView?: { lat: number; lon: number; zoom: number } | null
   areas: Area[]
   activeExample: string
   customPolygon: GeoJSONGeometry | null
@@ -952,6 +958,7 @@ function AoiEdgeLabel({
 }
 
 export function MapView({
+  initialView = null,
   areas,
   activeExample,
   customPolygon,
@@ -976,7 +983,19 @@ export function MapView({
   onClearArea,
   onViewChange,
 }: MapViewProps) {
-  const center = useMemo<[number, number]>(() => [-14.5, -52], [])
+  // Continental default, used only when there is no remembered view.
+  const center = useMemo<[number, number]>(
+    () =>
+      initialView ? [initialView.lat, initialView.lon] : [-14.5, -52],
+    // Mount-time only: see initialView.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
+  const initialZoom = useMemo(
+    () => initialView?.zoom ?? 4,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
   const containerRef = useRef<HTMLDivElement | null>(null)
   const [swipeDragging, setSwipeDragging] = useState(false)
   const [aoiMenu, setAoiMenu] = useState<AoiContextMenuState | null>(null)
@@ -1124,7 +1143,12 @@ export function MapView({
   return (
     // z-0 keeps swipe chrome inside this stacking context, under Result/Control panels
     <div ref={containerRef} className="absolute inset-0 z-0">
-    <MapContainer center={center} zoom={4} className="h-full w-full" zoomControl={false}>
+    <MapContainer
+      center={center}
+      zoom={initialZoom}
+      className="h-full w-full"
+      zoomControl={false}
+    >
       <ZoomControl position="bottomright" />
       <LayersControl position="topright">
         <LayersControl.BaseLayer checked name="Satellite (Esri)">

--- a/frontend/src/lib/preferenceExtras.ts
+++ b/frontend/src/lib/preferenceExtras.ts
@@ -9,6 +9,11 @@ export interface PreferenceExtras {
   aoi_label?: string
   /** Last product version for which What’s New was shown (or silently seeded). */
   last_seen_version?: string
+  /**
+   * Where the map was left. Restored on start so a session resumes at the last
+   * place worked on rather than at the continental default.
+   */
+  map_view?: { lat: number; lon: number; zoom: number }
 }
 
 export function parsePreferenceExtras(

--- a/frontend/src/pages/MapScreen.tsx
+++ b/frontend/src/pages/MapScreen.tsx
@@ -28,6 +28,8 @@ import {
 } from "@/components/OverlayToolsPanel"
 
 export interface MapScreenProps {
+  /** Where the map was left last session; null starts at the default view. */
+  initialView?: { lat: number; lon: number; zoom: number } | null
   areas: Area[]
   activeExample: string
   customPolygon: GeoJSONGeometry | null
@@ -142,6 +144,7 @@ export function MapScreen(props: MapScreenProps) {
   return (
     <div className="relative h-full min-h-0 w-full">
       <MapView
+        initialView={props.initialView}
         areas={props.areas}
         activeExample={props.activeExample}
         customPolygon={props.customPolygon}


### PR DESCRIPTION
Independent of #29, #30 and #31 — this one goes straight against `main`.

Two commits:

- **Do not restore the AOI and composition onto the map at startup.** A
  composition drawn in a previous session reappeared over a fresh map, which
  reads as a result of the current session rather than as a leftover.
- **Reopen at the last map position** instead of the continental view, so a
  user returns to where they were working rather than to Brazil.

The two belong together: the first stops restoring the *overlay*, and without
the second the application would then always open somewhere the user was not.