### PR TITLE
Accuracy assessment, prose removal, and the solar diffuse terms

### DIFF
--- a/.temp/HANDOFF.md
+++ b/.temp/HANDOFF.md
@@ -1,0 +1,353 @@
+# Handoff — sessão de 9–10/08/2026
+
+Contexto para retomar em outra conversa. Escrito para ser lido de cima para
+baixo por quem não acompanhou a sessão.
+
+**Repositórios envolvidos**
+
+| Caminho | O que é |
+|---|---|
+| `~/estudos/UTFPr/TERRA-Simulation` | os estudos numéricos (este repo) |
+| `~/estudos/UTFPr/geosense/geosense-infer` | a aplicação TERRA (Go + Wails + sidecar Python) |
+
+---
+
+## 1. O estado em uma tela
+
+Trabalhamos em três frentes que convergiram:
+
+1. **Linha de pesquisa** para o mestrado/doutorado — documento com 7 propostas
+2. **Experimentos numéricos** sobre uma AOI real exportada do TERRA
+3. **Auditoria** das features solares do TERRA em produção
+
+O fio condutor: a AOI exportada é um **conjunto habitacional urbano em
+Teresina/PI**, e a pergunta do usuário é se painéis solares ali teriam boa
+efetividade. Isso expôs que a cadeia do TERRA é de **usina em terreno**, não de
+**telhado**, e as duas medem coisas diferentes.
+
+---
+
+## 2. Entregáveis
+
+### Linha de pesquisa — `docs/linha-pesquisa/`
+
+| Arquivo | Conteúdo |
+|---|---|
+| `linha-de-pesquisa.tex` + `.pdf` | 12 páginas, compila limpo. 6 eixos, **7 propostas** com pergunta/hipótese/método/dados/falseamento |
+| `referencias.bib` | 30 referências |
+| `topicos-avancados-solar-ml.md` | 10 camadas técnicas, do material à decisão |
+| `skills-para-cientista.md` | skills de Claude Code para trabalho científico |
+
+**Recomendação registrada:** núcleo em **P2** (cobertura condicional de
+intervalos em regimes de rampa) + **P4** (decompor o ganho da física por
+ablação) + **P3** (previsibilidade e valor do curtailment no SIN), unidas pela
+pergunta *"o que a estrutura conhecida do problema físico oferece a um modelo
+estatístico que os dados sozinhos não oferecem?"*.
+
+**Pendência:** referências de 2025–26 precisam de volume/página/DOI conferidos
+no editor antes de citar. Vários DOIs foram montados a partir de metadados de
+busca.
+
+### Estudo — `studies/E-raster-resource-spatialisation/`
+
+Cinco artefatos sobre a mesma AOI:
+
+| Arquivo | O que responde |
+|---|---|
+| `E-raster.ipynb` | vale encaixado sintético a −25,4° — mede efeito de relevo onde ele existe |
+| `E-raster-real.ipynb` | a AOI como **terreno** — mede o mesmo onde o relevo é suave |
+| `E-rooftop.ipynb` | a AOI como **bairro** — telhado, não chão |
+| `E-3d.ipynb` | modelo 3D em Plotly com ray-casting |
+| `aoi-3d.html` | a mesma análise como página web |
+
+Mais `E5-surrogate-validity-detection/` (detecção de perda de validade de
+substituto).
+
+**Página publicada:** https://claude.ai/code/artifact/9fad5e0f-c7f6-4c93-a1c8-5cdc0c94cdb8
+
+---
+
+## 3. Os números finais da AOI
+
+Conjunto habitacional em Teresina/PI (−4,7734, −42,5749), AOI de 693 × 488 m.
+
+| | Valor |
+|---|---|
+| Edificações na AOI | **519** (mais 495 no entorno, só sombreiam) |
+| Capacidade instalável | **4464 kWp** |
+| Geração | **6881 MWh/ano** |
+| Rendimento | **1541 kWh/kWp** (93,5% do ideal de 1648) |
+| Irradiação | 2143 kWh/m²/ano |
+| Temperatura média | 32 °C |
+| Fração difusa | 0,40 |
+
+**Resposta à pergunta original: sim, o bairro é bom candidato para GD.** A folga
+tem explicação local — a 4,8° do equador a curva de inclinação é quase plana e a
+diferença norte/sul fica em ~3%. O mesmo bairro no Paraná teria dispersão maior.
+
+**A regra "inclinação = latitude" não se aplica aqui:** pediria 5°, abaixo do
+mínimo construtivo de ~10° para escoamento de água.
+
+### Procedência dos dados
+
+| Camada | Fonte | Natureza |
+|---|---|---|
+| AOI | export do TERRA (só `aoi.geojson`) | — |
+| Contornos | **Overture Maps** (OSM + Google Open Buildings) | medido |
+| Altura | GHSL ANBH 2018, ~100 m | medido, agregado |
+| Relevo | Copernicus GLO-30 via OpenTopography (doi:10.5069/G9028PQB) | medido |
+| Meteorologia | NASA POWER horário 2023 | medido |
+| Inclinação/forma do telhado | tipologia (2 águas, 20°) | **suposto** |
+| Fração aproveitável | 55% | **suposto** |
+| Sombreamento | ray-casting exato (Rust) | calculado |
+
+---
+
+## 4. Cinco erros encontrados, e o que cada um ensina
+
+Ordenados por quanto custaram.
+
+### 4.1 Cobertura do OpenStreetMap — fator 6×
+
+O OSM registrava **43** edificações no bairro; existem **~520**. As 42 mapeadas
+estavam todas numa faixa de 60 m na borda norte; 87% da AOI estava vazia no dado.
+
+**Como foi detectado:** o usuário mostrou a imagem de satélite (Esri, via TERRA).
+Nada no fluxo acusava — o modelo rodava, os números eram coerentes entre si, as
+verificações internas passavam.
+
+**A assimetria que torna a falha invisível:** a **capacidade** muda por 6×; o
+**rendimento por kWp** não muda (1546 → 1541), porque é propriedade do sítio e
+não da contagem.
+
+**Correção:** `fetch_buildings_overture.py`, via duckdb sobre
+`s3://overturemaps-us-west-2/release/2026-07-22.0/theme=buildings/type=building/*`.
+Das 1037 baixadas, 871 vêm do Google Open Buildings.
+
+**Lição:** para AOI em região com mapeamento colaborativo irregular, confrontar
+a fonte vetorial com imagem de satélite é etapa obrigatória, não conferência.
+
+### 4.2 Sombreamento: telhado ≠ relevo — ~6% em energia
+
+A aproximação de sombreamento descartava vizinhos com `dz <= 0` (mais baixos que
+o ponto). **Correto para relevo** — de onde a rotina veio — e **errado para
+telhado**: no telhado o observador está no topo do obstáculo, e a casa vizinha de
+mesma altura ainda barra o sol rasante.
+
+Medido contra ray-casting exato: erro mediano +2,2 pp, **p95 17,9 pp**,
+superestimação de **+5,7%** em energia. A aproximação julgava 84 de 86 águas sem
+sombra; o ray-casting encontrou sombra real em 53.
+
+Naquele sítio, uma casa de 3,7 m a 8 m bloqueia o sol até 24,8°, e o sol abaixo
+disso carrega ~22% do DNI anual.
+
+**O SVF calculado dava 1,000** — céu totalmente aberto — nas mesmas águas onde
+18% do DNI era barrado.
+
+**Correção:** `build_3d_data.py` passou a usar o ray-caster como motor.
+
+### 4.3 NASA POWER e hora solar local — meu erro, não do TERRA
+
+O produto horário do POWER estampa em **hora solar local** por padrão. Lido como
+UTC, o total anual fica correto mas a energia migra para a manhã, e telhados a
+leste rendem ~2× os de oeste.
+
+**O TERRA já trata isso corretamente** — passa `time-standard=UTC` na URL.
+Verificado:
+
+```
+time-standard=UTC : corr(GHI, cos z) = 0.967   ← o TERRA
+time-standard=LST : corr(GHI, cos z) = 0.550   ← o que eu fiz (omiti)
+```
+
+E o TERRA ainda trata o offset de meia hora (`HOUR_LABEL_OFFSET_MIN`), porque o
+POWER rotula o fluxo médio pela hora inicial.
+
+### 4.4 Janela de referência engolindo o evento (E5)
+
+No experimento de detecção, a degradação começava antes do fim da janela que
+calibra o limiar — o detector era proibido de disparar antes de o erro estourar.
+Corrigido com `DEGRADATION_START_YEARS` e verificação executável.
+
+### 4.5 Assimetria leste/oeste do modelo de Erbs — **em aberto**
+
+O rendimento por água dá **leste 1765 vs oeste 1293 kWh/kWp** (36% de diferença).
+Investigado:
+
+- **GHI** manhã 16% maior que a tarde — **real** (convecção vespertina no Piauí)
+- **DNI decomposto** manhã 153% maior — **artefato do Erbs**
+
+`kt` de 0,71 pela manhã contra 0,44 à tarde vira fração direta de 0,76 contra
+~0,45, porque a relação de Erbs é fortemente não-linear. Erbs é ajustado para
+médias, não para o ciclo diurno de sítio convectivo.
+
+**O que isso invalida:** só a comparação **por água isolada**. A média das duas
+águas de uma casa continua correta (leste+oeste = 1529, norte+sul = 1566, batem),
+e o agregado do bairro também.
+
+**Correção pendente:** testar DIRINT/DISC em vez de Erbs, ou usar **PVGIS**, que
+entrega DNI/DHI medidos por satélite geoestacionário sem decomposição.
+
+---
+
+## 5. Auditoria do TERRA — `geosense-infer/sidecar/`
+
+Li `solar.py` (878 linhas), as partes densas de `energy.py` (1956), `wind.py`
+(1152) e o lado Go.
+
+### O que está correto e é mais rigoroso do que os experimentos
+
+- **Perez (1990)** para transposição — contra o isotrópico que usei
+- **`time-standard=UTC`** explícito, com offset de meia hora
+- **Convenção de aspecto** verificada numericamente nas 4 direções: correta. E
+  trata célula plana como `NaN`, não como 0° (que leria como voltada ao norte)
+- **Horn (1981)** para declividade/aspecto, **Faiman** para temperatura,
+  **IAM ASHRAE**, sweep de tilt 0–45° a 0,5°
+- **Três PRs distintos** (modelado / derivado / aplicado) com proveniência.
+  `_require_resolved` rejeita float nu na fronteira de cada produto
+- **`loss_waterfall`** documenta cada limite no ponto onde ocorre, incluindo o
+  viés de altura do vento (`u1` de Faiman calibrado a altura de módulo, cadeia
+  entrega WS2M)
+- **`FLAT_PLACEMENT_BIAS_PCT`** mede o custo da apresentação: 1476,20 contra
+  1474,73 kWh/kWp/ano = 0,10%, conservador
+- **`wind.py`** usa expoente de cisalhamento **bulk** e não horário, com a razão
+  declarada: o horário amplifica as horas noturnas estáveis e infla o fator de
+  capacidade sem justificativa física
+- **Go não recomputa física** — orquestra, persiste, exporta.
+  `export_parity_test.go` impede divergência Go ↔ TypeScript com mecanismo
+  anti-silenciamento
+
+### As lacunas confirmadas
+
+**1. SVF ausente no difuso.** `shading_loss_fraction` remove só o feixe;
+`beam_fraction` documenta: *"Shading removes beam energy only"*.
+
+Medido no `E-raster.ipynb`: **−2,82%** em vale encaixado, **−0,04%** em planície.
+O sombreamento de feixe, que é a parte cara de calcular, muda a mediana em
+**−0,003%**.
+
+> O horizonte já é calculado. Ignorar o SVF é pagar o custo caro (traçar o
+> horizonte) e colher só o efeito pequeno (o feixe).
+
+**Recomendação:** implementar o SVF **com um critério de quando se aplica** — o
+próprio horizonte fornece o limiar. Aplicá-lo incondicionalmente gasta cálculo
+onde o efeito é ruído.
+
+**2. IAM difuso ausente.** Já declarado no passo 4 do waterfall como
+simplificação conhecida. Registrado no README como estudo pendente.
+
+**3. Sem tratamento de caso urbano/telhado.** Zero menções a `roof`, `building`
+ou edificação em `solar.py` e `energy.py`. A cadeia é usina em terreno — GCR,
+densidade por hectare, tracking.
+
+> Aplicar a cadeia de usina a uma AOI urbana mede **o chão, não os telhados**.
+> Sobre a AOI de Teresina ela dá SVF de 0,999 e conclui "sem sombreamento" —
+> acertaria por acidente, porque o DEM não vê casa nenhuma.
+
+### Não li
+
+`infer.py`, `lulc.py`, `composite.py`, `prithvi.py`, o frontend, e o grosso de
+`app.go`.
+
+---
+
+## 6. Achados sobre disponibilidade de dados
+
+Relevantes para a premissa de que o catálogo precisa ser resolvido antes da
+simulação.
+
+### Não há LiDAR nem DSM de alta resolução para o Brasil
+
+Catálogo do OpenTopography consultado para a AOI: `{"Datasets": []}`. A altura
+**por casa** não se resolve com dado aberto — exige drone ou dado comercial. A
+altura **do bairro** já temos (GHSL).
+
+### A escolha do DEM não move o resultado
+
+Quatro produtos sobre a mesma AOI (COP30, NASADEM, SRTMGL1, COP90): declividade
+mediana varia de 1,27° a 2,08° — **48%** em termos relativos. Mas o efeito no
+rendimento é de **1 kWh/kWp**. O que limita é a geometria das edificações, não a
+resolução do terreno.
+
+### Imagem de satélite pública para Teresina para em ~1,19 m/px
+
+Esri World Imagery: z17 é o máximo real; z18+ retorna placeholder cinza. Isso dá
+**44 pixels por casa** (casa mediana de 63 m² ≈ 7,9 m de lado).
+
+Para distinguir 2 águas de 4 águas seria preciso ver cumeeira e espigões — ~20 px
+por lado, ou **≈0,4 m/px**.
+
+> **Reconstruir geometria de telhado por visão computacional nesta AOI, com
+> imagem pública, não é possível.** Não é limitação de algoritmo, é de amostragem.
+
+E o contorno não ajuda: testei a razão área/bounding-box das 519 casas — duas e
+quatro águas cabem igualmente num retângulo.
+
+---
+
+## 7. Pendências, em ordem
+
+1. **Revogar a chave do OpenTopography** (`140cc396…`) — foi exposta em texto no
+   chat. Gerar outra em portal.opentopography.org → MyOpenTopo → API Key.
+   Ela **não** está em nenhum arquivo do repo (verificado com grep); entra por
+   `OPENTOPOGRAPHY_API_KEY`.
+2. **Corrigir a decomposição direta/difusa** — testar DIRINT/DISC ou PVGIS contra
+   Erbs. É o item 4.5, e afeta a leitura por água.
+3. **Conferir DOIs** das referências de 2025–26 antes de citar.
+4. **Escolher a linha de pesquisa** entre as sete. A skill
+   `scientific-problem-selection` (Fischbach & Walsh, *Cell* 2024) foi instalada
+   exatamente para isso.
+5. **Experimento sobre forma do telhado** — três caminhos discutidos e não
+   decididos: (a) quanto custa errar 2 águas vs 4 águas, (b) curva de resolução
+   (qual m/px é o requisito), (c) tentar extrair o extraível de 1,19 m/px.
+   O usuário pediu para pausar aqui e "formar melhor".
+
+---
+
+## 8. Convenções desta sessão
+
+- **Experimentos rápidos** vão em notebook Jupyter gerado por um
+  `build_notebook*.py` — editar o `.py`, nunca o `.ipynb`. Relatório em Markdown,
+  não LaTeX/R.
+- **Venv** em `.venv/` na raiz; kernel Jupyter registrado como `terra-sim`. O
+  Python do sistema não tem as dependências.
+- **Fusão de stacks por competência:** Rust para geometria e ray-casting
+  (`raycaster/`, 102 M raios em 101 s), Python para cadeia solar e análise,
+  Plotly para figura no notebook.
+- Cada estudo declara **critério de falseamento antes de rodar** e verifica
+  **condições de interpretabilidade** executáveis (ex.: "horizonte máximo < 15°
+  significa sem cenário para medir, não sem efeito").
+
+### Memórias gravadas
+
+Em `~/.claude/projects/-Users-rexionmars-estudos-UTFPr-TERRA-Simulation/memory/`:
+
+- `terra-svf-prioridade.md`
+- `cobertura-osm-vs-overture.md`
+- `sombreamento-telhado-vs-relevo.md`
+- `nasa-power-hora-solar-local.md`
+- `terra-simulation-formato-experimentos.md`
+
+---
+
+## 9. Reproduzir o estudo do zero
+
+```sh
+cd studies/E-raster-resource-spatialisation
+
+export OPENTOPOGRAPHY_API_KEY=...          # opcional; sem ela cai no AWS
+
+../../.venv/bin/python fetch_data.py               # DEM + NASA POWER
+../../.venv/bin/python fetch_buildings_overture.py  # contornos
+../../.venv/bin/python fetch_heights.py             # altura GHSL
+
+cd raycaster && cargo build --release && cd ..      # ray-caster
+../../.venv/bin/python build_3d_data.py             # cadeia solar -> aoi3d.json
+
+../../.venv/bin/python build_notebook_3d.py
+jupyter nbconvert --execute --inplace \
+  --ExecutePreprocessor.kernel_name=terra-sim E-3d.ipynb
+```
+
+Validação do sombreamento: `../../.venv/bin/python validate_shading.py`
+(o binário Rust é validado por 7 testes de geometria conhecida antes de uso).

--- a/app.go
+++ b/app.go
@@ -253,7 +253,10 @@ func (a *App) Predict(req backend.PredictRequest) (*backend.PredictResult, error
 	if err != nil {
 		return nil, err
 	}
-	a.persistRunIfLoggedIn(req, res)
+	// Set after persisting, so the stored copy -- marshalled inside -- does not
+	// carry a run's own id inside its own row. The frontend needs it to attach
+	// compositions made while this run is on screen.
+	res.RunID = a.persistRunIfLoggedIn(req, res)
 	return res, nil
 }
 
@@ -1066,17 +1069,19 @@ func decodeDataURI(uri string) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(uri[i+len(marker):])
 }
 
-func (a *App) persistRunIfLoggedIn(req backend.PredictRequest, res *backend.PredictResult) {
-	a.persistAnalysis(req, res)
+// persistRunIfLoggedIn saves the run and returns its id, so the caller can tell
+// the frontend which run it is now looking at. Empty when nothing was saved.
+func (a *App) persistRunIfLoggedIn(req backend.PredictRequest, res *backend.PredictResult) string {
+	return a.persistAnalysis(req, res)
 }
 
-func (a *App) persistAnalysis(req backend.PredictRequest, res *backend.PredictResult) {
+func (a *App) persistAnalysis(req backend.PredictRequest, res *backend.PredictResult) string {
 	a.mu.RLock()
 	user := a.currentUser
 	st := a.store
 	a.mu.RUnlock()
 	if st == nil || res == nil {
-		return
+		return ""
 	}
 	userID := store.LocalUserID
 	if user != nil {
@@ -1177,6 +1182,7 @@ func (a *App) persistAnalysis(req backend.PredictRequest, res *backend.PredictRe
 	if strings.TrimSpace(req.ProjectID) != "" {
 		st.TouchProject(req.ProjectID)
 	}
+	return runID
 }
 
 // ListRuns returns recent inference runs (signed-in user, or local guest).

--- a/app_projects.go
+++ b/app_projects.go
@@ -85,7 +85,15 @@ func (a *App) SetRunProject(runID, projectID string) error {
 
 // SaveProjectOverlayRequest persists a composition (or similar) into a project.
 type SaveProjectOverlayRequest struct {
-	ProjectID  string `json:"project_id"`
+	ProjectID string `json:"project_id"`
+	/*
+		The run on screen when this composition was made, when there was one.
+
+		Optional by design: a composition needs no classification -- browsing
+		scenes on the map produces one -- and those belong to the project
+		rather than to a run.
+	*/
+	RunID      string `json:"run_id"`
 	Kind       string `json:"kind"`
 	Title      string `json:"title"`
 	MetaJSON   string `json:"meta_json"`
@@ -143,6 +151,7 @@ func (a *App) SaveProjectOverlay(req SaveProjectOverlayRequest) (*store.ProjectO
 	row, err := a.store.AddProjectOverlay(userID, store.ProjectOverlay{
 		ID:         overlayID,
 		ProjectID:  projectID,
+		RunID:      strings.TrimSpace(req.RunID),
 		Kind:       kind,
 		Title:      title,
 		MetaJSON:   meta,

--- a/backend/export_research.go
+++ b/backend/export_research.go
@@ -300,6 +300,12 @@ func BuildResearchPackZIP(meta ResearchExportMeta, result *PredictResult, dataDi
 		manifest["wind_gross_annual_energy_mwh_per_turbine"] = wd.Hub.GrossAnnualEnergyMWhPerTurbine
 		manifest["wind_turbine"] = wd.Turbine.Name
 		manifest["wind_turbine_citation"] = wd.Turbine.Citation
+		// Which power curve, from where, at which revision. The citation names
+		// the turbine; these say which file the numbers were read from, which
+		// is what a reader needs to obtain the same curve.
+		manifest["wind_turbine_citation_url"] = wd.Turbine.CitationURL
+		manifest["wind_turbine_curve_source_url"] = wd.Turbine.CurveSourceURL
+		manifest["wind_turbine_curve_source_commit"] = wd.Turbine.CurveSourceCommit
 		manifest["wind_excluded_losses"] = wd.Hub.ExcludedLosses
 		manifest["wind_all_checks_passed"] = wd.DataQuality.AllChecksPassed
 		manifest["wind_flags"] = wd.DataQuality.Flags

--- a/backend/sidecar.go
+++ b/backend/sidecar.go
@@ -1346,7 +1346,8 @@ func (r *Runner) AnalyzeSolarTerrain(ctx context.Context, req SolarTerrainReques
 		// scale the raster was not drawn on, with no error anywhere.
 		Scale: t.Scale, ShadingMeanPct: t.ShadingMeanPct,
 		ShadingMaxPct: t.ShadingMaxPct, HorizonMaxDistM: t.HorizonMaxDistM,
-		BeamFraction: t.BeamFraction, PowerProvenance: t.PowerProvenance,
+		BeamFraction: t.BeamFraction, SkyView: t.SkyView,
+		PowerProvenance: t.PowerProvenance,
 	}
 	if uri, err := pngToDataURI(t.OverlayPNG); err == nil {
 		out.OverlayURI = uri

--- a/backend/sidecar.go
+++ b/backend/sidecar.go
@@ -523,6 +523,7 @@ func convertLULC(raw *lulcSidecarPayload) *LULCAnalysis {
 		PredVsRef:             raw.PredVsRef,
 		ComparePixels:         raw.ComparePixels,
 		CompareReferenceCells: raw.CompareReferenceCells,
+		Agreement:             raw.Agreement,
 	}
 	if out.Composition == nil {
 		out.Composition = []LULCClassRow{}

--- a/backend/solar_skyview_test.go
+++ b/backend/solar_skyview_test.go
@@ -1,0 +1,49 @@
+package backend
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The sidecar reports the sky view factor whether or not it applied it. A field
+// dropped in the Go mirror is invisible: the JSON decodes, the overlay renders,
+// and the verdict silently becomes "not applied".
+func TestSolarTerrainCarriesTheSkyViewVerdict(t *testing.T) {
+	raw := []byte(`{"poa_min":1,"poa_max":2,"beam_fraction":0.64,
+	 "sky_view":{"applied":true,"mean_horizon_deg":9.7,"max_horizon_deg":31.2,
+	 "threshold_deg":2.0,"diffuse_loss_mean_pct":2.84,"diffuse_loss_max_pct":11.5}}`)
+	var p solarTerrainSidecarPayload
+	if err := json.Unmarshal(raw, &p); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if p.SkyView == nil {
+		t.Fatal("sky_view dropped at the boundary")
+	}
+	if !p.SkyView.Applied {
+		t.Error("applied verdict lost")
+	}
+	if p.SkyView.ThresholdDeg != 2.0 {
+		t.Errorf("threshold = %v, want 2.0", p.SkyView.ThresholdDeg)
+	}
+	if p.SkyView.DiffuseLossMeanPct == nil || *p.SkyView.DiffuseLossMeanPct != 2.84 {
+		t.Error("diffuse loss lost")
+	}
+
+	// Not applied is a real verdict, not a missing one: the losses stay null
+	// while the horizon evidence survives.
+	var q solarTerrainSidecarPayload
+	if err := json.Unmarshal([]byte(`{"sky_view":{"applied":false,
+	 "mean_horizon_deg":0.3,"threshold_deg":2.0,
+	 "diffuse_loss_mean_pct":null}}`), &q); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if q.SkyView == nil || q.SkyView.Applied {
+		t.Fatal("not-applied verdict lost")
+	}
+	if q.SkyView.DiffuseLossMeanPct != nil {
+		t.Error("a loss was reported for a run that did not apply one")
+	}
+	if q.SkyView.MeanHorizonDeg != 0.3 {
+		t.Error("the evidence behind the verdict was dropped")
+	}
+}

--- a/backend/store/overlay_run_test.go
+++ b/backend/store/overlay_run_test.go
@@ -1,0 +1,44 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestOverlayCarriesItsRun covers the association added so a composition made
+// under one run does not surface while a different run is open.
+func TestOverlayCarriesItsRun(t *testing.T) {
+	s := openStoreIn(t, filepath.Join(t.TempDir(), "data"))
+	p, err := s.CreateProject(Project{UserID: LocalUserID, Name: "P"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.AddProjectOverlay(LocalUserID, ProjectOverlay{
+		ProjectID: p.ID, RunID: "run-a", Title: "with run",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// A composition made with no run open: browsing scenes needs none.
+	if _, err := s.AddProjectOverlay(LocalUserID, ProjectOverlay{
+		ProjectID: p.ID, Title: "no run",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := s.ListProjectOverlays(LocalUserID, p.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]string{}
+	for _, r := range rows {
+		got[r.Title] = r.RunID
+	}
+	if got["with run"] != "run-a" {
+		t.Errorf("run id did not survive the round trip: %q", got["with run"])
+	}
+	// Empty, not the string "NULL" or a scan error: readers branch on it.
+	if got["no run"] != "" {
+		t.Errorf("a composition made without a run reports %q", got["no run"])
+	}
+}

--- a/backend/store/projects.go
+++ b/backend/store/projects.go
@@ -307,9 +307,9 @@ func (s *Store) AddProjectOverlay(userID string, o ProjectOverlay) (*ProjectOver
 	}
 	_, err := s.db.Exec(
 		`INSERT INTO project_overlays
-		 (id, project_id, kind, title, meta_json, png_relpath, tif_relpath, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		o.ID, o.ProjectID, o.Kind, o.Title, o.MetaJSON,
+		 (id, project_id, run_id, kind, title, meta_json, png_relpath, tif_relpath, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		o.ID, o.ProjectID, nullIfEmpty(o.RunID), o.Kind, o.Title, o.MetaJSON,
 		nullIfEmpty(o.PNGRelPath), nullIfEmpty(o.TIFRelPath), o.CreatedAt,
 	)
 	if err != nil {
@@ -328,7 +328,7 @@ func (s *Store) ListProjectOverlays(userID, projectID string) ([]ProjectOverlay,
 		return nil, err
 	}
 	rows, err := s.db.Query(
-		`SELECT id, project_id, kind, title, meta_json,
+		`SELECT id, project_id, COALESCE(run_id,''), kind, title, meta_json,
 		        COALESCE(png_relpath,''), COALESCE(tif_relpath,''), created_at
 		 FROM project_overlays WHERE project_id = ?
 		 ORDER BY created_at DESC`,
@@ -342,7 +342,7 @@ func (s *Store) ListProjectOverlays(userID, projectID string) ([]ProjectOverlay,
 	for rows.Next() {
 		var o ProjectOverlay
 		if err := rows.Scan(
-			&o.ID, &o.ProjectID, &o.Kind, &o.Title, &o.MetaJSON,
+			&o.ID, &o.ProjectID, &o.RunID, &o.Kind, &o.Title, &o.MetaJSON,
 			&o.PNGRelPath, &o.TIFRelPath, &o.CreatedAt,
 		); err != nil {
 			return nil, err

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -107,8 +107,17 @@ type Project struct {
 
 // ProjectOverlay is a persisted composition (or similar) asset under a project.
 type ProjectOverlay struct {
-	ID         string `json:"id"`
-	ProjectID  string `json:"project_id"`
+	ID        string `json:"id"`
+	ProjectID string `json:"project_id"`
+	/*
+		The run this composition was made under, when there was one.
+
+		Empty for a composition made with no run open -- browsing scenes needs
+		no classification -- and for every row written before the column
+		existed. Empty means "belongs to the project", not "belongs to no
+		project", so readers scope those by the recorded extent instead.
+	*/
+	RunID      string `json:"run_id,omitempty"`
 	Kind       string `json:"kind"`
 	Title      string `json:"title"`
 	MetaJSON   string `json:"meta_json,omitempty"`
@@ -315,6 +324,27 @@ CREATE INDEX IF NOT EXISTS idx_runs_project_created ON inference_runs(project_id
 `
 	if _, err := s.db.Exec(projectSchema); err != nil {
 		return fmt.Errorf("migrate projects: %w", err)
+	}
+	/*
+		Which run a composition was made under.
+
+		Compositions were scoped to the project alone, and a project accumulates
+		runs across separate fields: one here held 57 runs and 13 compositions
+		spread over three locations up to 100 km apart, all listed together
+		whichever run was open. Applying one put a raster off the edge of the
+		area being looked at.
+
+		Nullable, and it will stay nullable: a composition can be made with no
+		run open at all -- browsing scenes on the map needs no classification --
+		and those belong to the project rather than to any run. Rows written
+		before this column exists are in the same position, and readers fall
+		back to comparing the recorded extent against the current area.
+	*/
+	for _, stmt := range []string{
+		`ALTER TABLE project_overlays ADD COLUMN run_id TEXT`,
+		`CREATE INDEX IF NOT EXISTS idx_project_overlays_run ON project_overlays(run_id)`,
+	} {
+		_, _ = s.db.Exec(stmt)
 	}
 	if err := s.ensureLocalUser(); err != nil {
 		return err

--- a/backend/types.go
+++ b/backend/types.go
@@ -691,12 +691,30 @@ type SolarTerrainAnalysis struct {
 	// Share of the horizontal irradiation carried by the beam component, which
 	// is what the shading loss is scaled by before it reaches the totals.
 	BeamFraction float64 `json:"beam_fraction"`
+	// Sky view factor: the diffuse counterpart of the shading above. The same
+	// horizon answers both, so this costs nothing extra to report.
+	SkyView *SolarSkyView `json:"sky_view,omitempty"`
 	// Raster as a base64 PNG data URI, drawn on Scale.
 	OverlayURI string `json:"overlay_uri"`
 	RasterTIF  string `json:"raster_tif"`
 	Extent     Bounds `json:"extent"`
 	// Whether the series behind these figures was fetched or read from cache.
 	PowerProvenance *PowerProvenance `json:"power_provenance,omitempty"`
+}
+
+// SolarSkyView is how much of the sky dome the terrain leaves visible, and the
+// threshold that decided whether the diffuse loss was worth applying.
+//
+// Reported whether or not it was applied: "not applied" and "applied at zero"
+// are different statements about the terrain, and only the first means the
+// question was never asked.
+type SolarSkyView struct {
+	Applied            bool     `json:"applied"`
+	MeanHorizonDeg     float64  `json:"mean_horizon_deg"`
+	MaxHorizonDeg      float64  `json:"max_horizon_deg"`
+	ThresholdDeg       float64  `json:"threshold_deg"`
+	DiffuseLossMeanPct *float64 `json:"diffuse_loss_mean_pct"`
+	DiffuseLossMaxPct  *float64 `json:"diffuse_loss_max_pct"`
 }
 
 // NDates reports the years of hourly record behind the map, so a saved run can
@@ -720,6 +738,7 @@ type solarTerrainSidecarPayload struct {
 	ShadingMaxPct   *float64         `json:"shading_max_pct"`
 	HorizonMaxDistM float64          `json:"horizon_max_dist_m"`
 	BeamFraction    float64          `json:"beam_fraction"`
+	SkyView         *SolarSkyView    `json:"sky_view,omitempty"`
 	OverlayPNG      string           `json:"overlay_png"`
 	RasterTIF       string           `json:"raster_tif"`
 	Extent          Bounds           `json:"extent"`

--- a/backend/types.go
+++ b/backend/types.go
@@ -910,10 +910,8 @@ type EnergyPerformanceRatio struct {
 	Applied                            float64                  `json:"applied"`
 	AppliedSource                      string                   `json:"applied_source"`
 	Reference                          float64                  `json:"reference"`
-	ReferenceSource                    string                   `json:"reference_source"`
 	Modelled                           float64                  `json:"modelled"`
 	Derived                            float64                  `json:"derived"`
-	DerivedSource                      string                   `json:"derived_source"`
 	DerivedIfOptionalAtPVWattsDefaults float64                  `json:"derived_if_optional_at_pvwatts_defaults"`
 	DeclaredLossFactor                 float64                  `json:"declared_loss_factor"`
 	OptionalLossFactor                 float64                  `json:"optional_loss_factor"`
@@ -924,7 +922,6 @@ type EnergyPerformanceRatio struct {
 	DegradationFactor                  float64                  `json:"degradation_factor"`
 	DegradationRatePerYear             float64                  `json:"degradation_rate_per_year"`
 	AnalysisPeriodYears                int                      `json:"analysis_period_years"`
-	DegradationSource                  string                   `json:"degradation_source"`
 	// Ratio implied by the Global Solar Atlas benchmark at this site, as a
 	// two-element band. The only external validation the applied ratio has.
 	GSAImpliedBand []float64 `json:"gsa_implied_band"`
@@ -1045,9 +1042,7 @@ type EnergyTrackerConfiguration struct {
 	AxisAzimuthDeg        float64 `json:"axis_azimuth_deg"`
 	AxisAzimuthConvention string  `json:"axis_azimuth_convention"`
 	MaxAngleDeg           float64 `json:"max_angle_deg"`
-	MaxAngleSource        string  `json:"max_angle_source"`
 	Backtrack             bool    `json:"backtrack"`
-	BacktrackNote         string  `json:"backtrack_note"`
 	Terrain               string  `json:"terrain"`
 }
 
@@ -1150,7 +1145,6 @@ type EnergyModelDerivedLandUse struct {
 	GCRRatio              float64         `json:"gcr_ratio"`
 	Basis                 string          `json:"basis"`
 	Note                  string          `json:"note"`
-	ModuleEfficiencyNote  string          `json:"module_efficiency_note"`
 	Parity                EnergyParityGCR `json:"parity"`
 }
 
@@ -1191,7 +1185,6 @@ type EnergyTracking struct {
 	PerHectare       EnergyPerHectare           `json:"per_hectare"`
 	PerformanceRatio EnergyTrackingPR           `json:"performance_ratio"`
 	Excluded         string                     `json:"excluded"`
-	ResolutionNote   string                     `json:"resolution_note"`
 }
 
 // EnergyTimeStandard labels the diurnal profile. UTCOffsetHours is null when
@@ -1251,20 +1244,18 @@ type EnergyGenerationProfile struct {
 // area basis it is measured on. The basis moves the answer further than the
 // exceedance band does, so it is never reported without it.
 type EnergyCapacityDensity struct {
-	Basis                   string  `json:"basis"`
-	ValueMWPerHa            float64 `json:"value_mw_per_ha"`
-	Units                   string  `json:"units"`
-	ValueMWDCPerHa          float64 `json:"value_mw_dc_per_ha"`
-	AreaBasis               string  `json:"area_basis"`
-	Mounting                string  `json:"mounting"`
-	Source                  string  `json:"source"`
-	AcreConversion          string  `json:"acre_conversion"`
-	BuildableFraction       float64 `json:"buildable_fraction"`
-	BuildableFractionSource string  `json:"buildable_fraction_source"`
+	Basis             string  `json:"basis"`
+	ValueMWPerHa      float64 `json:"value_mw_per_ha"`
+	Units             string  `json:"units"`
+	ValueMWDCPerHa    float64 `json:"value_mw_dc_per_ha"`
+	AreaBasis         string  `json:"area_basis"`
+	Mounting          string  `json:"mounting"`
+	Source            string  `json:"source"`
+	AcreConversion    string  `json:"acre_conversion"`
+	BuildableFraction float64 `json:"buildable_fraction"`
 	// Separately sourced from the model-internal inverter oversizing factor:
 	// the two are unrelated quantities and must not be substituted.
 	FleetDCACRatio          float64 `json:"fleet_dc_ac_ratio"`
-	FleetDCACRatioSource    string  `json:"fleet_dc_ac_ratio_source"`
 	ACToDCConversionApplied bool    `json:"ac_to_dc_conversion_applied"`
 	Note                    string  `json:"note"`
 }
@@ -1332,10 +1323,9 @@ type EnergyExceedanceLevel struct {
 // EnergyNormality is the test behind using a normal fit at all, reported rather
 // than assumed.
 type EnergyNormality struct {
-	Test           string  `json:"test"`
-	Statistic      float64 `json:"statistic"`
-	PValue         float64 `json:"p_value"`
-	Interpretation string  `json:"interpretation"`
+	Test      string  `json:"test"`
+	Statistic float64 `json:"statistic"`
+	PValue    float64 `json:"p_value"`
 }
 
 // EnergyExceedanceCrosswalk states that the exceedance P90 and the statistical
@@ -1357,7 +1347,6 @@ type EnergyExceedance struct {
 	StdKWhM2Year        float64                   `json:"std_kwh_m2_year"`
 	CVPct               float64                   `json:"cv_pct"`
 	Levels              []EnergyExceedanceLevel   `json:"levels"`
-	P50Note             string                    `json:"p50_note"`
 	Normality           EnergyNormality           `json:"normality"`
 	Crosswalk           EnergyExceedanceCrosswalk `json:"crosswalk"`
 	LinearityAssumption string                    `json:"linearity_assumption"`
@@ -1422,7 +1411,6 @@ type EnergyAssumptions struct {
 	CapacityDensityMWDCPerHa float64 `json:"capacity_density_mw_dc_per_ha"`
 	ShadingApplied           bool    `json:"shading_applied"`
 	ShadingDerate            float64 `json:"shading_derate"`
-	ResolutionNote           string  `json:"resolution_note"`
 	Note                     string  `json:"note"`
 }
 
@@ -1530,7 +1518,6 @@ type WindMeasured struct {
 	AirDensityMeanKgM3     float64             `json:"air_density_mean_kg_m3"`
 	AirDensityMinKgM3      float64             `json:"air_density_min_kg_m3"`
 	AirDensityMaxKgM3      float64             `json:"air_density_max_kg_m3"`
-	HumidityNote           string              `json:"humidity_note"`
 	MonthlyMeanSpeed50m    []WindMonthlySpeed  `json:"monthly_mean_speed_50m"`
 	Direction              WindDirection       `json:"direction"`
 	DirectionEnergyRose50m []WindRoseSector    `json:"direction_energy_rose_50m"`
@@ -1570,9 +1557,7 @@ type WindHub struct {
 	GrossCapacityFactorNoDensityCorrectionPct float64             `json:"gross_capacity_factor_no_density_correction_pct"`
 	GrossAnnualEnergyMWhPerTurbine            float64             `json:"gross_annual_energy_mwh_per_turbine"`
 	OperatingRegime                           WindOperatingRegime `json:"operating_regime"`
-	DensityNormalisationNote                  string              `json:"density_normalisation_note"`
 	HoursPerYear                              float64             `json:"hours_per_year"`
-	HoursPerYearNote                          string              `json:"hours_per_year_note"`
 	ExcludedLosses                            []string            `json:"excluded_losses"`
 }
 
@@ -1601,7 +1586,6 @@ type WindShearDiagnostics struct {
 	AssumedRoughnessBandM      []float64 `json:"assumed_roughness_band_m"`
 	ExpectedShearExponentBand  []float64 `json:"expected_shear_exponent_band"`
 	ConsistentWithAssumedCover bool      `json:"consistent_with_assumed_cover"`
-	RoughnessBandNote          string    `json:"roughness_band_note"`
 	ShearExponentHourlyMean    float64   `json:"shear_exponent_hourly_mean"`
 	ShearExponentHourlyMedian  float64   `json:"shear_exponent_hourly_median"`
 	ShearExponentDay           float64   `json:"shear_exponent_day"`
@@ -1621,9 +1605,7 @@ type WindDataQuality struct {
 	RecordMaximumMS        map[string]float64   `json:"record_maximum_ms"`
 	RecordMaximumFloorMS   float64              `json:"record_maximum_floor_ms"`
 	RecordMaximumPlausible bool                 `json:"record_maximum_plausible"`
-	RecordMaximumFloorNote string               `json:"record_maximum_floor_note"`
 	CalmFraction2mFlagPct  float64              `json:"calm_fraction_2m_flag_pct"`
-	CalmFraction2mNote     string               `json:"calm_fraction_2m_note"`
 	NaNCount               map[string]int       `json:"nan_count"`
 	Shear                  WindShearDiagnostics `json:"shear"`
 	Flags                  []string             `json:"flags"`
@@ -1649,7 +1631,6 @@ type WindTurbine struct {
 	CitationURL       string  `json:"citation_url"`
 	CurveSourceURL    string  `json:"curve_source_url"`
 	CurveSourceCommit string  `json:"curve_source_commit"`
-	DrivetrainNote    string  `json:"drivetrain_note"`
 }
 
 // WindAssumptions repeats the conventions the figures rest on, including the
@@ -1665,11 +1646,9 @@ type WindAssumptions struct {
 	RoughnessBandM      []float64 `json:"roughness_band_m"`
 	CalmThresholdMS     float64   `json:"calm_threshold_ms"`
 	RecordMaxFloorMS    float64   `json:"record_max_floor_ms"`
-	ConventionsNote     string    `json:"conventions_note"`
 	Qualifier           string    `json:"qualifier"`
 	ExcludedLosses      []string  `json:"excluded_losses"`
 	ComparisonNote      string    `json:"comparison_note"`
-	ResolutionNote      string    `json:"resolution_note"`
 }
 
 // WindAnalysis is a wind resource screening at the AOI, from reanalysis hourly
@@ -1686,7 +1665,6 @@ type WindAnalysis struct {
 	RecordWindow   string    `json:"record_window"`
 	HubHeightM     float64   `json:"hub_height_m"`
 	Qualifier      string    `json:"qualifier"`
-	LoadsNote      string    `json:"loads_note"`
 
 	Measured         WindMeasured    `json:"measured"`
 	Hub              WindHub         `json:"hub"`

--- a/backend/types.go
+++ b/backend/types.go
@@ -366,13 +366,17 @@ type lulcSidecarPayload struct {
 // PredictResult is returned to the frontend. The overlay is delivered as a
 // base64 data URI so Leaflet can render it without an asset-server path.
 type PredictResult struct {
-	Extent         Bounds  `json:"extent"`
-	OverlayURI     string  `json:"overlay_uri"`
-	ConfidenceURI  string  `json:"confidence_uri"`
-	NDVIMeanURI    string  `json:"ndvi_mean_uri"`
-	TrueColorURI   string  `json:"true_color_uri"`
-	ReferenceURI   string  `json:"reference_uri"`
-	RasterTIF      string  `json:"raster_tif"`
+	Extent        Bounds `json:"extent"`
+	OverlayURI    string `json:"overlay_uri"`
+	ConfidenceURI string `json:"confidence_uri"`
+	NDVIMeanURI   string `json:"ndvi_mean_uri"`
+	TrueColorURI  string `json:"true_color_uri"`
+	ReferenceURI  string `json:"reference_uri"`
+	RasterTIF     string `json:"raster_tif"`
+	// The saved run this result became, set after persisting so the stored
+	// copy does not carry its own row id. Empty when nothing was saved.
+	// Compositions made while this result is on screen attach to it.
+	RunID          string  `json:"run_id,omitempty"`
 	MeanConfidence float64 `json:"mean_confidence"`
 	// The floor MeanConfidence cannot go below: confidence is
 	// max(predict_proba), so with K classes it lives on [1/K, 1] and never

--- a/backend/types.go
+++ b/backend/types.go
@@ -178,6 +178,58 @@ type LULCCompareRow struct {
 	NReferenceCells int `json:"n_reference_cells,omitempty"`
 }
 
+/*
+LULCAgreement is the accuracy assessment of the classification against the
+MapBiomas reference.
+
+Computed over the reference's native 30 m cells rather than the 10 m pixels
+they were resampled onto: about nine pixels carry one label observation, so a
+pixel-level assessment would claim nine times the sample size it has and an
+interval roughly three times too narrow.
+*/
+type LULCAgreement struct {
+	// Independent label observations the assessment rests on.
+	NReferenceCells int `json:"n_reference_cells"`
+	// Share of cells where the classification and the reference agree, with a
+	// Wilson score interval at 95%.
+	OverallPct float64   `json:"overall_pct"`
+	OverallCI  []float64 `json:"overall_ci"`
+	// Pontius & Millones (2011): total disagreement splits into holding
+	// different amounts of a class, and holding the same amounts in different
+	// places. The composition comparison shows the first and hides the second.
+	QuantityDisagreementPct   float64 `json:"quantity_disagreement_pct"`
+	AllocationDisagreementPct float64 `json:"allocation_disagreement_pct"`
+
+	PerClass []LULCClassAccuracy `json:"per_class"`
+	// Reference cells carrying a class the classifier has no label for. Not
+	// errors -- the share of the area the assessment is silent about.
+	NOutsideLegend int     `json:"n_outside_legend"`
+	Matrix         [][]int `json:"matrix"`
+	MatrixClasses  []int   `json:"matrix_classes"`
+}
+
+/*
+LULCClassAccuracy is one class's producer's and user's accuracy.
+
+Both, never one. Producer's alone hides commission and user's alone hides
+omission: a classifier that labels the whole scene soybean has perfect
+producer's accuracy for soybean and is useless.
+*/
+type LULCClassAccuracy struct {
+	ClassID int    `json:"class_id"`
+	Name    string `json:"name"`
+	Color   string `json:"color"`
+	// Of the reference cells of this class, the share the classifier found.
+	// Nil when the reference holds none, which is absent rather than zero.
+	ProducersPct *float64  `json:"producers_pct"`
+	ProducersCI  []float64 `json:"producers_ci,omitempty"`
+	// Of the cells called this class, the share that really are.
+	UsersPct   *float64  `json:"users_pct"`
+	UsersCI    []float64 `json:"users_ci,omitempty"`
+	NReference int       `json:"n_reference"`
+	NPredicted int       `json:"n_predicted"`
+}
+
 // LULCAnalysis is the descriptive land cover / land use payload.
 type LULCAnalysis struct {
 	Year        int              `json:"year"`
@@ -195,6 +247,11 @@ type LULCAnalysis struct {
 	// agreement statistic must be computed over. Zero when unavailable.
 	ComparePixels         int `json:"compare_pixels,omitempty"`
 	CompareReferenceCells int `json:"compare_reference_cells,omitempty"`
+	// Agreement against the reference, which the composition rows above cannot
+	// express: two maps with identical class proportions can disagree on every
+	// cell. Nil when the reference cell mapping was unavailable, since without
+	// it there is no honest denominator.
+	Agreement *LULCAgreement `json:"agreement,omitempty"`
 }
 
 // LULCRequest selects an embedded area (or explicit polygon + MapBiomas path).
@@ -260,14 +317,19 @@ type CompositeResult struct {
 
 // sidecarResult is the raw JSON returned by the sidecar on stdout.
 type sidecarResult struct {
-	Extent          Bounds                `json:"extent"`
-	OverlayPNG      string                `json:"overlay_png"`
-	RasterTIF       string                `json:"raster_tif"`
-	ConfidencePNG   string                `json:"confidence_png"`
-	NDVIMeanPNG     string                `json:"ndvi_mean_png"`
-	TrueColorPNG    string                `json:"true_color_png"`
-	ReferencePNG    string                `json:"reference_png"`
-	MeanConfidence  float64               `json:"mean_confidence"`
+	Extent         Bounds  `json:"extent"`
+	OverlayPNG     string  `json:"overlay_png"`
+	RasterTIF      string  `json:"raster_tif"`
+	ConfidencePNG  string  `json:"confidence_png"`
+	NDVIMeanPNG    string  `json:"ndvi_mean_png"`
+	TrueColorPNG   string  `json:"true_color_png"`
+	ReferencePNG   string  `json:"reference_png"`
+	MeanConfidence float64 `json:"mean_confidence"`
+	// The floor MeanConfidence cannot go below: confidence is
+	// max(predict_proba), so with K classes it lives on [1/K, 1] and never
+	// approaches zero. Without it the figure reads on a 0-100 scale it does
+	// not occupy. Zero when the class count was unavailable.
+	ConfidenceFloor float64               `json:"confidence_floor,omitempty"`
 	NDates          int                   `json:"n_dates"`
 	DateRange       []string              `json:"date_range"`
 	ClassStats      []ClassStat           `json:"class_stats"`
@@ -294,19 +356,29 @@ type lulcSidecarPayload struct {
 	// agreement statistic must be computed over. Zero when unavailable.
 	ComparePixels         int `json:"compare_pixels,omitempty"`
 	CompareReferenceCells int `json:"compare_reference_cells,omitempty"`
+	// Agreement against the reference, which the composition rows above cannot
+	// express: two maps with identical class proportions can disagree on every
+	// cell. Nil when the reference cell mapping was unavailable, since without
+	// it there is no honest denominator.
+	Agreement *LULCAgreement `json:"agreement,omitempty"`
 }
 
 // PredictResult is returned to the frontend. The overlay is delivered as a
 // base64 data URI so Leaflet can render it without an asset-server path.
 type PredictResult struct {
-	Extent          Bounds                `json:"extent"`
-	OverlayURI      string                `json:"overlay_uri"`
-	ConfidenceURI   string                `json:"confidence_uri"`
-	NDVIMeanURI     string                `json:"ndvi_mean_uri"`
-	TrueColorURI    string                `json:"true_color_uri"`
-	ReferenceURI    string                `json:"reference_uri"`
-	RasterTIF       string                `json:"raster_tif"`
-	MeanConfidence  float64               `json:"mean_confidence"`
+	Extent         Bounds  `json:"extent"`
+	OverlayURI     string  `json:"overlay_uri"`
+	ConfidenceURI  string  `json:"confidence_uri"`
+	NDVIMeanURI    string  `json:"ndvi_mean_uri"`
+	TrueColorURI   string  `json:"true_color_uri"`
+	ReferenceURI   string  `json:"reference_uri"`
+	RasterTIF      string  `json:"raster_tif"`
+	MeanConfidence float64 `json:"mean_confidence"`
+	// The floor MeanConfidence cannot go below: confidence is
+	// max(predict_proba), so with K classes it lives on [1/K, 1] and never
+	// approaches zero. Without it the figure reads on a 0-100 scale it does
+	// not occupy. Zero when the class count was unavailable.
+	ConfidenceFloor float64               `json:"confidence_floor,omitempty"`
 	NDates          int                   `json:"n_dates"`
 	DateRange       []string              `json:"date_range"`
 	ClassStats      []ClassStat           `json:"class_stats"`

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -308,16 +308,6 @@ function App() {
 
   const hasArea = !!customPolygon || !!activeExample
 
-  const handleSelectExample = (id: string) => {
-    const area = areas.find((a) => a.id === id)
-    if (!area) return
-    setActiveExample(id)
-    setCustomPolygon(area.geometry)
-    setResult(null)
-    setShowPredictionOverlay(true)
-    setAnalysisLabel(undefined)
-  }
-
   const clearArea = () => {
     setCustomPolygon(null)
     setActiveExample("")
@@ -436,7 +426,6 @@ function App() {
             setAnalysisLabel={setAnalysisLabel}
             lulcRunning={lulcRunning}
             setLulcRunning={setLulcRunning}
-            onSelectExample={handleSelectExample}
             onClearArea={clearArea}
             onImportPolygon={handleImportPolygon}
           />
@@ -499,7 +488,6 @@ function AppBody(props: {
   setAnalysisLabel: (v: string | undefined) => void
   lulcRunning: boolean
   setLulcRunning: (v: boolean) => void
-  onSelectExample: (id: string) => void
   onClearArea: () => void
   onImportPolygon: () => void
 }) {
@@ -2332,7 +2320,6 @@ function AppBody(props: {
                   composeOpacity={composeOpacity}
                   onViewChange={handleViewChange}
                   onPolygonDrawn={handlePolygonDrawn}
-                  onSelectExample={props.onSelectExample}
                   onLocationSelect={(lat, lon) =>
                     props.setFlyTo({ lat, lon, key: Date.now() })
                   }
@@ -2452,7 +2439,6 @@ function AppBody(props: {
                   hasArea={props.hasArea}
                   areas={props.areas}
                   activeExample={props.activeExample}
-                  onSelectExample={props.onSelectExample}
                   customPolygon={props.customPolygon}
                   onPolygonDrawn={handlePolygonDrawn}
                   onImportPolygon={props.onImportPolygon}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -61,8 +61,15 @@ import type {
 } from "@/lib/types"
 import { parsePreferenceExtras } from "@/lib/preferenceExtras"
 import { makeRunLabel, resolveAoiDisplayLabel, aoiLabelFromRunSummary } from "@/lib/aoiLabel"
-import { projectOverlayToComposition } from "@/lib/projectOverlays"
-import { geometryCentroid, usesExampleArea } from "@/lib/geometry"
+import {
+  projectOverlayToComposition,
+  scopeCompositionsToView,
+} from "@/lib/projectOverlays"
+import {
+  geometryBounds,
+  geometryCentroid,
+  usesExampleArea,
+} from "@/lib/geometry"
 import { ProjectSwitcher } from "@/components/ProjectSwitcher"
 import { resolveCompositionMeta } from "@/lib/compositeCatalog"
 import {
@@ -601,6 +608,17 @@ function AppBody(props: {
    * opened; cleared wherever the result is.
    */
   const [currentRunLabel, setCurrentRunLabel] = useState<string | null>(null)
+  /*
+    The saved run on screen, by id.
+
+    The label was the only run identity the frontend held, and a label can be
+    renamed. Compositions attach to this, so it has to be the row's own id: a
+    composition filed under a renamed label would come loose from its run.
+
+    Null while a run is being made -- the id only exists once the backend has
+    saved it -- and null when the result on screen is a live one nobody kept.
+  */
+  const [currentRunId, setCurrentRunId] = useState<string | null>(null)
 
   /**
    * Name a run about to be sent, and record the name.
@@ -625,6 +643,37 @@ function AppBody(props: {
   const [compositionGallery, setCompositionGallery] = useState<
     CompositionOverlay[]
   >([])
+  /*
+    The compositions that belong with what is on screen.
+
+    The gallery holds every composition in the project, and a project spans
+    fields: one here had thirteen across three locations up to 100 km apart,
+    all listed whichever run was open, so applying one put a raster off the
+    edge of the area in view. Scoped by the run that made it, or -- for the
+    ones that predate the association, and for any made with no run open -- by
+    whether it covers the area at all.
+  */
+  const visibleAoi = useMemo(() => {
+    const geom =
+      props.customPolygon ??
+      props.areas.find((a) => a.id === props.activeExample)?.geometry ??
+      null
+    const b = geometryBounds(geom)
+    return b
+      ? {
+          lon_min: b.lonMin,
+          lat_min: b.latMin,
+          lon_max: b.lonMax,
+          lat_max: b.latMax,
+        }
+      : null
+  }, [props.customPolygon, props.activeExample, props.areas])
+
+  const scopedCompositions = useMemo(
+    () => scopeCompositionsToView(compositionGallery, currentRunId, visibleAoi),
+    [compositionGallery, currentRunId, visibleAoi]
+  )
+
   const [showCompositionOverlay, setShowCompositionOverlay] = useState(true)
   const [composeRunning, setComposeRunning] = useState(false)
   const [composeProgress, setComposeProgress] = useState(0)
@@ -924,8 +973,29 @@ function AppBody(props: {
         // The gallery is always loaded so the compositions stay one click away
         // in Overlay Tools; only the display is conditional.
         setCompositionGallery(gallery)
-        setComposition(userInitiated ? gallery[0] ?? null : null)
-        setShowCompositionOverlay(userInitiated && !!gallery[0])
+        /*
+          Only a composition that covers the area being opened is put on the
+          map. This took gallery[0] -- the project's most recent -- and turned
+          the overlay on, so opening a project whose latest composition was
+          made over a different field drew a raster off the edge of the view
+          the same action had just flown to.
+        */
+        // From the project, not from the branch above: the AOI arrives either
+        // as an example area or as a saved polygon, and only one of those runs.
+        const openedGeom = p.area_id
+          ? (props.areas.find((a) => a.id === p.area_id)?.geometry ?? null)
+          : parseRunPolygon(p.polygon_geojson ?? "", props.areas).polygon
+        const openedAoi = geometryBounds(openedGeom)
+        const inView = openedAoi
+          ? scopeCompositionsToView(gallery, null, {
+              lon_min: openedAoi.lonMin,
+              lat_min: openedAoi.latMin,
+              lon_max: openedAoi.lonMax,
+              lat_max: openedAoi.latMax,
+            })
+          : gallery
+        setComposition(userInitiated ? inView[0] ?? null : null)
+        setShowCompositionOverlay(userInitiated && !!inView[0])
       } catch (e) {
         notifyError("Could not open project", e)
       }
@@ -1109,6 +1179,9 @@ function AppBody(props: {
           })
           const reqSave: SaveProjectOverlayRequest = {
             project_id: activeProjectId,
+            // The run on screen, so this composition surfaces with that run
+            // and not with every other run in the project.
+            run_id: currentRunId ?? "",
             kind: "composition",
             title: meta.title,
             meta_json: metaJson,
@@ -1699,6 +1772,9 @@ function AppBody(props: {
     try {
       const res = (await Predict(req as never)) as unknown as PredictResult
       props.setResult(res)
+      // The row the backend just wrote. Compositions made from here attach to
+      // it; empty when nothing was saved, which leaves them project-level.
+      setCurrentRunId(res.run_id || null)
       props.setShowPredictionOverlay(true)
       if (!props.analysisLabel?.trim()) {
         props.setAnalysisLabel(req.label)
@@ -1822,6 +1898,7 @@ function AppBody(props: {
           res.n_dates > 0
         props.setResult(isClassification ? res : null)
         setCurrentRunLabel(run.label ?? null)
+        setCurrentRunId(run.id)
         props.setShowPredictionOverlay(true)
         if (isModelKind(run.model_kind)) props.setModelKind(run.model_kind)
         const extras = parsePreferenceExtras(prefs?.extras_json)
@@ -1920,6 +1997,7 @@ function AppBody(props: {
   const backToAnalysesList = useCallback(() => {
     props.setResult(null)
     setCurrentRunLabel(null)
+    setCurrentRunId(null)
     // The standalone products have to go too. The analysis payload is
     // non-null whenever any of them is present, so clearing only the
     // classification leaves the detail view up and the saved list unreachable.
@@ -1971,6 +2049,7 @@ function AppBody(props: {
   const startNewClassification = useCallback(() => {
     props.setResult(null)
     setCurrentRunLabel(null)
+    setCurrentRunId(null)
     props.setShowPredictionOverlay(true)
     props.setSwipeCompare(false)
     props.setSwipeRatio(0.5)
@@ -2288,9 +2367,9 @@ function AppBody(props: {
                     setCompositionGallery([])
                     setShowCompositionOverlay(true)
                   }}
-                  compositionGallery={compositionGallery}
+                  compositionGallery={scopedCompositions}
                   onSelectComposition={(id) => {
-                    const hit = compositionGallery.find((c) => c.id === id)
+                    const hit = scopedCompositions.find((c) => c.id === id)
                     if (hit) {
                       setComposition(hit)
                       setShowCompositionOverlay(true)

--- a/frontend/src/components/CompareAnalyses.tsx
+++ b/frontend/src/components/CompareAnalyses.tsx
@@ -18,7 +18,7 @@ import type {
 } from "@/lib/types"
 import { displayRunLabel } from "@/lib/aoiLabel"
 import {
-  VI_GAP_DAYS,
+  gapLimitMs,
   dateToMs,
   insertTimeGaps,
   timeAxisProps,
@@ -278,10 +278,14 @@ function NdviChart({
   /** Shared for the same reason, so a difference in height is a difference. */
   yDomain: [number, number]
 }) {
-  const rows = insertTimeGaps(
-    (data ?? []).map((p) => ({ t: dateToMs(p.date), ndvi_mean: p.ndvi_mean })),
-    VI_GAP_DAYS
-  )
+  const points = (data ?? []).map((p) => ({
+    t: dateToMs(p.date),
+    ndvi_mean: p.ndvi_mean,
+  }))
+  // Per panel, from that run's own cadence: the two runs being compared may
+  // have been sampled differently, and one threshold for both would break the
+  // sparser series or join across a real absence in the denser one.
+  const rows = insertTimeGaps(points, gapLimitMs(points.map((r) => r.t)))
   return (
     <div>
       <p className="mb-1 text-meta text-muted-foreground">{slot}</p>

--- a/frontend/src/components/ControlPanel.tsx
+++ b/frontend/src/components/ControlPanel.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useState } from "react"
+import { forwardRef } from "react"
 import { motion } from "motion/react"
 import {
   Play,
@@ -7,22 +7,18 @@ import {
   Upload,
   Trash2,
   ChevronLeft,
-  ChevronRight,
-  Layers,
   CheckCircle2,
   Circle,
   Globe2,
 } from "lucide-react"
-import type { Area, GeoJSONGeometry, ModelKind } from "@/lib/types"
+import type { GeoJSONGeometry, ModelKind } from "@/lib/types"
 import { cn } from "@/lib/utils"
 import { todayISO } from "@/lib/dates"
 import { btnPrimaryCommit } from "@/components/ui/buttons"
 import { PanelSection as Section } from "@/components/ui/PanelSection"
 
 interface ControlPanelProps {
-  areas: Area[]
   activeExample: string
-  onSelectExample: (id: string) => void
   customPolygon: GeoJSONGeometry | null
   hasArea: boolean
   onClearArea: () => void
@@ -56,9 +52,7 @@ interface ControlPanelProps {
 export const ControlPanel = forwardRef<HTMLDivElement, ControlPanelProps>(
   function ControlPanel(props, ref) {
   const {
-    areas,
     activeExample,
-    onSelectExample,
     customPolygon,
     hasArea,
     onClearArea,
@@ -86,7 +80,6 @@ export const ControlPanel = forwardRef<HTMLDivElement, ControlPanelProps>(
     onCollapse,
   } = props
 
-  const [showExamples, setShowExamples] = useState(false)
   const canLULC = hasArea
   const busy = running || lulcRunning
 
@@ -155,41 +148,6 @@ export const ControlPanel = forwardRef<HTMLDivElement, ControlPanelProps>(
             : "No area defined"}
         </div>
 
-        {/* Examples: secondary launcher, collapsed by default */}
-        <div className="flex flex-col gap-1.5">
-          <button
-            onClick={() => setShowExamples((s) => !s)}
-            className="flex items-center gap-1.5 self-start text-[11px] text-muted-foreground hover:text-foreground"
-          >
-            <Layers className="size-3" />
-            Reference examples
-            {showExamples ? (
-              <ChevronLeft className="size-3 rotate-90" />
-            ) : (
-              <ChevronRight className="size-3 rotate-90" />
-            )}
-          </button>
-          {showExamples && (
-            <div className="grid grid-cols-3 gap-1.5">
-              {areas.map((a) => (
-                <button
-                  key={a.id}
-                  disabled={busy}
-                  onClick={() => onSelectExample(a.id)}
-                  title={a.label}
-                  className={cn(
-                    "rounded-sm border px-2 py-1 text-xs disabled:opacity-50",
-                    activeExample === a.id
-                      ? "border-primary bg-primary/10"
-                      : "border-border hover:bg-secondary"
-                  )}
-                >
-                  {a.id}
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
       </Section>
 
       <hr className="hairline" />

--- a/frontend/src/components/EnergyModelSection.tsx
+++ b/frontend/src/components/EnergyModelSection.tsx
@@ -122,10 +122,6 @@ function EnergyWaterfall({ energy }: { energy: EnergyModelAnalysis }) {
                     : s.cumulative_ratio.toFixed(6)}
                 </span>
               </div>
-              <p className="mt-1 pl-7 text-[10px] leading-relaxed text-muted-foreground">
-                {s.source}
-                {s.note ? ` — ${s.note}` : ""}
-              </p>
             </li>
           )
         })}
@@ -314,9 +310,7 @@ function TrackingComparison({ energy }: { energy: EnergyModelAnalysis }) {
       <p className="eyebrow">Fixed tilt against one-axis tracking</p>
 
       <div>
-        <p className="mb-2 text-[11px] leading-relaxed text-foreground">
-          Per hectare, as published. {t.per_hectare.note}
-        </p>
+            <p className="eyebrow !text-[9px] mb-2">Per hectare, as published</p>
         <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
           <div className="rounded-sm border border-border bg-secondary px-3 py-2">
             <div className="flex items-baseline justify-between gap-2">
@@ -335,9 +329,6 @@ function TrackingComparison({ energy }: { energy: EnergyModelAnalysis }) {
             </div>
             <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
               {bol.source}
-            </p>
-            <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-              {bol.note}
             </p>
           </div>
           <div className="rounded-sm border border-border bg-secondary px-3 py-2">
@@ -362,9 +353,7 @@ function TrackingComparison({ energy }: { energy: EnergyModelAnalysis }) {
             <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
               {ong.source}
             </p>
-            <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-              {ong.note}
-            </p>
+                <p className="text-[10px] text-muted-foreground">tracking land per unit energy</p>
           </div>
         </div>
         <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">
@@ -391,16 +380,10 @@ function TrackingComparison({ energy }: { energy: EnergyModelAnalysis }) {
           {md.gcr_ratio.toFixed(4)}
         </div>
         <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-          {md.basis}. {md.note}
-        </p>
-        <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
           Sign parity at a tracker ground coverage of{" "}
           {md.parity.gcr_tracker.toFixed(4)}, that is{" "}
           {md.parity.gcr_ratio.toFixed(3)} of the fixed-tilt value, searched
           over {md.parity.search_range.join(" to ")}. {md.parity.note}
-        </p>
-        <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-          {md.module_efficiency_note}
         </p>
       </div>
 
@@ -435,9 +418,6 @@ function TrackingComparison({ energy }: { energy: EnergyModelAnalysis }) {
             }
           />
         </div>
-        <p className="mt-2 text-[10px] leading-relaxed text-muted-foreground">
-          {t.per_kwp.note}
-        </p>
       </div>
 
       <div
@@ -484,9 +464,6 @@ function TrackingComparison({ energy }: { energy: EnergyModelAnalysis }) {
             </li>
           ))}
         </ul>
-        <p className="mt-2 text-[10px] leading-relaxed text-muted-foreground">
-          {t.seasonal.note}
-        </p>
       </div>
 
       <div
@@ -553,9 +530,7 @@ function GenerationProfile({ energy }: { energy: EnergyModelAnalysis }) {
           {g.time_standard.hour_label}
         </p>
       </div>
-      <p className="text-[11px] leading-relaxed text-muted-foreground">
-        {g.time_standard.note} {g.note}
-      </p>
+          <p className="text-[10px] text-muted-foreground">before applied performance ratio</p>
 
       <div className="edge-fade-x -mx-1 overflow-x-auto px-1">
         <div className="min-w-[34rem]">
@@ -647,9 +622,6 @@ function GenerationProfile({ energy }: { energy: EnergyModelAnalysis }) {
             </li>
           ))}
         </ul>
-        <p className="mt-2 text-[10px] leading-relaxed text-muted-foreground">
-          {g.monthly.note}
-        </p>
       </div>
 
       <div
@@ -743,11 +715,6 @@ function PlantClassCard({
         {cls.contiguity.n_patches} patches at {cls.contiguity.connectivity}-way
         connectivity. {cls.contiguity.note}
       </p>
-      {cls.note && (
-        <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-          {cls.note}
-        </p>
-      )}
     </div>
   )
 }
@@ -771,9 +738,7 @@ function PlantEnergy({ energy }: { energy: EnergyModelAnalysis }) {
           basis {p.reporting_basis} · {ex.convention} convention
         </p>
       </div>
-      <p className="text-[11px] leading-relaxed text-muted-foreground">
-        {p.areas_note}
-      </p>
+          <p className="text-[10px] text-muted-foreground">areas are not additive</p>
 
       <div className="grid grid-cols-1 gap-2 lg:grid-cols-2">
         {p.suitable.area_ha > 0 && (
@@ -883,9 +848,10 @@ function PlantEnergy({ energy }: { energy: EnergyModelAnalysis }) {
             </ul>
           </div>
         </div>
-        <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">
-          {p.uncertainty.statement} {p.uncertainty.dominant_term}
-        </p>
+            <p className="mt-2 text-[10px] text-muted-foreground">
+              resource variability only · dominant term{" "}
+              <span className="telemetry">{p.uncertainty.dominant_term}</span>
+            </p>
       </div>
 
       <div
@@ -978,9 +944,6 @@ export function EnergyModelSection({ energy }: { energy: EnergyModelAnalysis }) 
           sub={`azimuth ${g.surface_azimuth_deg.toFixed(0)}° · plane-of-array ${g.poa_kwh_m2_year.toFixed(2)} kWh/m2/yr`}
         />
       </div>
-      <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">
-        {d.note}
-      </p>
 
       <div
         className="mt-4 border-t pt-4"

--- a/frontend/src/components/EnergyModelSection.tsx
+++ b/frontend/src/components/EnergyModelSection.tsx
@@ -23,6 +23,33 @@ import { cn } from "@/lib/utils"
  * from the beam and diffuse components is a property of the radiation product;
  * drawn inside the chain it reads as a plant loss the site would incur.
  */
+/**
+ * A dense label/value pair.
+ *
+ * This section carried its figures inside sentences -- "Specific yield 1234.56
+ * kWh/kWp/yr at a performance ratio of 0.80 (reference), reporting basis
+ * year_one" -- which put the method between the reader and every number. The
+ * numbers are the same; they are now read down a column rather than out of a
+ * paragraph.
+ */
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <span className="truncate text-[10px] text-muted-foreground">{label}</span>
+      <span className="telemetry shrink-0 text-[11px] text-foreground">{value}</span>
+    </div>
+  )
+}
+
+/** Two-column grid for a run of Stat rows. */
+function StatGrid({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-1 gap-x-6 gap-y-1 sm:grid-cols-2">
+      {children}
+    </div>
+  )
+}
+
 function EnergyWaterfall({ energy }: { energy: EnergyModelAnalysis }) {
   const w = energy.loss_waterfall
   const steps = w.steps
@@ -41,11 +68,12 @@ function EnergyWaterfall({ energy }: { energy: EnergyModelAnalysis }) {
         </p>
       </div>
 
-      <p className="mb-3 text-[11px] leading-relaxed text-muted-foreground">
-        {w.base.note} The daily climatology over {w.base.climatology_window}{" "}
-        gives {w.base.ghi_climatology_kwh_m2_year.toFixed(2)} kWh/m2/yr and is
-        carried as context rather than as the base.
-      </p>
+      <StatGrid>
+        <Stat
+          label="Daily climatology"
+          value={`${w.base.climatology_window} · ${w.base.ghi_climatology_kwh_m2_year.toFixed(2)} kWh/m2/yr`}
+        />
+      </StatGrid>
 
       <div className="mb-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-[10px] text-muted-foreground">
         <span className="flex items-center gap-1.5">
@@ -127,9 +155,9 @@ function EnergyWaterfall({ energy }: { energy: EnergyModelAnalysis }) {
         })}
       </ul>
 
-      <p className="mt-2 text-[10px] leading-relaxed text-muted-foreground">
-        Carried outside the performance ratio:{" "}
-        {w.outside_performance_ratio.join("; ")}.
+      <p className="mt-2 text-[10px] text-muted-foreground">
+        Outside the performance ratio:{" "}
+        <span className="telemetry">{w.outside_performance_ratio.join(" · ")}</span>
       </p>
     </div>
   )
@@ -208,41 +236,34 @@ function PerformanceRatioScale({ energy }: { energy: EnergyModelAnalysis }) {
           </div>
         ))}
       </div>
-      <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">
-        {hasBand ? (
-          <>
-            The Global Solar Atlas implies {lo.toFixed(3)} to {hi.toFixed(3)} at
-            this site. The applied ratio {pr.applied.toFixed(3)} (
-            {pr.applied_source}){" "}
-            {bracketed
-              ? "lies inside that band, so it is bracketed by an external measurement rather than asserted"
-              : `lies outside it by ${Math.min(Math.abs(pr.applied - lo), Math.abs(pr.applied - hi)).toFixed(4)}`}
-            . The derived ratio {pr.derived.toFixed(4)}{" "}
-            {pr.derived < lo
-              ? `sits ${(lo - pr.derived).toFixed(4)} below the lower edge`
-              : pr.derived > hi
-                ? `sits ${(pr.derived - hi).toFixed(4)} above the upper edge`
-                : "lies inside the band as well"}
-            ; it is this chain decomposed plus its declared assumptions, and it
-            does not replace the applied ratio.
-          </>
-        ) : (
-          <>
-            No external band was returned with this run, so the applied ratio{" "}
-            {pr.applied.toFixed(3)} ({pr.applied_source}) is stated without one.
-          </>
+      <StatGrid>
+        {hasBand && (
+          <Stat
+            label="Global Solar Atlas band"
+            value={`${lo.toFixed(3)} – ${hi.toFixed(3)}`}
+          />
         )}
-      </p>
-      <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-        At the values the reference suggests for the two optional terms the
-        derived ratio becomes{" "}
-        {pr.derived_if_optional_at_pvwatts_defaults.toFixed(4)}. Reporting basis{" "}
-        {pr.reporting_basis}, degradation factor{" "}
-        {pr.degradation_factor.toFixed(6)}. The rate is carried as a fraction
-        per year and is shown here as a percentage:{" "}
-        {(pr.degradation_rate_per_year * 100).toFixed(2)}% per year over{" "}
-        {pr.analysis_period_years} years. {pr.degradation_source}
-      </p>
+        <Stat
+          label="Applied ratio"
+          value={`${pr.applied.toFixed(3)}${hasBand ? (bracketed ? " · inside band" : " · outside band") : ""}`}
+        />
+        <Stat label="Derived ratio" value={pr.derived.toFixed(4)} />
+      </StatGrid>
+      <StatGrid>
+        <Stat
+          label="Derived at reference optionals"
+          value={pr.derived_if_optional_at_pvwatts_defaults.toFixed(4)}
+        />
+        <Stat label="Reporting basis" value={pr.reporting_basis} />
+        <Stat
+          label="Degradation factor"
+          value={pr.degradation_factor.toFixed(6)}
+        />
+        <Stat
+          label="Degradation rate"
+          value={`${(pr.degradation_rate_per_year * 100).toFixed(2)}% /yr over ${pr.analysis_period_years} yr`}
+        />
+      </StatGrid>
     </div>
   )
 }
@@ -269,16 +290,15 @@ function EnergyCheckpoints({ energy }: { energy: EnergyModelAnalysis }) {
               {c.value.toFixed(6)}
             </span>
           </div>
-          <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-            {c.residual == null
-              ? "Not an identity, so no residual is reported."
-              : c.residual === 0
-                ? "Residual 0 against the identity."
-                : `Residual ${c.residual.toExponential(2)} against the identity.`}
-            {c.external_band.length >= 2
-              ? ` External band ${Math.min(...c.external_band).toFixed(3)} to ${Math.max(...c.external_band).toFixed(3)}.`
-              : ""}{" "}
-            {c.note}
+          <p className="mt-1 text-[10px] text-muted-foreground">
+            <span className="telemetry">
+              {c.residual == null
+                ? "no residual"
+                : `residual ${c.residual === 0 ? "0" : c.residual.toExponential(2)}`}
+              {c.external_band.length >= 2
+                ? ` · band ${Math.min(...c.external_band).toFixed(3)}–${Math.max(...c.external_band).toFixed(3)}`
+                : ""}
+            </span>
           </p>
         </li>
       ))}
@@ -327,9 +347,6 @@ function TrackingComparison({ energy }: { energy: EnergyModelAnalysis }) {
               {bol.fixed_mwh_acre_year.toFixed(0)} and{" "}
               {bol.tracking_mwh_acre_year.toFixed(0)} MWh/acre/yr)
             </div>
-            <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-              {bol.source}
-            </p>
           </div>
           <div className="rounded-sm border border-border bg-secondary px-3 py-2">
             <div className="flex items-baseline justify-between gap-2">
@@ -350,15 +367,9 @@ function TrackingComparison({ energy }: { energy: EnergyModelAnalysis }) {
                 )
                 .join(" · ")}
             </div>
-            <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-              {ong.source}
-            </p>
                 <p className="text-[10px] text-muted-foreground">tracking land per unit energy</p>
           </div>
         </div>
-        <p className="mt-2 text-[11px] leading-relaxed text-muted-foreground">
-          {pub.disagreement}
-        </p>
       </div>
 
       <div
@@ -379,12 +390,16 @@ function TrackingComparison({ energy }: { energy: EnergyModelAnalysis }) {
           {md.gcr_tracker.toFixed(3)} tracking, a ratio of{" "}
           {md.gcr_ratio.toFixed(4)}
         </div>
-        <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-          Sign parity at a tracker ground coverage of{" "}
-          {md.parity.gcr_tracker.toFixed(4)}, that is{" "}
-          {md.parity.gcr_ratio.toFixed(3)} of the fixed-tilt value, searched
-          over {md.parity.search_range.join(" to ")}. {md.parity.note}
-        </p>
+        <StatGrid>
+          <Stat
+            label="Sign parity at tracker GCR"
+            value={`${md.parity.gcr_tracker.toFixed(4)} · ${md.parity.gcr_ratio.toFixed(3)}× fixed`}
+          />
+          <Stat
+            label="Search range"
+            value={md.parity.search_range.join(" – ")}
+          />
+        </StatGrid>
       </div>
 
       <div
@@ -467,30 +482,33 @@ function TrackingComparison({ energy }: { energy: EnergyModelAnalysis }) {
       </div>
 
       <div
-        className="border-t pt-3 text-[10px] leading-relaxed text-muted-foreground"
+        className="border-t pt-3"
         style={{ borderColor: "var(--border)" }}
       >
-        <p>
-          Axis tilt {t.configuration.axis_tilt_deg.toFixed(0)}°, axis azimuth{" "}
-          {t.configuration.axis_azimuth_deg.toFixed(0)}° (
-          {t.configuration.axis_azimuth_convention}), rotation limit{" "}
-          {t.configuration.max_angle_deg.toFixed(0)}° (
-          {t.configuration.max_angle_source}), backtracking{" "}
-          {t.configuration.backtrack ? "on" : "off"}.{" "}
-          {t.configuration.backtrack_note} {t.configuration.terrain}
-        </p>
-        <p className="mt-1">
-          {t.performance_ratio.note} Measured across the wind assumption:{" "}
-          {t.performance_ratio.transfer_between_configurations
-            .map(
-              (r) =>
-                `${r.wind} ${r.performance_ratio_fixed.toFixed(6)} against ${r.performance_ratio_tracker.toFixed(6)}, ${r.difference_pct.toFixed(4)}%`
-            )
-            .join("; ")}
-          .
-        </p>
-        <p className="mt-1">{t.excluded}</p>
-        <p className="mt-1">{t.resolution_note}</p>
+        <StatGrid>
+          <Stat
+            label="Axis tilt / azimuth"
+            value={`${t.configuration.axis_tilt_deg.toFixed(0)}° / ${t.configuration.axis_azimuth_deg.toFixed(0)}° ${t.configuration.axis_azimuth_convention}`}
+          />
+          <Stat
+            label="Rotation limit"
+            value={`${t.configuration.max_angle_deg.toFixed(0)}°`}
+          />
+          <Stat
+            label="Backtracking"
+            value={t.configuration.backtrack ? "on" : "off"}
+          />
+        </StatGrid>
+        <StatGrid>
+          {t.performance_ratio.transfer_between_configurations.map((r) => (
+            <Stat
+              key={r.wind}
+              label={`Fixed vs tracker PR, ${r.wind} wind`}
+              value={`${r.performance_ratio_fixed.toFixed(6)} / ${r.performance_ratio_tracker.toFixed(6)}, ${r.difference_pct.toFixed(4)}%`}
+            />
+          ))}
+          <Stat label="Meteorology cell" value="0.5° × 0.625°" />
+        </StatGrid>
       </div>
     </div>
   )
@@ -651,9 +669,10 @@ function GenerationProfile({ energy }: { energy: EnergyModelAnalysis }) {
             </div>
           ))}
         </div>
-        <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-          {g.share_of_annual_generation_by_hour.units}, on the same time
-          standard as the surface above.
+        <p className="mt-1 text-[10px] text-muted-foreground">
+          <span className="telemetry">
+            {g.share_of_annual_generation_by_hour.units}
+          </span>
         </p>
       </div>
     </div>
@@ -705,16 +724,26 @@ function PlantClassCard({
           sub="GWh/yr"
         />
       </div>
-      <p className="mt-2 text-[10px] leading-relaxed text-muted-foreground">
-        Specific yield {cls.specific_yield_kwh_kwp_year.toFixed(2)} kWh/kWp/yr
-        at a performance ratio of {cls.performance_ratio.toFixed(2)} (
-        {cls.performance_ratio_source}), reporting basis {cls.reporting_basis}.
-      </p>
-      <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-        Largest contiguous patch {cls.contiguity.largest_ha.toFixed(3)} ha over{" "}
-        {cls.contiguity.n_patches} patches at {cls.contiguity.connectivity}-way
-        connectivity. {cls.contiguity.note}
-      </p>
+      <StatGrid>
+        <Stat
+          label="Specific yield"
+          value={`${cls.specific_yield_kwh_kwp_year.toFixed(2)} kWh/kWp/yr`}
+        />
+        <Stat
+          label="Performance ratio"
+          value={`${cls.performance_ratio.toFixed(2)} · ${cls.reporting_basis}`}
+        />
+      </StatGrid>
+      <StatGrid>
+        <Stat
+          label="Largest contiguous patch"
+          value={`${cls.contiguity.largest_ha.toFixed(3)} ha`}
+        />
+        <Stat
+          label="Patches"
+          value={`${cls.contiguity.n_patches} at ${cls.contiguity.connectivity}-way`}
+        />
+      </StatGrid>
     </div>
   )
 }
@@ -762,11 +791,12 @@ function PlantEnergy({ energy }: { energy: EnergyModelAnalysis }) {
               {p.restrictive.area_ha.toFixed(3)} ha
             </span>
           </div>
-          <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-            {p.restrictive.capacity_dc_mw == null
-              ? "No capacity is reported for this class."
-              : `Capacity ${p.restrictive.capacity_dc_mw.toFixed(2)} MW DC.`}{" "}
-            {p.restrictive.note}
+          <p className="mt-1 text-[10px] text-muted-foreground">
+            <span className="telemetry">
+              {p.restrictive.capacity_dc_mw == null
+                ? "no capacity reported"
+                : `${p.restrictive.capacity_dc_mw.toFixed(2)} MW DC`}
+            </span>
           </p>
         </div>
       )}
@@ -803,24 +833,34 @@ function PlantEnergy({ energy }: { energy: EnergyModelAnalysis }) {
             </li>
           ))}
         </ul>
-        <p className="mt-2 text-[10px] leading-relaxed text-muted-foreground">
-          Method applied: {ex.method_applied}. Mean{" "}
-          {ex.mean_kwh_m2_year.toFixed(2)} kWh/m2/yr, standard deviation{" "}
-          {ex.std_kwh_m2_year.toFixed(2)}, coefficient of variation{" "}
-          {ex.cv_pct.toFixed(3)}%. {ex.convention_note}
-        </p>
-        <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-          {ex.p50_note} {ex.normality.test} on the annual totals gives a
-          statistic of {ex.normality.statistic.toFixed(5)} at p ={" "}
-          {ex.normality.p_value.toFixed(4)}: {ex.normality.interpretation}.
-        </p>
-        <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-          {ex.crosswalk.note} Exceedance P90{" "}
-          {ex.crosswalk.exceedance_p90_kwh_m2_year.toFixed(2)} equals the
-          statistical 10th percentile{" "}
-          {ex.crosswalk.statistical_p10_kwh_m2_year.toFixed(2)} kWh/m2/yr.
-          Energy is treated as {ex.linearity_assumption}.
-        </p>
+        <StatGrid>
+          <Stat label="Method" value={ex.method_applied} />
+          <Stat
+            label="Mean"
+            value={`${ex.mean_kwh_m2_year.toFixed(2)} kWh/m2/yr`}
+          />
+          <Stat
+            label="Standard deviation"
+            value={ex.std_kwh_m2_year.toFixed(2)}
+          />
+          <Stat label="Coefficient of variation" value={`${ex.cv_pct.toFixed(3)}%`} />
+        </StatGrid>
+        <StatGrid>
+          <Stat
+            label={`Normality · ${ex.normality.test}`}
+            value={`W ${ex.normality.statistic.toFixed(5)} · p ${ex.normality.p_value.toFixed(4)}`}
+          />
+        </StatGrid>
+        <StatGrid>
+          <Stat
+            label="Exceedance P90"
+            value={`${ex.crosswalk.exceedance_p90_kwh_m2_year.toFixed(2)} kWh/m2/yr`}
+          />
+          <Stat
+            label="Statistical P10"
+            value={`${ex.crosswalk.statistical_p10_kwh_m2_year.toFixed(2)} kWh/m2/yr`}
+          />
+        </StatGrid>
       </div>
 
       <div
@@ -833,7 +873,7 @@ function PlantEnergy({ energy }: { energy: EnergyModelAnalysis }) {
         <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
           <div>
             <div className="eyebrow !text-[9px]">included</div>
-            <ul className="mt-1 flex flex-col gap-0.5 text-[10px] leading-relaxed text-muted-foreground">
+            <ul className="mt-1 flex flex-col gap-0.5 text-[10px] text-muted-foreground">
               {p.uncertainty.included.map((u) => (
                 <li key={u}>{u}</li>
               ))}
@@ -841,7 +881,7 @@ function PlantEnergy({ energy }: { energy: EnergyModelAnalysis }) {
           </div>
           <div>
             <div className="eyebrow !text-[9px]">excluded</div>
-            <ul className="mt-1 flex flex-col gap-0.5 text-[10px] leading-relaxed text-muted-foreground">
+            <ul className="mt-1 flex flex-col gap-0.5 text-[10px] text-muted-foreground">
               {p.uncertainty.excluded.map((u) => (
                 <li key={u}>{u}</li>
               ))}
@@ -855,44 +895,58 @@ function PlantEnergy({ energy }: { energy: EnergyModelAnalysis }) {
       </div>
 
       <div
-        className="border-t pt-3 text-[10px] leading-relaxed text-muted-foreground"
+        className="border-t pt-3"
         style={{ borderColor: "var(--border)" }}
       >
-        <p>
-          Capacity density {p.capacity_density.value_mw_dc_per_ha.toFixed(6)}{" "}
-          MW DC per hectare on the{" "}
-          {p.capacity_density.area_basis.replace(/_/g, " ")} basis, key{" "}
-          {p.capacity_density.basis}, mounting{" "}
-          {p.capacity_density.mounting.replace(/_/g, " ")}, buildable fraction{" "}
-          {p.capacity_density.buildable_fraction.toFixed(2)}.{" "}
-          {p.capacity_density.note}
-        </p>
-        <p className="mt-1">{p.capacity_density.source}</p>
-        <p className="mt-1">
-          Buildable fraction source: {p.capacity_density.buildable_fraction_source}
-        </p>
-        <p className="mt-1">
-          Fleet DC/AC ratio {p.capacity_density.fleet_dc_ac_ratio.toFixed(6)}.{" "}
-          {p.capacity_density.fleet_dc_ac_ratio_source}
-        </p>
-        <p className="mt-1">
-          Energy density cross-check:{" "}
-          {p.energy_density_cross_check.site_mwh_ha_year.toFixed(1)} against a
-          published {p.energy_density_cross_check.reference_mwh_ha_year.toFixed(1)}{" "}
-          MWh/ha/yr, a ratio of {p.energy_density_cross_check.ratio.toFixed(3)}{" "}
-          on the {p.energy_density_cross_check.area_basis.replace(/_/g, " ")}{" "}
-          basis. {p.energy_density_cross_check.note}
-        </p>
-        <p className="mt-1">
-          Horizon shading derate {p.shading.derate.toFixed(4)},{" "}
-          {p.shading.applied ? "applied" : "not applied"}. {p.shading.note}
-        </p>
-        <p className="mt-1">
-          Slope limits {p.thresholds.slope_acceptable_deg} and{" "}
-          {p.thresholds.slope_restrictive_deg} degrees.{" "}
-          {p.thresholds.note}
-        </p>
-        <p className="mt-1">{p.limitations}</p>
+        <StatGrid>
+          <Stat
+            label="Capacity density"
+            value={`${p.capacity_density.value_mw_dc_per_ha.toFixed(6)} MW DC/ha`}
+          />
+          <Stat
+            label="Area basis"
+            value={p.capacity_density.area_basis.replace(/_/g, " ")}
+          />
+          <Stat
+            label="Mounting"
+            value={p.capacity_density.mounting.replace(/_/g, " ")}
+          />
+          <Stat
+            label="Buildable fraction"
+            value={p.capacity_density.buildable_fraction.toFixed(2)}
+          />
+        </StatGrid>
+        <StatGrid>
+          <Stat
+            label="Fleet DC/AC ratio"
+            value={p.capacity_density.fleet_dc_ac_ratio.toFixed(6)}
+          />
+          <Stat
+            label="Energy density, site"
+            value={`${p.energy_density_cross_check.site_mwh_ha_year.toFixed(1)} MWh/ha/yr`}
+          />
+          <Stat
+            label="Energy density, published"
+            value={`${p.energy_density_cross_check.reference_mwh_ha_year.toFixed(1)} MWh/ha/yr`}
+          />
+          <Stat
+            label={`Ratio, ${p.energy_density_cross_check.area_basis.replace(/_/g, " ")} basis`}
+            value={p.energy_density_cross_check.ratio.toFixed(3)}
+          />
+          {/*
+            "not applied" is not a formatting choice: a derate of 1.0000 that
+            was never applied and one applied at 1.0000 are different claims
+            about whether the horizon was looked at.
+          */}
+          <Stat
+            label={`Horizon shading derate, ${p.shading.applied ? "applied" : "not applied"}`}
+            value={p.shading.derate.toFixed(4)}
+          />
+          <Stat
+            label="Slope limits, legal constraints not checked"
+            value={`${p.thresholds.slope_acceptable_deg}° / ${p.thresholds.slope_restrictive_deg}°`}
+          />
+        </StatGrid>
       </div>
     </div>
   )
@@ -985,44 +1039,52 @@ export function EnergyModelSection({ energy }: { energy: EnergyModelAnalysis }) 
       </div>
 
       <div
-        className="mt-4 border-t pt-4 text-[10px] leading-relaxed text-muted-foreground"
+        className="border-t pt-3"
         style={{ borderColor: "var(--border)" }}
       >
-        <p>
-          Horizontal plane over the hourly window{" "}
-          {g.ghi_hourly_kwh_m2_year.toFixed(2)} kWh/m2/yr; the same array laid
-          flat receives {g.poa_horizontal_kwh_m2_year.toFixed(2)} kWh/m2/yr.
-        </p>
-        <p className="mt-1">
-          Temperature coefficient {mt.gamma_pdc_per_c} per °C, module type{" "}
-          {mt.module_type}. The alternatives are{" "}
-          {Object.entries(mt.alternatives)
-            .map(([k, v]) => `${k} ${v}`)
-            .join(", ")}
-          . {mt.source}
-        </p>
-        <p className="mt-1">
-          Transposition{" "}
-          {energy.loss_waterfall.assumptions.transposition_model.value}:{" "}
-          {energy.loss_waterfall.assumptions.transposition_model.source}
-        </p>
-        <p className="mt-1">
-          Ground albedo {energy.loss_waterfall.assumptions.albedo.value}:{" "}
-          {energy.loss_waterfall.assumptions.albedo.source}
-        </p>
-        <p className="mt-1">
-          Wind field {energy.loss_waterfall.assumptions.wind_source.value}:{" "}
-          {energy.loss_waterfall.assumptions.wind_source.source}
-        </p>
-        <p className="mt-1">
-          Placing the declared losses physically rather than as one flat factor
-          moves the yield by{" "}
-          {energy.loss_waterfall.assumptions.flat_placement_bias_pct.value}%:{" "}
-          {energy.loss_waterfall.assumptions.flat_placement_bias_pct.source}
-        </p>
-        <p className="mt-1">{energy.assumptions.resolution_note}</p>
-        <p className="mt-1">{energy.assumptions.note}</p>
-        <p className="mt-1">{energy.grid_note}</p>
+        <StatGrid>
+          <Stat
+            label="Horizontal plane, hourly window"
+            value={`${g.ghi_hourly_kwh_m2_year.toFixed(2)} kWh/m2/yr`}
+          />
+          <Stat
+            label="Same array laid flat"
+            value={`${g.poa_horizontal_kwh_m2_year.toFixed(2)} kWh/m2/yr`}
+          />
+        </StatGrid>
+        <StatGrid>
+          <Stat
+            label="Temperature coefficient"
+            value={`${mt.gamma_pdc_per_c} /°C`}
+          />
+          <Stat label="Module type" value={mt.module_type ?? "custom"} />
+          {Object.entries(mt.alternatives).map(([k, v]) => (
+            <Stat key={k} label={`Alternative, ${k}`} value={`${v} /°C`} />
+          ))}
+          <Stat
+            label="Transposition"
+            value={energy.loss_waterfall.assumptions.transposition_model.value}
+          />
+          <Stat
+            label="Ground albedo"
+            value={String(energy.loss_waterfall.assumptions.albedo.value)}
+          />
+          {/*
+            The wind qualifier stays: WS2M alone reads as the wind the model
+            wants, and the Faiman coefficient expects a module-height wind. The
+            height mismatch is the figure's meaning, not commentary on it.
+          */}
+          <Stat
+            label="Wind field, 2 m not module height"
+            value={energy.loss_waterfall.assumptions.wind_source.value}
+          />
+          <Stat
+            label="Physical vs flat loss placement"
+            value={`${energy.loss_waterfall.assumptions.flat_placement_bias_pct.value}%`}
+          />
+          <Stat label="Radiation cell" value="1°, one cell over the AOI" />
+          <Stat label="Meteorology cell" value="0.5° × 0.625°" />
+        </StatGrid>
         <PowerProvenanceNote provenance={energy.power_provenance} />
       </div>
     </section>

--- a/frontend/src/components/LulcSection.tsx
+++ b/frontend/src/components/LulcSection.tsx
@@ -1,4 +1,4 @@
-import type { LULCAnalysis } from "@/lib/types"
+import type { LULCAgreement, LULCAnalysis } from "@/lib/types"
 
 const CALENDAR_NOTES: Record<string, string> = {
   A: "Wheat → Soybean → Fallow → Oat → Soybean",
@@ -100,7 +100,18 @@ export function LulcSection({ lulc, areaId }: LulcSectionProps) {
         </div>
         {hasCompare && (
           <div className="rounded-sm border border-border bg-secondary p-3 md:col-span-2 xl:col-span-1">
-            <p className="eyebrow mb-1">MapBiomas vs predicted (shared pixels)</p>
+            {/*
+              Named for what it measures. "MapBiomas vs predicted" reads as
+              validation, and it is not: these are two marginal distributions
+              compared side by side, which agree whenever the two maps hold the
+              same amount of a class regardless of where. The agreement panel
+              below is the one that answers whether they agree.
+            */}
+            <p className="eyebrow mb-1">Class composition · reference vs predicted</p>
+            <p className="mb-1 text-[10px] text-muted-foreground">
+              How much of each class each map holds — not whether they agree on
+              where.
+            </p>
             {/*
               The reference is native at 30 m and is resampled onto the 10 m
               classification grid, so roughly nine pixels carry one label
@@ -169,11 +180,113 @@ export function LulcSection({ lulc, areaId }: LulcSectionProps) {
         )}
       </div>
 
+      {lulc.agreement && <AgreementPanel a={lulc.agreement} />}
+
       <p className="mt-3 text-[10px] text-muted-foreground">
         *Agricultural = annual cropland (39+41) + mosaic (21). Annual MapBiomas
         labels compress crop rotations into a single cover class.
       </p>
     </section>
+  )
+}
+
+/**
+ * Agreement against the reference, beside the composition it corrects.
+ *
+ * The panel above compares how much of each class each map holds. That is not
+ * agreement: a classifier that swaps soybean for other temporary crops in equal
+ * measure reproduces the reference composition exactly and is wrong on every
+ * cell it swapped. Pontius & Millones (2011) name the two halves — quantity, in
+ * the panel above; allocation, invisible until here.
+ */
+function AgreementPanel({ a }: { a: LULCAgreement }) {
+  const pct = (v: number | null) => (v == null ? "—" : `${v.toFixed(1)}%`)
+  const ci = (v?: [number, number]) =>
+    v ? `${v[0].toFixed(0)}–${v[1].toFixed(0)}` : ""
+
+  return (
+    <div
+      className="mt-4 rounded-sm border border-border bg-secondary p-3"
+      style={{ borderColor: "var(--border)" }}
+    >
+      <div className="mb-2 flex flex-wrap items-baseline justify-between gap-2">
+        <p className="eyebrow">Agreement with MapBiomas</p>
+        {/* The denominator, stated where the figures are. These are native
+            30 m cells, not the 10 m pixels resampled from them: nine pixels
+            carrying one label are one observation, and counting pixels would
+            narrow every interval below by about three. */}
+        <p className="telemetry text-[10px] text-muted-foreground">
+          n = {a.n_reference_cells.toLocaleString()} reference cells
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+        <Metric
+          label="Overall accuracy"
+          value={`${a.overall_pct.toFixed(1)}%`}
+          sub={`95% CI ${ci(a.overall_ci)}`}
+        />
+        <Metric
+          label="Quantity disagr."
+          value={`${a.quantity_disagreement_pct.toFixed(1)}%`}
+          sub="different amounts"
+        />
+        <Metric
+          label="Allocation disagr."
+          value={`${a.allocation_disagreement_pct.toFixed(1)}%`}
+          sub="same amounts, wrong places"
+        />
+      </div>
+
+      <div className="mt-3">
+        <div className="mb-1 grid grid-cols-[7rem_1fr_1fr] gap-2 text-[10px] text-muted-foreground">
+          <span />
+          <span>Producer&rsquo;s (found)</span>
+          <span>User&rsquo;s (correct)</span>
+        </div>
+        <div className="flex flex-col gap-1">
+          {a.per_class.map((c) => (
+            <div
+              key={c.class_id}
+              className="grid grid-cols-[7rem_1fr_1fr] items-baseline gap-2 text-[11px]"
+            >
+              <span className="flex items-center gap-1.5 truncate text-muted-foreground">
+                <span
+                  className="size-2 shrink-0 rounded-[2px]"
+                  style={{ backgroundColor: c.color }}
+                />
+                {c.class_id} {c.name}
+              </span>
+              <span className="telemetry text-foreground">
+                {pct(c.producers_pct)}
+                <span className="ml-1 text-[9px] text-muted-foreground">
+                  {ci(c.producers_ci)}
+                </span>
+              </span>
+              <span className="telemetry text-foreground">
+                {pct(c.users_pct)}
+                <span className="ml-1 text-[9px] text-muted-foreground">
+                  {ci(c.users_ci)}
+                </span>
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {a.n_outside_legend > 0 && (
+        <p className="mt-2 text-[10px] text-muted-foreground">
+          {a.n_outside_legend.toLocaleString()} further reference cells carry a
+          class the classifier has no label for. They are excluded rather than
+          counted as errors, so this assessment is silent about them.
+        </p>
+      )}
+      <p className="mt-1.5 text-[10px] text-muted-foreground">
+        Producer&rsquo;s and user&rsquo;s accuracy are reported together because
+        neither means anything alone: a map calling everything soybean scores
+        100% producer&rsquo;s for soybean. Intervals are Wilson score at 95%.
+      </p>
+    </div>
   )
 }
 

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -43,7 +43,6 @@ interface MapViewProps {
   activeExample: string
   customPolygon: GeoJSONGeometry | null
   onPolygonDrawn: (geom: GeoJSONGeometry | null) => void
-  onSelectExample: (id: string) => void
   flyTo: { lat: number; lon: number; key: number } | null
   result: PredictResult | null
   overlayOpacity: number
@@ -987,7 +986,6 @@ export function MapView({
   activeExample,
   customPolygon,
   onPolygonDrawn,
-  onSelectExample,
   flyTo,
   result,
   overlayOpacity,
@@ -1228,10 +1226,6 @@ export function MapView({
             ? "Terrain irradiation"
             : "Overlay"
 
-  // Example outlines are shown only when no custom polygon is active, as faint
-  // clickable shortcuts to the article's validated sites.
-  const showExamples = !customPolygon
-
   const aoiGeometry = useMemo(() => {
     if (customPolygon) return customPolygon
     if (activeExample) {
@@ -1282,21 +1276,6 @@ export function MapView({
           />
         </LayersControl.BaseLayer>
       </LayersControl>
-
-      {showExamples &&
-        areas.map((area) => (
-          <GeoJSON
-            key={area.id}
-            data={area.geometry as GeoJSON.Geometry}
-            style={{
-              color: activeExample === area.id ? "#22d3ee" : "#c2703d",
-              weight: 1.5,
-              fillOpacity: 0.04,
-              dashArray: "4 3",
-            }}
-            eventHandlers={{ click: () => onSelectExample(area.id) }}
-          />
-        ))}
 
       {compositionLayer}
       {solarLayer}

--- a/frontend/src/components/SolarSections.tsx
+++ b/frontend/src/components/SolarSections.tsx
@@ -173,12 +173,16 @@ export function SolarResourceSection({ solar }: { solar: SolarAnalysis }) {
                 `${t.deviation_deg.toFixed(0)}° costs ${t.loss_pct.toFixed(2)}%`
             )
             .join(" · ")}
-          . The optimum is a peak, not a requirement.
         </p>
       )}
 
-      <div className="mt-2 text-[11px] leading-relaxed text-muted-foreground">
-        <p>{solar.grid_note}</p>
+      {/*
+        The grid cell, kept where the paragraph about it was removed: two AOIs
+        tens of kilometres apart resolve to one radiation cell and return the
+        same series, so identical numbers would otherwise have no explanation.
+      */}
+      <div className="mt-2 text-[10px] text-muted-foreground">
+        <p className="telemetry">1° radiation cell, not site-specific</p>
         <PowerProvenanceNote provenance={solar.power_provenance} />
       </div>
     </section>
@@ -259,18 +263,18 @@ export function SolarTerrainSection({
           )}
         </div>
       </div>
-      <p className="mt-3 text-[10px] leading-relaxed text-muted-foreground">
-        The atmospheric resource has no spatial structure at this scale;
-        what varies over the area is the irradiation reaching an inclined
-        surface, because the surface is terrain. Horizon shading is a
-        share of the beam component
-        {/* Absent on runs saved before the field existed, where zero
-            would read as a measured beam share of nothing. */}
-        {terrain.beam_fraction > 0
-          ? `, which carries ${(terrain.beam_fraction * 100).toFixed(0)}% of the horizontal irradiation here`
-          : ""}
-        .
-      </p>
+      {/* The beam share as a figure. It was a paragraph explaining that the
+          atmospheric resource has no structure at this scale and that what
+          varies is the inclined surface -- method, and the same sentence for
+          every AOI. The number it ended on is what changes. */}
+      {terrain.beam_fraction > 0 && (
+        <p className="mt-3 text-[10px] text-muted-foreground">
+          <span className="telemetry">
+            Beam share {(terrain.beam_fraction * 100).toFixed(0)}%
+          </span>{" "}
+          of horizontal irradiation · horizon shading applies to this component
+        </p>
+      )}
       <PowerProvenanceNote
         provenance={terrain.power_provenance}
       />
@@ -323,10 +327,14 @@ export function SolarSitingSection({
           </li>
         ))}
       </ul>
-      <p className="mt-3 text-[10px] leading-relaxed text-muted-foreground">
-        Slope limits {siting.thresholds.slope_acceptable_deg}{" "}
-        and {siting.thresholds.slope_restrictive_deg} degrees.{" "}
-        {siting.thresholds.note}
+      {/* The thresholds as figures, and the one thing the classes do not
+          account for -- without it "suitable" reads as permitted. */}
+      <p className="mt-3 text-[10px] text-muted-foreground">
+        <span className="telemetry">
+          Slope limits {siting.thresholds.slope_acceptable_deg}° /{" "}
+          {siting.thresholds.slope_restrictive_deg}°
+        </span>{" "}
+        · legal constraints not checked
       </p>
     </section>
   )

--- a/frontend/src/components/SolarSections.tsx
+++ b/frontend/src/components/SolarSections.tsx
@@ -106,7 +106,15 @@ export function SolarResourceSection({ solar }: { solar: SolarAnalysis }) {
               fontSize: 11,
             }}
           />
-          <Legend wrapperStyle={{ fontSize: 11, paddingTop: 4 }} iconType="plainline" />
+          {/* Above the plot: a bottom legend shares the band the axis title
+              occupies, and "Month" was drawn through the series keys. */}
+          <Legend
+            verticalAlign="top"
+            align="right"
+            height={20}
+            wrapperStyle={{ fontSize: 11, paddingBottom: 2 }}
+            iconType="plainline"
+          />
           {/* The verified triple, and a dash each: GHI, DNI and DHI are not
               independent -- GHI is the sum of DHI and the projected DNI -- so
               they are read together and have to stay separable in greyscale. */}

--- a/frontend/src/components/SolarSections.tsx
+++ b/frontend/src/components/SolarSections.tsx
@@ -287,10 +287,13 @@ export function SolarSitingSection({
   return (
     <section className="rounded-sm border border-border bg-secondary/50 p-4">
       <p className="eyebrow mb-3">Photovoltaic siting</p>
+      {/* Full-width, like the water occurrence tile: a 4:3 box across a whole
+          panel runs off the bottom of the window on a wide screen. */}
       <PanelTile
         title="Suitability classes"
         uri={siting.overlay_uri}
         empty="No siting raster"
+        fullWidth
       />
       <div className="mb-3 mt-3 grid grid-cols-2 gap-3">
         <WaterFigure

--- a/frontend/src/components/WindScreening.tsx
+++ b/frontend/src/components/WindScreening.tsx
@@ -2,28 +2,40 @@
  * The wind screening, as shown on screen.
  *
  * Lives outside AnalysisPage so the energy screen and the analysis screen render
- * it from one definition. Duplicating it would let the two drift, and this is
- * the block whose figures each carry the assumption that produced them.
+ * it from one definition. Duplicating it would let the two drift.
+ *
+ * STATISTICS, NOT PROSE. This block used to carry nineteen explanatory passages
+ * from the payload -- method, convention, citation, derivation -- several of
+ * which restated what the headings already said: a paragraph opening "screening
+ * indication, not a resource assessment" sat under a heading reading "Wind
+ * screening" beside chips reading "gross" and "unvalidated". The qualifiers
+ * that do work are structural and stay: the heading, the chips, and the word
+ * Gross in the figure labels.
+ *
+ * The passages that carried numbers inside sentences -- the Weibull fit check,
+ * the air density range, the operating regime -- are still here as figures.
+ * Nothing measured was dropped; it stopped being written out longhand.
  */
 import type { WindAnalysis } from "@/lib/types"
-import { Chip, PowerProvenanceNote, rampStop, WaterFigure } from "@/components/analysisPrimitives"
+import { Chip, PowerProvenanceNote, WaterFigure } from "@/components/analysisPrimitives"
 import { PALETTE_STOPS } from "@/lib/palettes"
-import { cn } from "@/lib/utils"
 
-/**
- * The wind screening, in its own section.
- *
- * Its capacity factor is gross, carries no external validation and rests on a
- * power-law extrapolation above the highest level the reanalysis holds, while
- * the photovoltaic figure beside it is computed at a ratio benchmarked against
- * the Global Solar Atlas. The two are never placed in a shared comparison and
- * the qualifier is printed before the first number.
- */
+/** A dense label/value pair for a figure that does not need its own tile. */
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <span className="truncate text-[10px] text-muted-foreground">{label}</span>
+      <span className="telemetry shrink-0 text-[11px] text-foreground">{value}</span>
+    </div>
+  )
+}
+
 export function WindScreening({ wind }: { wind: WindAnalysis }) {
   const m = wind.measured
   const h = wind.hub
   const q = wind.data_quality
   const shear = q.shear
+  const fit = m.weibull_fit_check_50m
   const roseMax = Math.max(
     ...m.direction_energy_rose_50m.map((s) => Math.max(s.energy_pct, s.hours_pct)),
     0.001
@@ -35,26 +47,24 @@ export function WindScreening({ wind }: { wind: WindAnalysis }) {
 
   return (
     <section className="rounded-sm border border-border bg-secondary/50 p-4">
-      <div className="mb-2 flex flex-wrap items-baseline justify-between gap-2">
+      <div className="mb-3 flex flex-wrap items-baseline justify-between gap-2">
         <div className="flex flex-wrap items-baseline gap-2">
           <p className="eyebrow">Wind screening</p>
           <Chip>separate product</Chip>
           <Chip>gross</Chip>
           <Chip>unvalidated</Chip>
         </div>
+        {/*
+          The grid cell, kept where the paragraph about it was removed. Two AOIs
+          tens of kilometres apart fall in one MERRA-2 cell and return the same
+          series, so without this the identical numbers have no explanation.
+        */}
         <p className="telemetry text-[10px] text-muted-foreground">
-          {wind.record_window} · {wind.record_years.toFixed(3)} years · cell
-          centre {wind.grid_cell_centre[1]?.toFixed(3)},{" "}
+          {wind.record_window} · {wind.record_years.toFixed(3)} years · one
+          0.5×0.625° cell at {wind.grid_cell_centre[1]?.toFixed(3)},{" "}
           {wind.grid_cell_centre[0]?.toFixed(3)}
         </p>
       </div>
-
-      <p className="text-[11px] leading-relaxed text-muted-foreground">
-        {wind.qualifier}
-      </p>
-      <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
-        {wind.assumptions.comparison_note}
-      </p>
 
       <div
         className="mt-3 border-t pt-3"
@@ -67,39 +77,41 @@ export function WindScreening({ wind }: { wind: WindAnalysis }) {
           <WaterFigure
             label="Mean speed 10 m"
             value={`${m.mean_speed_10m_ms.toFixed(4)} m/s`}
-            sub="level held in the record"
           />
           <WaterFigure
             label="Mean speed 50 m"
             value={`${m.mean_speed_50m_ms.toFixed(4)} m/s`}
-            sub="highest level held in the record"
           />
           <WaterFigure
             label="Weibull 50 m"
             value={`k ${m.weibull_k_50m.toFixed(4)}`}
-            sub={`c ${m.weibull_c_50m_ms.toFixed(4)} m/s · ${m.weibull_fit_check_50m.estimator}`}
+            sub={`c ${m.weibull_c_50m_ms.toFixed(4)} m/s`}
           />
           <WaterFigure
             label="Power density 50 m"
             value={`${m.wind_power_density_50m_w_m2.toFixed(2)} W/m2`}
-            sub={`energy pattern factor ${m.energy_pattern_factor_50m.toFixed(4)}`}
+            sub={`pattern factor ${m.energy_pattern_factor_50m.toFixed(4)}`}
           />
         </div>
-        <p className="mt-2 text-[10px] leading-relaxed text-muted-foreground">
-          {m.qualifier}
-        </p>
-        <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-          Weibull fit against the record: mean{" "}
-          {m.weibull_fit_check_50m.weibull_mean_ms.toFixed(4)} against{" "}
-          {m.weibull_fit_check_50m.empirical_mean_ms.toFixed(4)} m/s (
-          {m.weibull_fit_check_50m.mean_error_pct.toFixed(3)}%), mean cube{" "}
-          {m.weibull_fit_check_50m.weibull_mean_cube_m3s3.toFixed(3)} against{" "}
-          {m.weibull_fit_check_50m.empirical_mean_cube_m3s3.toFixed(3)} m3/s3 (
-          {m.weibull_fit_check_50m.mean_cube_error_pct.toFixed(3)}%). Air
-          density mean {m.air_density_mean_kg_m3.toFixed(4)} kg/m3, range{" "}
-          {m.air_density_min_kg_m3.toFixed(4)} to{" "}
-          {m.air_density_max_kg_m3.toFixed(4)}. {m.humidity_note}
-        </p>
+        {/* The fit check and the density range, which were a paragraph. */}
+        <div className="mt-3 grid grid-cols-1 gap-x-6 gap-y-1 sm:grid-cols-2">
+          <Stat
+            label="Weibull mean vs record"
+            value={`${fit.weibull_mean_ms.toFixed(4)} / ${fit.empirical_mean_ms.toFixed(4)} m/s · ${fit.mean_error_pct.toFixed(3)}%`}
+          />
+          <Stat
+            label="Weibull mean cube vs record"
+            value={`${fit.weibull_mean_cube_m3s3.toFixed(3)} / ${fit.empirical_mean_cube_m3s3.toFixed(3)} m3/s3 · ${fit.mean_cube_error_pct.toFixed(3)}%`}
+          />
+          <Stat
+            label="Air density mean"
+            value={`${m.air_density_mean_kg_m3.toFixed(4)} kg/m3`}
+          />
+          <Stat
+            label="Air density range"
+            value={`${m.air_density_min_kg_m3.toFixed(4)} – ${m.air_density_max_kg_m3.toFixed(4)} kg/m3`}
+          />
+        </div>
       </div>
 
       <div
@@ -109,46 +121,47 @@ export function WindScreening({ wind }: { wind: WindAnalysis }) {
         <p className="eyebrow !text-[9px] mb-2">
           At the {wind.hub_height_m.toFixed(0)} m hub · extrapolated
         </p>
-        <p className="mb-2 text-[11px] leading-relaxed text-muted-foreground">
-          {h.extrapolation.statement}
-        </p>
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           <WaterFigure
             label="Hub speed"
             value={`${h.mean_speed_ms.toFixed(4)} m/s`}
-            sub={`power law at ${wind.assumptions.shear_exponent.toFixed(4)}, ${h.extrapolation.height_ratio.toFixed(1)}x above the top level`}
+            sub={`power law α ${wind.assumptions.shear_exponent.toFixed(4)}, ${h.extrapolation.height_ratio.toFixed(1)}× the top level`}
           />
           <WaterFigure
             label="Gross capacity factor"
             value={`${h.gross_capacity_factor_pct.toFixed(3)}%`}
-            sub={`no plant loss applied; ${h.gross_capacity_factor_no_density_correction_pct.toFixed(3)}% without the density correction`}
+            sub={`${h.gross_capacity_factor_no_density_correction_pct.toFixed(3)}% undensity-corrected`}
           />
           <WaterFigure
             label="Gross annual energy"
             value={`${h.gross_annual_energy_mwh_per_turbine.toFixed(1)} MWh`}
-            sub={`per turbine over ${h.hours_per_year.toFixed(0)} hours; not to be multiplied by a plant size`}
+            sub={`per turbine · ${h.hours_per_year.toFixed(0)} h/yr`}
           />
           <WaterFigure
             label="Power density"
             value={`${h.wind_power_density_w_m2.toFixed(2)} W/m2`}
-            sub={`Weibull k ${h.weibull_k.toFixed(4)}, c ${h.weibull_c_ms.toFixed(4)} m/s`}
+            sub={`k ${h.weibull_k.toFixed(4)}, c ${h.weibull_c_ms.toFixed(4)} m/s`}
           />
         </div>
-        <p className="mt-2 text-[10px] leading-relaxed text-muted-foreground">
-          Operating regime: above cut-in{" "}
-          {h.operating_regime.above_cut_in_pct.toFixed(3)}% of hours, at or
-          above rated {h.operating_regime.at_or_above_rated_pct.toFixed(3)}%,
-          above cut-out {h.operating_regime.above_cut_out_pct.toFixed(3)}%, on a
-          curve with cut-in {h.operating_regime.cut_in_ms.toFixed(1)}, rated{" "}
-          {h.operating_regime.rated_ms.toFixed(4)} and cut-out{" "}
-          {h.operating_regime.cut_out_ms.toFixed(1)} m/s.
-        </p>
-        <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-          {h.density_normalisation_note} {h.hours_per_year_note}
-        </p>
-        <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-          Excluded from these figures: {h.excluded_losses.join("; ")}.
-        </p>
+        {/* The operating regime, which was a sentence. */}
+        <div className="mt-3 grid grid-cols-1 gap-x-6 gap-y-1 sm:grid-cols-3">
+          <Stat
+            label="Hours above cut-in"
+            value={`${h.operating_regime.above_cut_in_pct.toFixed(3)}%`}
+          />
+          <Stat
+            label="Hours at or above rated"
+            value={`${h.operating_regime.at_or_above_rated_pct.toFixed(3)}%`}
+          />
+          <Stat
+            label="Hours above cut-out"
+            value={`${h.operating_regime.above_cut_out_pct.toFixed(3)}%`}
+          />
+          <Stat
+            label="Cut-in / rated / cut-out"
+            value={`${h.operating_regime.cut_in_ms.toFixed(1)} / ${h.operating_regime.rated_ms.toFixed(4)} / ${h.operating_regime.cut_out_ms.toFixed(1)} m/s`}
+          />
+        </div>
       </div>
 
       <div
@@ -160,23 +173,22 @@ export function WindScreening({ wind }: { wind: WindAnalysis }) {
           <WaterFigure
             label={`Hours below ${q.calm_threshold_ms} m/s`}
             value={`${(q.calm_fraction_pct["10m"] ?? 0).toFixed(3)}%`}
-            sub={`at 10 m; 50 m ${(q.calm_fraction_pct["50m"] ?? 0).toFixed(3)}%, 2 m ${(q.calm_fraction_pct["2m"] ?? 0).toFixed(3)}%`}
+            sub={`50 m ${(q.calm_fraction_pct["50m"] ?? 0).toFixed(3)}%, 2 m ${(q.calm_fraction_pct["2m"] ?? 0).toFixed(3)}%`}
           />
           <WaterFigure
             label="Record maximum 10 m"
             value={`${(q.record_maximum_ms["10m"] ?? 0).toFixed(2)} m/s`}
-            sub={`over ${q.record_hours} hours; floor ${q.record_maximum_floor_ms.toFixed(1)} m/s, ${q.record_maximum_plausible ? "met" : "not met"}`}
+            sub={`floor ${q.record_maximum_floor_ms.toFixed(1)} m/s · ${q.record_maximum_plausible ? "met" : "not met"}`}
           />
           <WaterFigure
             label="Shear exponent"
             value={shear.shear_exponent.toFixed(4)}
-            sub={`10 m to 50 m long-term means; day ${shear.shear_exponent_day.toFixed(4)}, night ${shear.shear_exponent_night.toFixed(4)}`}
+            sub={`day ${shear.shear_exponent_day.toFixed(4)}, night ${shear.shear_exponent_night.toFixed(4)}`}
           />
           {/* Null when the exponent lies outside what a neutral logarithmic
               profile between 10 m and 50 m can produce for any roughness
               length. Rendered as a number it printed "0.000 m", a physically
-              meaningful-looking roughness that was never computed, beside the
-              flag stating that the inversion has no root. */}
+              meaningful-looking roughness that was never computed. */}
           <WaterFigure
             label="Implied roughness"
             value={
@@ -186,38 +198,36 @@ export function WindScreening({ wind }: { wind: WindAnalysis }) {
             }
             sub={
               shear.implied_roughness_length_m == null
-                ? `no roughness length inverts this exponent; assumed cover ${shear.assumed_roughness_band_m.join(" to ")} m`
-                : `assumed cover ${shear.assumed_roughness_band_m.join(" to ")} m, ${shear.consistent_with_assumed_cover ? "consistent" : "not consistent"}`
+                ? `no inversion; assumed ${shear.assumed_roughness_band_m.join("–")} m`
+                : `assumed ${shear.assumed_roughness_band_m.join("–")} m · ${shear.consistent_with_assumed_cover ? "consistent" : "not consistent"}`
             }
           />
         </div>
-        <p className="mt-2 text-[10px] leading-relaxed text-muted-foreground">
-          The assumed roughness band supports a shear exponent of{" "}
-          {shear.expected_shear_exponent_band.map((v) => v.toFixed(3)).join(" to ")}
-          . {shear.roughness_band_note}
-        </p>
-        <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-          {q.record_maximum_floor_note} {q.calm_fraction_2m_note}
-        </p>
-        {q.flags.length > 0 && (
-          <ul className="mt-2 flex flex-col gap-1.5">
-            {q.flags.map((f) => (
-              <li
-                key={f}
-                className="border-l-2 pl-2 text-[10px] leading-relaxed text-muted-foreground"
-                style={{ borderColor: PALETTE_STOPS.rdbu_r[14] }}
-              >
-                {f}
-              </li>
-            ))}
-          </ul>
-        )}
-        <p className="mt-2 text-[10px] leading-relaxed text-muted-foreground">
-          {q.all_checks_passed
-            ? "Every record check passed."
-            : `${q.flags.length} record check${q.flags.length === 1 ? "" : "s"} did not pass, so the hub figures rest on a series the checks do not support.`}{" "}
-          Record {q.record_hours} hours against {q.expected_hours} expected.
-        </p>
+        {/*
+          The checks as a count. Each flag was a multi-sentence string that
+          restated a number already above it; the outcome is what the reader
+          acts on, and every input to it is a figure in this block.
+        */}
+        <div className="mt-3 grid grid-cols-1 gap-x-6 gap-y-1 sm:grid-cols-3">
+          <Stat
+            label="Record checks"
+            value={
+              q.all_checks_passed
+                ? "all passed"
+                : `${q.flags.length} not passed`
+            }
+          />
+          <Stat
+            label="Record hours"
+            value={`${q.record_hours} / ${q.expected_hours} expected`}
+          />
+          <Stat
+            label="Shear band supported"
+            value={shear.expected_shear_exponent_band
+              .map((v) => v.toFixed(3))
+              .join(" – ")}
+          />
+        </div>
       </div>
 
       <div
@@ -288,7 +298,7 @@ export function WindScreening({ wind }: { wind: WindAnalysis }) {
         </div>
         <div>
           <p className="eyebrow !text-[9px] mb-2">
-            Direction at 50 m · share of energy against share of hours
+            Direction at 50 m · energy against hours
           </p>
           <ul className="flex flex-col gap-1">
             {m.direction_energy_rose_50m.map((s) => (
@@ -321,42 +331,57 @@ export function WindScreening({ wind }: { wind: WindAnalysis }) {
               </li>
             ))}
           </ul>
-          <p className="mt-1 text-[10px] leading-relaxed text-muted-foreground">
-            Upper bar energy, lower bar hours; they differ because the power
-            flux goes as the cube of speed. {m.direction.convention_note}{" "}
-            Circular mean {m.direction.circular_mean_deg_50m.toFixed(2)}° at 50
-            m and {m.direction.circular_mean_deg_10m.toFixed(2)}° at 10 m,
-            median turning {m.direction.median_turning_deg.toFixed(1)}°.
-          </p>
+          <div className="mt-2 grid grid-cols-1 gap-x-6 gap-y-1">
+            <Stat
+              label="Circular mean 50 m / 10 m"
+              value={`${m.direction.circular_mean_deg_50m.toFixed(2)}° / ${m.direction.circular_mean_deg_10m.toFixed(2)}°`}
+            />
+            <Stat
+              label="Median turning"
+              value={`${m.direction.median_turning_deg.toFixed(1)}°`}
+            />
+          </div>
         </div>
       </div>
 
+      {/*
+        The reference curve, as its parameters. It was a paragraph ending in a
+        citation, a drivetrain note and the name of the column the points were
+        read from; the curve is identified by its name and its numbers.
+      */}
       <div
-        className="mt-3 border-t pt-3 text-[10px] leading-relaxed text-muted-foreground"
+        className="mt-3 border-t pt-3"
         style={{ borderColor: "var(--border)" }}
       >
-        <p>
-          Reference power curve: {wind.turbine.name},{" "}
-          {(wind.turbine.rated_power_w / 1e6).toFixed(3)} MW,{" "}
-          {wind.turbine.rotor_diameter_m.toFixed(0)} m rotor,{" "}
-          {wind.turbine.blades} blades, {wind.turbine.iec_class} turbulence
-          class {wind.turbine.turbulence_class}, hub{" "}
-          {wind.turbine.hub_height_m.toFixed(0)} m,{" "}
-          {wind.turbine.power_curve_points} curve points read from the{" "}
-          {wind.turbine.power_curve_column} column. It is a reference curve, not
-          a turbine selected for this site. {wind.turbine.drivetrain_note}
+        <p className="eyebrow !text-[9px] mb-2">
+          Reference power curve · not a turbine selected for this site
         </p>
-        <p className="mt-1">{wind.turbine.citation}</p>
-        <p className="mt-1">
-          Hub height {wind.assumptions.hub_height_m.toFixed(0)} m:{" "}
-          {wind.assumptions.hub_height_source} Shear exponent{" "}
-          {wind.assumptions.shear_exponent.toFixed(4)}:{" "}
-          {wind.assumptions.shear_exponent_source}
-        </p>
-        <p className="mt-1">{wind.assumptions.conventions_note}</p>
-        <p className="mt-1">{wind.loads_note}</p>
-        <p className="mt-1">{wind.grid_note}</p>
-        <PowerProvenanceNote provenance={wind.power_provenance} />
+        <div className="grid grid-cols-1 gap-x-6 gap-y-1 sm:grid-cols-2">
+          <Stat label="Model" value={wind.turbine.name} />
+          <Stat
+            label="Rated power"
+            value={`${(wind.turbine.rated_power_w / 1e6).toFixed(3)} MW`}
+          />
+          <Stat
+            label="Rotor / blades"
+            value={`${wind.turbine.rotor_diameter_m.toFixed(0)} m · ${wind.turbine.blades}`}
+          />
+          <Stat
+            label="Class"
+            value={`${wind.turbine.iec_class} · turbulence ${wind.turbine.turbulence_class}`}
+          />
+          <Stat
+            label="Curve hub height"
+            value={`${wind.turbine.hub_height_m.toFixed(0)} m`}
+          />
+          <Stat
+            label="Curve points"
+            value={String(wind.turbine.power_curve_points)}
+          />
+        </div>
+        <div className="mt-2">
+          <PowerProvenanceNote provenance={wind.power_provenance} />
+        </div>
       </div>
     </section>
   )

--- a/frontend/src/components/analysisPrimitives.tsx
+++ b/frontend/src/components/analysisPrimitives.tsx
@@ -74,14 +74,31 @@ export function PanelTile({
   uri,
   empty,
   onOpen,
+  fullWidth = false,
 }: {
   title: string
-  uri?: string
+  uri: string | undefined
   empty: string
   onOpen?: () => void
+  /**
+   * Set when the tile is not in a grid column.
+   *
+   * The preview is 4:3 of whatever width it is given, which is right in a
+   * five-column grid and wrong across a whole panel: on a wide window the
+   * water-occurrence tile came out around 1400 px tall, past the bottom of the
+   * screen and past the height of a screenshot. Bounding the height instead
+   * lets object-contain letterbox the raster, so the figure stays whole and
+   * stays on screen.
+   */
+  fullWidth?: boolean
 }) {
   const preview = (
-    <div className="rounded-sm border border-border bg-background relative aspect-[4/3] overflow-hidden">
+    <div
+      className={cn(
+        "rounded-sm border border-border bg-background relative overflow-hidden",
+        fullWidth ? "h-[min(24rem,45vh)]" : "aspect-[4/3]"
+      )}
+    >
       {uri ? (
         <img src={uri} alt={title} className="h-full w-full object-contain" />
       ) : (

--- a/frontend/src/components/energy/AoiSection.tsx
+++ b/frontend/src/components/energy/AoiSection.tsx
@@ -10,25 +10,18 @@
  * the tabs: 1 degree for radiation, 0.5 by 0.625 degrees for the reanalysis the
  * wind screening reads.
  */
-import { useState } from "react"
 import {
   CheckCircle2,
-  ChevronLeft,
-  ChevronRight,
-  Layers,
   Pencil,
   Trash2,
   Upload,
 } from "lucide-react"
-import type { Area } from "@/lib/types"
 import { cn } from "@/lib/utils"
 import { PanelSection } from "@/components/ui/PanelSection"
 
 export function AoiSection({
   note,
-  areas,
   activeExample,
-  onSelectExample,
   hasArea,
   hasCustomPolygon,
   onImportPolygon,
@@ -36,9 +29,7 @@ export function AoiSection({
   busy,
 }: {
   note: string
-  areas: Area[]
   activeExample: string
-  onSelectExample: (id: string) => void
   hasArea: boolean
   hasCustomPolygon: boolean
   onImportPolygon: () => void
@@ -46,8 +37,6 @@ export function AoiSection({
   /** A run is in flight; editing the AOI under it would discard the result. */
   busy: boolean
 }) {
-  const [showExamples, setShowExamples] = useState(false)
-
   return (
     <PanelSection title="Area">
       <p className="text-xs leading-relaxed text-muted-foreground">{note}</p>
@@ -90,45 +79,9 @@ export function AoiSection({
             : activeExample
               ? `Example ${activeExample} loaded`
               : "Area defined"
-          : "No area defined. Draw one on the map, import a file, or load an example."}
+          : "No area defined. Draw one on the map or import a file."}
       </div>
 
-      <div className="flex flex-col gap-1.5">
-        <button
-          type="button"
-          onClick={() => setShowExamples((s) => !s)}
-          className="flex items-center gap-1.5 self-start text-[11px] text-muted-foreground hover:text-foreground"
-        >
-          <Layers className="size-3" />
-          Reference examples
-          {showExamples ? (
-            <ChevronLeft className="size-3 rotate-90" />
-          ) : (
-            <ChevronRight className="size-3 rotate-90" />
-          )}
-        </button>
-        {showExamples && (
-          <div className="grid grid-cols-3 gap-1.5">
-            {areas.map((a) => (
-              <button
-                key={a.id}
-                type="button"
-                disabled={busy}
-                onClick={() => onSelectExample(a.id)}
-                title={a.label}
-                className={cn(
-                  "rounded-sm border px-2 py-1 text-xs disabled:opacity-50",
-                  activeExample === a.id
-                    ? "border-primary bg-primary/10"
-                    : "border-border hover:bg-secondary"
-                )}
-              >
-                {a.id}
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
     </PanelSection>
   )
 }

--- a/frontend/src/lib/chartAxis.ts
+++ b/frontend/src/lib/chartAxis.ts
@@ -61,13 +61,47 @@ export function timeLabelFormatter(t: number): string {
 }
 
 /**
- * Days after which a break is drawn instead of a segment.
+ * Days after which a break is drawn instead of a segment, when the series is
+ * too short to speak for itself.
  *
  * Sentinel-2's revisit is five days with both satellites, so three missed
  * passes is the point where a straight line stops being a plausible reading of
  * the interval and starts being an assertion about weeks nobody observed.
+ *
+ * A FALLBACK, NOT THE RULE. Applied to every series it broke almost all of
+ * them: monthly-best selection returns one scene per month by construction, so
+ * a real run has a median interval near 30 days and a fixed 16-day threshold
+ * severed every segment. Measured on a 13-acquisition run, 10 of 12 intervals
+ * exceeded it and the chart drew 2 line segments among 13 isolated dots. What
+ * counts as a gap depends on the cadence, so gapLimitMs derives it.
  */
 export const VI_GAP_DAYS = 16
+
+/**
+ * The interval beyond which a break is a break, derived from the sampling.
+ *
+ * A gap is a gap relative to how often this series is sampled: 30 days is
+ * routine under monthly-best selection and a long absence under a dense
+ * five-day cadence. The median interval is what the run itself says its
+ * cadence is, and the multiple below is the point past which an interval stops
+ * being ordinary spacing.
+ *
+ * The median rather than the mean, because the outlier this has to survive is
+ * exactly the gap it is trying to detect: one four-month hole pulls a mean far
+ * enough to stop the hole being detected.
+ */
+export function gapLimitMs(times: number[], fallbackDays = VI_GAP_DAYS): number {
+  const ts = times.filter((t) => Number.isFinite(t)).sort((a, b) => a - b)
+  const gaps: number[] = []
+  for (let i = 1; i < ts.length; i++) gaps.push(ts[i] - ts[i - 1])
+  // Under three intervals there is no cadence to speak of, only points.
+  if (gaps.length < 3) return fallbackDays * DAY_MS
+  gaps.sort((a, b) => a - b)
+  const median = gaps[Math.floor(gaps.length / 2)]
+  if (!Number.isFinite(median) || median <= 0) return fallbackDays * DAY_MS
+  // 2.5x: a missed acquisition still connects, two consecutive absences do not.
+  return Math.max(median * 2.5, fallbackDays * DAY_MS)
+}
 
 /**
  * Opens a hole in a series wherever consecutive samples are too far apart.
@@ -79,9 +113,11 @@ export const VI_GAP_DAYS = 16
  */
 export function insertTimeGaps<T extends { t: number }>(
   rows: T[],
-  gapDays: number
+  // Milliseconds, not days: the threshold is derived from the series' own
+  // cadence by gapLimitMs, and passing days invited the fixed value that broke
+  // every monthly series.
+  limit: number
 ): (T | { t: number })[] {
-  const limit = gapDays * DAY_MS
   const out: (T | { t: number })[] = []
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i]

--- a/frontend/src/lib/projectOverlays.ts
+++ b/frontend/src/lib/projectOverlays.ts
@@ -1,4 +1,5 @@
 import type {
+  Bounds,
   CompositionOverlay,
   CompositeIndex,
   CompositeKind,
@@ -72,5 +73,55 @@ export function projectOverlayToComposition(
     presetId: meta.presetId,
     sceneDate: meta.sceneDate,
     raster_tif: o.raster_tif,
+    runId: o.run_id || undefined,
   }
+}
+
+/** Do two geographic boxes overlap at all? */
+function boxesIntersect(a: Bounds, b: Bounds): boolean {
+  return !(
+    a.lon_max < b.lon_min ||
+    b.lon_max < a.lon_min ||
+    a.lat_max < b.lat_min ||
+    b.lat_max < a.lat_min
+  )
+}
+
+/**
+ * The compositions that belong with what is on screen.
+ *
+ * Compositions were scoped to the project alone, and a project spans fields: a
+ * real one here held 13 compositions across three locations up to 100 km
+ * apart, every one of them listed whichever run was open. Applying one put a
+ * raster off the edge of the area being looked at.
+ *
+ * Three cases, and the third is why an extent test survives alongside the run
+ * association:
+ *
+ *   - made under this run          -> shown
+ *   - made under a different run   -> hidden, it belongs to that one
+ *   - made under no run at all     -> shown when it covers the area in view
+ *
+ * The last case is not a leftover. A composition needs no classification --
+ * browsing scenes produces one -- so it belongs to the project rather than to
+ * any run, and the only thing that says whether it belongs *here* is where it
+ * is. Every row written before the association existed is in that case too.
+ *
+ * With no run open, the run test has nothing to compare against and the extent
+ * carries the whole decision.
+ */
+export function scopeCompositionsToView(
+  gallery: CompositionOverlay[],
+  runId: string | null,
+  view: Bounds | null
+): CompositionOverlay[] {
+  return gallery.filter((c) => {
+    if (c.runId) return c.runId === runId
+    if (!view) return true
+    // A composition saved before extents were recorded reads as the zero box.
+    // Excluding it on that basis would hide it everywhere, so it is kept.
+    const e = c.extent
+    if (!e || (!e.lon_min && !e.lon_max && !e.lat_min && !e.lat_max)) return true
+    return boxesIntersect(e, view)
+  })
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -779,10 +779,8 @@ export interface EnergyPerformanceRatio {
   applied: number
   applied_source: string
   reference: number
-  reference_source: string
   modelled: number
   derived: number
-  derived_source: string
   derived_if_optional_at_pvwatts_defaults: number
   declared_loss_factor: number
   optional_loss_factor: number
@@ -793,7 +791,6 @@ export interface EnergyPerformanceRatio {
   degradation_factor: number
   degradation_rate_per_year: number
   analysis_period_years: number
-  degradation_source: string
   /** Band implied by the Global Solar Atlas at this site: [low, high]. */
   gsa_implied_band: number[]
 }
@@ -896,9 +893,7 @@ export interface EnergyTrackerConfiguration {
   axis_azimuth_deg: number
   axis_azimuth_convention: string
   max_angle_deg: number
-  max_angle_source: string
   backtrack: boolean
-  backtrack_note: string
   terrain: string
 }
 
@@ -988,7 +983,6 @@ export interface EnergyModelDerivedLandUse {
   gcr_ratio: number
   basis: string
   note: string
-  module_efficiency_note: string
   parity: EnergyParityGCR
 }
 
@@ -1022,7 +1016,6 @@ export interface EnergyTracking {
   per_hectare: EnergyPerHectare
   performance_ratio: EnergyTrackingPR
   excluded: string
-  resolution_note: string
 }
 
 /** utc_offset_hours is null when none was supplied; the hours are then UTC. */
@@ -1089,9 +1082,7 @@ export interface EnergyCapacityDensity {
   source: string
   acre_conversion: string
   buildable_fraction: number
-  buildable_fraction_source: string
   fleet_dc_ac_ratio: number
-  fleet_dc_ac_ratio_source: string
   ac_to_dc_conversion_applied: boolean
   note: string
 }
@@ -1151,7 +1142,6 @@ export interface EnergyNormality {
   test: string
   statistic: number
   p_value: number
-  interpretation: string
 }
 
 export interface EnergyExceedanceCrosswalk {
@@ -1171,7 +1161,6 @@ export interface EnergyExceedance {
   std_kwh_m2_year: number
   cv_pct: number
   levels: EnergyExceedanceLevel[]
-  p50_note: string
   normality: EnergyNormality
   crosswalk: EnergyExceedanceCrosswalk
   linearity_assumption: string
@@ -1237,7 +1226,6 @@ export interface EnergyAssumptions {
   capacity_density_mw_dc_per_ha: number
   shading_applied: boolean
   shading_derate: number
-  resolution_note: string
   note: string
 }
 
@@ -1337,7 +1325,6 @@ export interface WindMeasured {
   air_density_mean_kg_m3: number
   air_density_min_kg_m3: number
   air_density_max_kg_m3: number
-  humidity_note: string
   monthly_mean_speed_50m: WindMonthlySpeed[]
   direction: WindDirection
   direction_energy_rose_50m: WindRoseSector[]
@@ -1375,9 +1362,7 @@ export interface WindHub {
   gross_capacity_factor_no_density_correction_pct: number
   gross_annual_energy_mwh_per_turbine: number
   operating_regime: WindOperatingRegime
-  density_normalisation_note: string
   hours_per_year: number
-  hours_per_year_note: string
   excluded_losses: string[]
 }
 
@@ -1406,7 +1391,6 @@ export interface WindShearDiagnostics {
   assumed_roughness_band_m: number[]
   expected_shear_exponent_band: number[]
   consistent_with_assumed_cover: boolean
-  roughness_band_note: string
   shear_exponent_hourly_mean: number
   shear_exponent_hourly_median: number
   shear_exponent_day: number
@@ -1428,9 +1412,7 @@ export interface WindDataQuality {
   record_maximum_ms: Record<string, number>
   record_maximum_floor_ms: number
   record_maximum_plausible: boolean
-  record_maximum_floor_note: string
   calm_fraction_2m_flag_pct: number
-  calm_fraction_2m_note: string
   nan_count: Record<string, number>
   shear: WindShearDiagnostics
   flags: string[]
@@ -1455,7 +1437,6 @@ export interface WindTurbine {
   citation_url: string
   curve_source_url: string
   curve_source_commit: string
-  drivetrain_note: string
 }
 
 export interface WindAssumptions {
@@ -1468,12 +1449,10 @@ export interface WindAssumptions {
   roughness_band_m: number[]
   calm_threshold_ms: number
   record_max_floor_ms: number
-  conventions_note: string
   qualifier: string
   excluded_losses: string[]
   /** States that the wind capacity factor is not comparable with the PV one. */
   comparison_note: string
-  resolution_note: string
 }
 
 /**
@@ -1498,7 +1477,6 @@ export interface WindAnalysis {
   record_window: string
   hub_height_m: number
   qualifier: string
-  loads_note: string
   measured: WindMeasured
   hub: WindHub
   shear_sensitivity: WindShearRow[]

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -200,6 +200,14 @@ export interface LULCRequest {
 }
 
 export interface PredictResult {
+  /**
+   * The saved run this result became, when one was saved.
+   *
+   * Set by the backend after persisting, so it is absent from the stored copy
+   * of a run's own result. Compositions made while this result is on screen
+   * attach to it.
+   */
+  run_id?: string
   extent: Bounds
   overlay_uri: string
   confidence_uri: string
@@ -313,6 +321,14 @@ export interface Project {
 export interface ProjectOverlay {
   id: string
   project_id: string
+  /**
+   * The run on screen when this composition was made.
+   *
+   * Empty for one made with no run open, and for every row written before the
+   * column existed. Empty means "belongs to the project", so those are scoped
+   * by their recorded extent instead.
+   */
+  run_id?: string
   kind: string
   title: string
   meta_json?: string
@@ -324,6 +340,8 @@ export interface ProjectOverlay {
 }
 
 export interface SaveProjectOverlayRequest {
+  /** The run on screen when the composition was made, when there was one. */
+  run_id?: string
   project_id: string
   kind: string
   title: string
@@ -403,6 +421,8 @@ export interface CompositionOverlay {
   sceneDate?: string
   /** Local GeoTIFF path for export (when available). */
   raster_tif?: string
+  /** The run this was made under; empty for a project-level composition. */
+  runId?: string
 }
 
 export type WaterIndex = "NDWI" | "MNDWI" | "AWEI"

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -139,6 +139,43 @@ export interface LULCCompareRow {
   n_reference_cells?: number
 }
 
+/** One class's producer's and user's accuracy, each with a 95% interval. */
+export interface LULCClassAccuracy {
+  class_id: number
+  name: string
+  color: string
+  /** Of the reference cells of this class, the share the classifier found. */
+  producers_pct: number | null
+  producers_ci?: [number, number]
+  /** Of the cells called this class, the share that really are. */
+  users_pct: number | null
+  users_ci?: [number, number]
+  n_reference: number
+  n_predicted: number
+}
+
+/**
+ * Agreement against the reference — what the composition comparison cannot say.
+ *
+ * Two maps holding identical proportions of every class can disagree on every
+ * cell, so the composition rows and this measure different things. Computed
+ * over the reference's native 30 m cells, not the 10 m pixels resampled from
+ * them, because nine pixels carrying one label are one observation.
+ */
+export interface LULCAgreement {
+  n_reference_cells: number
+  overall_pct: number
+  overall_ci: [number, number]
+  /** Pontius & Millones (2011): different amounts vs. different places. */
+  quantity_disagreement_pct: number
+  allocation_disagreement_pct: number
+  per_class: LULCClassAccuracy[]
+  /** Reference cells whose class the classifier has no label for. */
+  n_outside_legend: number
+  matrix: number[][]
+  matrix_classes: number[]
+}
+
 export interface LULCAnalysis {
   year: number
   source: string
@@ -152,6 +189,8 @@ export interface LULCAnalysis {
   compare_pixels?: number
   /** Distinct native reference cells behind them; the comparison sample size. */
   compare_reference_cells?: number
+  /** Absent when the reference cell mapping was unavailable. */
+  agreement?: LULCAgreement
 }
 
 export interface LULCRequest {
@@ -168,7 +207,16 @@ export interface PredictResult {
   true_color_uri: string
   reference_uri: string
   raster_tif: string
+  /**
+   * Mean of max(predict_proba) over classified pixels.
+   *
+   * Ensemble vote share, not a calibrated probability of being correct:
+   * Random Forest vote fractions are biased toward the middle of the range
+   * (Niculescu-Mizil & Caruana 2005). Read it with confidence_floor.
+   */
   mean_confidence: number
+  /** 1/K for a K-class model; the value mean_confidence cannot go below. */
+  confidence_floor?: number
   n_dates: number
   // Go marshals a nil slice as null, and a run that produced no classification
   // -- a water or solar run, which needs no scene -- leaves every one of these

--- a/frontend/src/pages/AnalysisPage.tsx
+++ b/frontend/src/pages/AnalysisPage.tsx
@@ -1710,10 +1710,14 @@ export function AnalysisPage({
               </div>
               {result.water.occurrence_uri && (
                 <div className="mb-3">
+                  {/* Spans the panel rather than sitting in a grid column, so
+                      its height is bounded instead of following a 4:3 ratio of
+                      the full width. */}
                   <PanelTile
                     title="Water occurrence"
                     uri={result.water.occurrence_uri}
                     empty="No occurrence raster"
+                    fullWidth
                   />
                   <ContinuousRamp
                     palette="blues"

--- a/frontend/src/pages/AnalysisPage.tsx
+++ b/frontend/src/pages/AnalysisPage.tsx
@@ -427,12 +427,9 @@ export function AnalysisPage({
     }
   }, [hubView, selectedProjectId, loadProjectDetail, loadUnassigned])
 
-  const [openedRunId, setOpenedRunId] = useState<string | null>(null)
-
   const handleOpenRun = useCallback(
     async (run: InferenceRun) => {
       setOpenedOverlay(null)
-      setOpenedRunId(run.id)
       if (run.project_id) {
         setSelectedProjectId(run.project_id)
         setHubView("detail")
@@ -616,10 +613,6 @@ export function AnalysisPage({
           await loadUnassigned()
         }
         clearSelection()
-        if (result && openedRunId === run.id) {
-          setOpenedRunId(null)
-          onBackToList()
-        }
         notifySuccess("Analysis deleted")
       } catch (e) {
         notifyError("Could not delete analysis", e)
@@ -633,9 +626,6 @@ export function AnalysisPage({
       loadProjectDetail,
       loadUnassigned,
       clearSelection,
-      result,
-      openedRunId,
-      onBackToList,
     ]
   )
 
@@ -717,55 +707,63 @@ export function AnalysisPage({
     )
   }
 
-  const runsPanel = (
-    <SavedRunsPanel
-      title={panelTitle}
-      /*
-        The list is filtered by project and by nothing else, so it holds every
-        run kind -- classification, surface water, solar and wind alike. The
-        caption named only the first and even listed its three models, twenty
-        lines above the code that branches on r.kind to draw the other three.
-        Inside a project it says nothing at all now: the tab above already does.
-      */
-      caption={
-        hubView === "unassigned"
-          ? "Runs of any product not yet assigned to a project."
-          : undefined
-      }
-      runs={scopedRuns}
-      loading={!!loadingRun || comparing || hubLoading}
-      selectedIds={selectedIds}
-      onToggleSelect={toggleSelect}
-      onClearSelection={clearSelection}
-      onCompare={() => void startCompare()}
-      comparing={comparing}
-      onOpen={handleOpenRun}
-      onDelete={(run) => void handleDeleteRun(run)}
-      onRefresh={() => {
-        void refreshRuns()
-        if (hubView === "detail" && selectedProjectId) void loadProjectDetail(selectedProjectId)
-        if (hubView === "unassigned") void loadUnassigned()
-      }}
-      projects={projects}
-      onAssignProject={
-        hubView === "unassigned"
-          ? async (runId, projectId) => {
-              try {
-                await SetRunProject(runId, projectId)
-                await refreshRuns()
-                await loadUnassigned()
-                await refreshProjects()
-                notifySuccess("Assigned to project")
-              } catch (e) {
-                notifyError("Could not assign run", e)
-              }
-            }
-          : undefined
-      }
-    />
-  )
-
   if (!result) {
+    /*
+      Scoped to the hub, where the list IS the screen. It used to be built out
+      here and placed a third time at the foot of an open analysis, so reading
+      one result ended in the roster of every other one -- a list of forty-eight
+      runs answering a question the reader had already left behind. The header
+      of the detail view carries "Saved analyses" for going back, and comparing,
+      deleting and assigning all live on the hub the button returns to.
+    */
+    const runsPanel = (
+      <SavedRunsPanel
+        title={panelTitle}
+        /*
+          The list is filtered by project and by nothing else, so it holds every
+          run kind -- classification, surface water, solar and wind alike. The
+          caption named only the first and even listed its three models, twenty
+          lines above the code that branches on r.kind to draw the other three.
+          Inside a project it says nothing at all now: the tab above already does.
+        */
+        caption={
+          hubView === "unassigned"
+            ? "Runs of any product not yet assigned to a project."
+            : undefined
+        }
+        runs={scopedRuns}
+        loading={!!loadingRun || comparing || hubLoading}
+        selectedIds={selectedIds}
+        onToggleSelect={toggleSelect}
+        onClearSelection={clearSelection}
+        onCompare={() => void startCompare()}
+        comparing={comparing}
+        onOpen={handleOpenRun}
+        onDelete={(run) => void handleDeleteRun(run)}
+        onRefresh={() => {
+          void refreshRuns()
+          if (hubView === "detail" && selectedProjectId) void loadProjectDetail(selectedProjectId)
+          if (hubView === "unassigned") void loadUnassigned()
+        }}
+        projects={projects}
+        onAssignProject={
+          hubView === "unassigned"
+            ? async (runId, projectId) => {
+                try {
+                  await SetRunProject(runId, projectId)
+                  await refreshRuns()
+                  await loadUnassigned()
+                  await refreshProjects()
+                  notifySuccess("Assigned to project")
+                } catch (e) {
+                  notifyError("Could not assign run", e)
+                }
+              }
+            : undefined
+        }
+      />
+    )
+
     const hubSelection =
       hubView === "list"
         ? ("all" as const)
@@ -1811,8 +1809,6 @@ export function AnalysisPage({
               </div>
             </section>
           )}
-
-          {runsPanel}
         </div>
       </PageBody>
 

--- a/frontend/src/pages/AnalysisPage.tsx
+++ b/frontend/src/pages/AnalysisPage.tsx
@@ -97,7 +97,7 @@ import {
   solarProductLabel,
 } from "@/lib/runSummary"
 import {
-  VI_GAP_DAYS,
+  gapLimitMs,
   dateToMs,
   insertTimeGaps,
   timeAxisProps,
@@ -1063,10 +1063,15 @@ export function AnalysisPage({
    * irregular, so a month and a week were drawn the same width and every slope
    * on the chart was wrong by whatever the gaps happened to be.
    *
-   * A break is inserted where the interval exceeds `VI_GAP_DAYS`. Drawn
-   * through, a straight segment across a six-week cloud gap asserts
-   * observations that were never made, and it is indistinguishable from a
-   * segment across three good acquisitions.
+   * A break is inserted where the interval is long relative to this run's own
+   * cadence -- see gapLimitMs. Drawn through, a straight segment across a
+   * six-week cloud gap asserts observations that were never made, and it is
+   * indistinguishable from a segment across three good acquisitions.
+   *
+   * Relative to the cadence rather than a fixed number of days, because the
+   * fixed 16-day rule that was here broke almost every real series: monthly
+   * -best selection returns one scene per month, so the ordinary interval is
+   * 30 days and every segment qualified as a gap.
    *
    * NOT memoised, deliberately. This point in the component is past two early
    * returns -- the hub and the project views render and return above it -- so a
@@ -1083,6 +1088,9 @@ export function AnalysisPage({
   /** Tick precision follows the span; see lib/chartAxis.ts. */
   const viAxis = { tickFormatter: timeTickFormatter(viSpan) }
 
+  // The break threshold comes from this run's own cadence: monthly-best
+  // selection samples once a month by construction, and a fixed 16-day rule
+  // severed every segment of such a series.
   const viChart = insertTimeGaps(
     viSeries.map((p) => ({
       t: dateToMs(p.date),
@@ -1090,7 +1098,7 @@ export function AnalysisPage({
       evi: p.evi_mean,
       savi: p.savi_mean,
     })),
-    VI_GAP_DAYS
+    gapLimitMs(viTimes)
   )
 
   // Same treatment for surface water: it is the same cloud-screened Sentinel-2
@@ -1102,7 +1110,7 @@ export function AnalysisPage({
   const waterTimes = waterRows.map((r) => r.t).filter((t) => Number.isFinite(t))
   const waterSpan =
     waterTimes.length > 1 ? Math.max(...waterTimes) - Math.min(...waterTimes) : 0
-  const waterChart = insertTimeGaps(waterRows, VI_GAP_DAYS)
+  const waterChart = insertTimeGaps(waterRows, gapLimitMs(waterTimes))
 
   const exportTif = async () => {
     if (!result.raster_tif) return
@@ -1117,6 +1125,12 @@ export function AnalysisPage({
   // Every product that contributes a table or a manifest field. solar_terrain
   // was missing, so an AOI carrying only a terrain run had both export buttons
   // hidden and no way to reach its own manifest.
+  /** Classified pixels behind the distribution: the sum of the class counts. */
+  const classifiedPixels = (result.class_stats ?? []).reduce(
+    (n, s) => n + (s.pixels ?? 0),
+    0
+  )
+
   const canExportTables =
     !!result.solar ||
     !!result.solar_terrain ||
@@ -1271,8 +1285,26 @@ export function AnalysisPage({
                     ? ` · ${result.date_range[0]} → ${result.date_range[1]}`
                     : ""}{" "}
                   · {modelLabel}
+                  {/*
+                    Named for what it is, and shown with the floor it cannot go
+                    below. It is the mean of max(predict_proba) -- the share of
+                    the ensemble that voted for the winning class -- so over K
+                    classes it lives on [1/K, 1]. Printed as "mean conf 38%" it
+                    read on a 0-100 scale it does not occupy: over five classes
+                    that is a fifth of the way from maximum uncertainty to
+                    certainty, not a third. It is also not a calibrated
+                    probability of being correct, which is why it no longer
+                    says "confidence".
+                  */}
                   {result.mean_confidence > 0 && (
-                    <> · mean conf {(result.mean_confidence * 100).toFixed(0)}%</>
+                    <>
+                      {" "}
+                      · mean vote share{" "}
+                      {(result.mean_confidence * 100).toFixed(0)}%
+                      {result.confidence_floor
+                        ? ` (floor ${(result.confidence_floor * 100).toFixed(0)}%)`
+                        : ""}
+                    </>
                   )}
                 </>
               ) : (
@@ -1414,7 +1446,22 @@ export function AnalysisPage({
             <div className="grid grid-cols-1 gap-3 xl:grid-cols-2 xl:items-stretch">
               {hasClassification && (result.class_stats?.length ?? 0) > 0 && (
                 <section className="rounded-sm border border-border bg-secondary/50 p-4">
-                  <p className="eyebrow mb-3">Predicted class distribution</p>
+                  <p className="eyebrow mb-1">Predicted class distribution</p>
+                  {/*
+                    The denominator, and what the hectares are and are not.
+
+                    Areas here are pixel counts times the nominal pixel area.
+                    That is a biased estimator: omission and commission do not
+                    cancel, so the figure carries an error the map alone cannot
+                    bound (Olofsson et al. 2013). Stated, because a column of
+                    hectares to one decimal reads as measurement.
+                  */}
+                  <p className="mb-3 text-[10px] text-muted-foreground">
+                    {classifiedPixels > 0
+                      ? `n = ${classifiedPixels.toLocaleString()} classified pixels at 10 m · `
+                      : ""}
+                    area from pixel count, uncorrected for classification error
+                  </p>
                   <ul className="flex flex-col gap-1.5">
                     {(result.class_stats ?? []).map((s) => (
                       <li key={s.class_id} className="flex items-center gap-2 text-xs">
@@ -1509,8 +1556,20 @@ export function AnalysisPage({
                           fontSize: 11,
                         }}
                       />
+                      {/*
+                        Above the plot, not below it.
+
+                        Recharts lays a bottom legend in the same band the axis
+                        title occupies, and the two were drawn on top of each
+                        other: "Acquisition date" read through the NDVI/EVI/SAVI
+                        keys. The axis title has to stay under the axis it
+                        names, so the legend is what moves.
+                      */}
                       <Legend
-                        wrapperStyle={{ fontSize: 11, paddingTop: 4 }}
+                        verticalAlign="top"
+                        align="right"
+                        height={20}
+                        wrapperStyle={{ fontSize: 11, paddingBottom: 2 }}
                         iconType="plainline"
                       />
                       {VI_LINES.map((s) => (

--- a/frontend/src/pages/EnergyScreen.tsx
+++ b/frontend/src/pages/EnergyScreen.tsx
@@ -146,7 +146,6 @@ export interface EnergyScreenProps {
   hasArea: boolean
   areas: Area[]
   activeExample: string
-  onSelectExample: (id: string) => void
   customPolygon: GeoJSONGeometry | null
   onPolygonDrawn: (geom: GeoJSONGeometry | null) => void
   onImportPolygon: () => void
@@ -356,7 +355,6 @@ export function EnergyScreen(props: EnergyScreenProps) {
         activeExample={props.activeExample}
         customPolygon={props.customPolygon}
         onPolygonDrawn={props.onPolygonDrawn}
-        onSelectExample={props.onSelectExample}
         flyTo={props.flyTo}
         solarOverlays={solarOverlays}
         // The classification chrome is pinned off rather than exposed: there is
@@ -392,9 +390,7 @@ export function EnergyScreen(props: EnergyScreenProps) {
       />
       <AoiSection
         note={AOI_NOTE_SOLAR}
-        areas={props.areas}
         activeExample={props.activeExample}
-        onSelectExample={props.onSelectExample}
         hasArea={props.hasArea}
         hasCustomPolygon={!!props.customPolygon}
         onImportPolygon={props.onImportPolygon}
@@ -449,9 +445,7 @@ export function EnergyScreen(props: EnergyScreenProps) {
     <>
       <AoiSection
         note={AOI_NOTE_WIND}
-        areas={props.areas}
         activeExample={props.activeExample}
-        onSelectExample={props.onSelectExample}
         hasArea={props.hasArea}
         hasCustomPolygon={!!props.customPolygon}
         onImportPolygon={props.onImportPolygon}

--- a/frontend/src/pages/MapScreen.tsx
+++ b/frontend/src/pages/MapScreen.tsx
@@ -85,7 +85,6 @@ export interface MapScreenProps {
   composeOpacity: number
   onViewChange: (v: { lat: number; lon: number; zoom: number }) => void
   onPolygonDrawn: (geom: GeoJSONGeometry | null) => void
-  onSelectExample: (id: string) => void
   onLocationSelect: (lat: number, lon: number) => void
   onClearArea: () => void
   onImportPolygon: () => void
@@ -185,7 +184,6 @@ export function MapScreen(props: MapScreenProps) {
         activeExample={props.activeExample}
         customPolygon={props.customPolygon}
         onPolygonDrawn={props.onPolygonDrawn}
-        onSelectExample={props.onSelectExample}
         flyTo={props.flyTo}
         result={props.result}
         overlayOpacity={props.overlayOpacity}
@@ -290,9 +288,7 @@ export function MapScreen(props: MapScreenProps) {
           <ControlPanel
             key="classify"
             panelOffsetClass={panelOffsetClass}
-            areas={props.areas}
             activeExample={props.activeExample}
-            onSelectExample={props.onSelectExample}
             customPolygon={props.customPolygon}
             hasArea={props.hasArea}
             onClearArea={props.onClearArea}

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -308,7 +308,6 @@ export namespace backend {
 	    capacity_density_mw_dc_per_ha: number;
 	    shading_applied: boolean;
 	    shading_derate: number;
-	    resolution_note: string;
 	    note: string;
 	
 	    static createFrom(source: any = {}) {
@@ -334,7 +333,6 @@ export namespace backend {
 	        this.capacity_density_mw_dc_per_ha = source["capacity_density_mw_dc_per_ha"];
 	        this.shading_applied = source["shading_applied"];
 	        this.shading_derate = source["shading_derate"];
-	        this.resolution_note = source["resolution_note"];
 	        this.note = source["note"];
 	    }
 	}
@@ -372,9 +370,7 @@ export namespace backend {
 	    source: string;
 	    acre_conversion: string;
 	    buildable_fraction: number;
-	    buildable_fraction_source: string;
 	    fleet_dc_ac_ratio: number;
-	    fleet_dc_ac_ratio_source: string;
 	    ac_to_dc_conversion_applied: boolean;
 	    note: string;
 	
@@ -393,9 +389,7 @@ export namespace backend {
 	        this.source = source["source"];
 	        this.acre_conversion = source["acre_conversion"];
 	        this.buildable_fraction = source["buildable_fraction"];
-	        this.buildable_fraction_source = source["buildable_fraction_source"];
 	        this.fleet_dc_ac_ratio = source["fleet_dc_ac_ratio"];
-	        this.fleet_dc_ac_ratio_source = source["fleet_dc_ac_ratio_source"];
 	        this.ac_to_dc_conversion_applied = source["ac_to_dc_conversion_applied"];
 	        this.note = source["note"];
 	    }
@@ -488,7 +482,6 @@ export namespace backend {
 	    test: string;
 	    statistic: number;
 	    p_value: number;
-	    interpretation: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new EnergyNormality(source);
@@ -499,7 +492,6 @@ export namespace backend {
 	        this.test = source["test"];
 	        this.statistic = source["statistic"];
 	        this.p_value = source["p_value"];
-	        this.interpretation = source["interpretation"];
 	    }
 	}
 	export class EnergyExceedanceLevel {
@@ -533,7 +525,6 @@ export namespace backend {
 	    std_kwh_m2_year: number;
 	    cv_pct: number;
 	    levels: EnergyExceedanceLevel[];
-	    p50_note: string;
 	    normality: EnergyNormality;
 	    crosswalk: EnergyExceedanceCrosswalk;
 	    linearity_assumption: string;
@@ -552,7 +543,6 @@ export namespace backend {
 	        this.std_kwh_m2_year = source["std_kwh_m2_year"];
 	        this.cv_pct = source["cv_pct"];
 	        this.levels = this.convertValues(source["levels"], EnergyExceedanceLevel);
-	        this.p50_note = source["p50_note"];
 	        this.normality = this.convertValues(source["normality"], EnergyNormality);
 	        this.crosswalk = this.convertValues(source["crosswalk"], EnergyExceedanceCrosswalk);
 	        this.linearity_assumption = source["linearity_assumption"];
@@ -1396,7 +1386,6 @@ export namespace backend {
 	    gcr_ratio: number;
 	    basis: string;
 	    note: string;
-	    module_efficiency_note: string;
 	    parity: EnergyParityGCR;
 	
 	    static createFrom(source: any = {}) {
@@ -1412,7 +1401,6 @@ export namespace backend {
 	        this.gcr_ratio = source["gcr_ratio"];
 	        this.basis = source["basis"];
 	        this.note = source["note"];
-	        this.module_efficiency_note = source["module_efficiency_note"];
 	        this.parity = this.convertValues(source["parity"], EnergyParityGCR);
 	    }
 	
@@ -1673,9 +1661,7 @@ export namespace backend {
 	    axis_azimuth_deg: number;
 	    axis_azimuth_convention: string;
 	    max_angle_deg: number;
-	    max_angle_source: string;
 	    backtrack: boolean;
-	    backtrack_note: string;
 	    terrain: string;
 	
 	    static createFrom(source: any = {}) {
@@ -1688,9 +1674,7 @@ export namespace backend {
 	        this.axis_azimuth_deg = source["axis_azimuth_deg"];
 	        this.axis_azimuth_convention = source["axis_azimuth_convention"];
 	        this.max_angle_deg = source["max_angle_deg"];
-	        this.max_angle_source = source["max_angle_source"];
 	        this.backtrack = source["backtrack"];
-	        this.backtrack_note = source["backtrack_note"];
 	        this.terrain = source["terrain"];
 	    }
 	}
@@ -1701,7 +1685,6 @@ export namespace backend {
 	    per_hectare: EnergyPerHectare;
 	    performance_ratio: EnergyTrackingPR;
 	    excluded: string;
-	    resolution_note: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new EnergyTracking(source);
@@ -1715,7 +1698,6 @@ export namespace backend {
 	        this.per_hectare = this.convertValues(source["per_hectare"], EnergyPerHectare);
 	        this.performance_ratio = this.convertValues(source["performance_ratio"], EnergyTrackingPR);
 	        this.excluded = source["excluded"];
-	        this.resolution_note = source["resolution_note"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -1798,10 +1780,8 @@ export namespace backend {
 	    applied: number;
 	    applied_source: string;
 	    reference: number;
-	    reference_source: string;
 	    modelled: number;
 	    derived: number;
-	    derived_source: string;
 	    derived_if_optional_at_pvwatts_defaults: number;
 	    declared_loss_factor: number;
 	    optional_loss_factor: number;
@@ -1812,7 +1792,6 @@ export namespace backend {
 	    degradation_factor: number;
 	    degradation_rate_per_year: number;
 	    analysis_period_years: number;
-	    degradation_source: string;
 	    gsa_implied_band: number[];
 	
 	    static createFrom(source: any = {}) {
@@ -1824,10 +1803,8 @@ export namespace backend {
 	        this.applied = source["applied"];
 	        this.applied_source = source["applied_source"];
 	        this.reference = source["reference"];
-	        this.reference_source = source["reference_source"];
 	        this.modelled = source["modelled"];
 	        this.derived = source["derived"];
-	        this.derived_source = source["derived_source"];
 	        this.derived_if_optional_at_pvwatts_defaults = source["derived_if_optional_at_pvwatts_defaults"];
 	        this.declared_loss_factor = source["declared_loss_factor"];
 	        this.optional_loss_factor = source["optional_loss_factor"];
@@ -1838,7 +1815,6 @@ export namespace backend {
 	        this.degradation_factor = source["degradation_factor"];
 	        this.degradation_rate_per_year = source["degradation_rate_per_year"];
 	        this.analysis_period_years = source["analysis_period_years"];
-	        this.degradation_source = source["degradation_source"];
 	        this.gsa_implied_band = source["gsa_implied_band"];
 	    }
 	
@@ -2506,11 +2482,9 @@ export namespace backend {
 	    roughness_band_m: number[];
 	    calm_threshold_ms: number;
 	    record_max_floor_ms: number;
-	    conventions_note: string;
 	    qualifier: string;
 	    excluded_losses: string[];
 	    comparison_note: string;
-	    resolution_note: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new WindAssumptions(source);
@@ -2527,11 +2501,9 @@ export namespace backend {
 	        this.roughness_band_m = source["roughness_band_m"];
 	        this.calm_threshold_ms = source["calm_threshold_ms"];
 	        this.record_max_floor_ms = source["record_max_floor_ms"];
-	        this.conventions_note = source["conventions_note"];
 	        this.qualifier = source["qualifier"];
 	        this.excluded_losses = source["excluded_losses"];
 	        this.comparison_note = source["comparison_note"];
-	        this.resolution_note = source["resolution_note"];
 	    }
 	}
 	export class WindTurbine {
@@ -2551,7 +2523,6 @@ export namespace backend {
 	    citation_url: string;
 	    curve_source_url: string;
 	    curve_source_commit: string;
-	    drivetrain_note: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new WindTurbine(source);
@@ -2575,7 +2546,6 @@ export namespace backend {
 	        this.citation_url = source["citation_url"];
 	        this.curve_source_url = source["curve_source_url"];
 	        this.curve_source_commit = source["curve_source_commit"];
-	        this.drivetrain_note = source["drivetrain_note"];
 	    }
 	}
 	export class WindShearDiagnostics {
@@ -2584,7 +2554,6 @@ export namespace backend {
 	    assumed_roughness_band_m: number[];
 	    expected_shear_exponent_band: number[];
 	    consistent_with_assumed_cover: boolean;
-	    roughness_band_note: string;
 	    shear_exponent_hourly_mean: number;
 	    shear_exponent_hourly_median: number;
 	    shear_exponent_day: number;
@@ -2602,7 +2571,6 @@ export namespace backend {
 	        this.assumed_roughness_band_m = source["assumed_roughness_band_m"];
 	        this.expected_shear_exponent_band = source["expected_shear_exponent_band"];
 	        this.consistent_with_assumed_cover = source["consistent_with_assumed_cover"];
-	        this.roughness_band_note = source["roughness_band_note"];
 	        this.shear_exponent_hourly_mean = source["shear_exponent_hourly_mean"];
 	        this.shear_exponent_hourly_median = source["shear_exponent_hourly_median"];
 	        this.shear_exponent_day = source["shear_exponent_day"];
@@ -2619,9 +2587,7 @@ export namespace backend {
 	    record_maximum_ms: Record<string, number>;
 	    record_maximum_floor_ms: number;
 	    record_maximum_plausible: boolean;
-	    record_maximum_floor_note: string;
 	    calm_fraction_2m_flag_pct: number;
-	    calm_fraction_2m_note: string;
 	    nan_count: Record<string, number>;
 	    shear: WindShearDiagnostics;
 	    flags: string[];
@@ -2641,9 +2607,7 @@ export namespace backend {
 	        this.record_maximum_ms = source["record_maximum_ms"];
 	        this.record_maximum_floor_ms = source["record_maximum_floor_ms"];
 	        this.record_maximum_plausible = source["record_maximum_plausible"];
-	        this.record_maximum_floor_note = source["record_maximum_floor_note"];
 	        this.calm_fraction_2m_flag_pct = source["calm_fraction_2m_flag_pct"];
-	        this.calm_fraction_2m_note = source["calm_fraction_2m_note"];
 	        this.nan_count = source["nan_count"];
 	        this.shear = this.convertValues(source["shear"], WindShearDiagnostics);
 	        this.flags = source["flags"];
@@ -2743,9 +2707,7 @@ export namespace backend {
 	    gross_capacity_factor_no_density_correction_pct: number;
 	    gross_annual_energy_mwh_per_turbine: number;
 	    operating_regime: WindOperatingRegime;
-	    density_normalisation_note: string;
 	    hours_per_year: number;
-	    hours_per_year_note: string;
 	    excluded_losses: string[];
 	
 	    static createFrom(source: any = {}) {
@@ -2764,9 +2726,7 @@ export namespace backend {
 	        this.gross_capacity_factor_no_density_correction_pct = source["gross_capacity_factor_no_density_correction_pct"];
 	        this.gross_annual_energy_mwh_per_turbine = source["gross_annual_energy_mwh_per_turbine"];
 	        this.operating_regime = this.convertValues(source["operating_regime"], WindOperatingRegime);
-	        this.density_normalisation_note = source["density_normalisation_note"];
 	        this.hours_per_year = source["hours_per_year"];
-	        this.hours_per_year_note = source["hours_per_year_note"];
 	        this.excluded_losses = source["excluded_losses"];
 	    }
 	
@@ -2875,7 +2835,6 @@ export namespace backend {
 	    air_density_mean_kg_m3: number;
 	    air_density_min_kg_m3: number;
 	    air_density_max_kg_m3: number;
-	    humidity_note: string;
 	    monthly_mean_speed_50m: WindMonthlySpeed[];
 	    direction: WindDirection;
 	    direction_energy_rose_50m: WindRoseSector[];
@@ -2898,7 +2857,6 @@ export namespace backend {
 	        this.air_density_mean_kg_m3 = source["air_density_mean_kg_m3"];
 	        this.air_density_min_kg_m3 = source["air_density_min_kg_m3"];
 	        this.air_density_max_kg_m3 = source["air_density_max_kg_m3"];
-	        this.humidity_note = source["humidity_note"];
 	        this.monthly_mean_speed_50m = this.convertValues(source["monthly_mean_speed_50m"], WindMonthlySpeed);
 	        this.direction = this.convertValues(source["direction"], WindDirection);
 	        this.direction_energy_rose_50m = this.convertValues(source["direction_energy_rose_50m"], WindRoseSector);
@@ -2931,7 +2889,6 @@ export namespace backend {
 	    record_window: string;
 	    hub_height_m: number;
 	    qualifier: string;
-	    loads_note: string;
 	    measured: WindMeasured;
 	    hub: WindHub;
 	    shear_sensitivity: WindShearRow[];
@@ -2954,7 +2911,6 @@ export namespace backend {
 	        this.record_window = source["record_window"];
 	        this.hub_height_m = source["hub_height_m"];
 	        this.qualifier = source["qualifier"];
-	        this.loads_note = source["loads_note"];
 	        this.measured = this.convertValues(source["measured"], WindMeasured);
 	        this.hub = this.convertValues(source["hub"], WindHub);
 	        this.shear_sensitivity = this.convertValues(source["shear_sensitivity"], WindShearRow);

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -3006,6 +3006,28 @@ export namespace backend {
 		    return a;
 		}
 	}
+	export class SolarSkyView {
+	    applied: boolean;
+	    mean_horizon_deg: number;
+	    max_horizon_deg: number;
+	    threshold_deg: number;
+	    diffuse_loss_mean_pct?: number;
+	    diffuse_loss_max_pct?: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new SolarSkyView(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.applied = source["applied"];
+	        this.mean_horizon_deg = source["mean_horizon_deg"];
+	        this.max_horizon_deg = source["max_horizon_deg"];
+	        this.threshold_deg = source["threshold_deg"];
+	        this.diffuse_loss_mean_pct = source["diffuse_loss_mean_pct"];
+	        this.diffuse_loss_max_pct = source["diffuse_loss_max_pct"];
+	    }
+	}
 	export class SolarRenderScale {
 	    palette: string;
 	    min: number;
@@ -3047,6 +3069,7 @@ export namespace backend {
 	    shading_max_pct?: number;
 	    horizon_max_dist_m: number;
 	    beam_fraction: number;
+	    sky_view?: SolarSkyView;
 	    overlay_uri: string;
 	    raster_tif: string;
 	    extent: Bounds;
@@ -3074,6 +3097,7 @@ export namespace backend {
 	        this.shading_max_pct = source["shading_max_pct"];
 	        this.horizon_max_dist_m = source["horizon_max_dist_m"];
 	        this.beam_fraction = source["beam_fraction"];
+	        this.sky_view = this.convertValues(source["sky_view"], SolarSkyView);
 	        this.overlay_uri = source["overlay_uri"];
 	        this.raster_tif = source["raster_tif"];
 	        this.extent = this.convertValues(source["extent"], Bounds);
@@ -3632,6 +3656,7 @@ export namespace backend {
 		    return a;
 		}
 	}
+	
 	
 	
 	export class SolarTerrainRequest {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -3476,6 +3476,7 @@ export namespace backend {
 	    true_color_uri: string;
 	    reference_uri: string;
 	    raster_tif: string;
+	    run_id?: string;
 	    mean_confidence: number;
 	    confidence_floor?: number;
 	    n_dates: number;
@@ -3506,6 +3507,7 @@ export namespace backend {
 	        this.true_color_uri = source["true_color_uri"];
 	        this.reference_uri = source["reference_uri"];
 	        this.raster_tif = source["raster_tif"];
+	        this.run_id = source["run_id"];
 	        this.mean_confidence = source["mean_confidence"];
 	        this.confidence_floor = source["confidence_floor"];
 	        this.n_dates = source["n_dates"];
@@ -3906,6 +3908,7 @@ export namespace main {
 	
 	export class SaveProjectOverlayRequest {
 	    project_id: string;
+	    run_id: string;
 	    kind: string;
 	    title: string;
 	    meta_json: string;
@@ -3919,6 +3922,7 @@ export namespace main {
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.project_id = source["project_id"];
+	        this.run_id = source["run_id"];
 	        this.kind = source["kind"];
 	        this.title = source["title"];
 	        this.meta_json = source["meta_json"];
@@ -4102,6 +4106,7 @@ export namespace store {
 	export class ProjectOverlay {
 	    id: string;
 	    project_id: string;
+	    run_id?: string;
 	    kind: string;
 	    title: string;
 	    meta_json?: string;
@@ -4119,6 +4124,7 @@ export namespace store {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
 	        this.project_id = source["project_id"];
+	        this.run_id = source["run_id"];
 	        this.kind = source["kind"];
 	        this.title = source["title"];
 	        this.meta_json = source["meta_json"];

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -2135,6 +2135,80 @@ export namespace backend {
 	        this.bounding_box = source["bounding_box"];
 	    }
 	}
+	export class LULCClassAccuracy {
+	    class_id: number;
+	    name: string;
+	    color: string;
+	    producers_pct?: number;
+	    producers_ci?: number[];
+	    users_pct?: number;
+	    users_ci?: number[];
+	    n_reference: number;
+	    n_predicted: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new LULCClassAccuracy(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.class_id = source["class_id"];
+	        this.name = source["name"];
+	        this.color = source["color"];
+	        this.producers_pct = source["producers_pct"];
+	        this.producers_ci = source["producers_ci"];
+	        this.users_pct = source["users_pct"];
+	        this.users_ci = source["users_ci"];
+	        this.n_reference = source["n_reference"];
+	        this.n_predicted = source["n_predicted"];
+	    }
+	}
+	export class LULCAgreement {
+	    n_reference_cells: number;
+	    overall_pct: number;
+	    overall_ci: number[];
+	    quantity_disagreement_pct: number;
+	    allocation_disagreement_pct: number;
+	    per_class: LULCClassAccuracy[];
+	    n_outside_legend: number;
+	    matrix: number[][];
+	    matrix_classes: number[];
+	
+	    static createFrom(source: any = {}) {
+	        return new LULCAgreement(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.n_reference_cells = source["n_reference_cells"];
+	        this.overall_pct = source["overall_pct"];
+	        this.overall_ci = source["overall_ci"];
+	        this.quantity_disagreement_pct = source["quantity_disagreement_pct"];
+	        this.allocation_disagreement_pct = source["allocation_disagreement_pct"];
+	        this.per_class = this.convertValues(source["per_class"], LULCClassAccuracy);
+	        this.n_outside_legend = source["n_outside_legend"];
+	        this.matrix = source["matrix"];
+	        this.matrix_classes = source["matrix_classes"];
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
 	export class LULCCompareRow {
 	    class_id: number;
 	    name: string;
@@ -2243,6 +2317,7 @@ export namespace backend {
 	    pred_vs_ref: LULCCompareRow[];
 	    compare_pixels?: number;
 	    compare_reference_cells?: number;
+	    agreement?: LULCAgreement;
 	
 	    static createFrom(source: any = {}) {
 	        return new LULCAnalysis(source);
@@ -2261,6 +2336,7 @@ export namespace backend {
 	        this.pred_vs_ref = this.convertValues(source["pred_vs_ref"], LULCCompareRow);
 	        this.compare_pixels = source["compare_pixels"];
 	        this.compare_reference_cells = source["compare_reference_cells"];
+	        this.agreement = this.convertValues(source["agreement"], LULCAgreement);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -2281,6 +2357,7 @@ export namespace backend {
 		    return a;
 		}
 	}
+	
 	
 	
 	
@@ -3400,6 +3477,7 @@ export namespace backend {
 	    reference_uri: string;
 	    raster_tif: string;
 	    mean_confidence: number;
+	    confidence_floor?: number;
 	    n_dates: number;
 	    date_range: string[];
 	    class_stats: ClassStat[];
@@ -3429,6 +3507,7 @@ export namespace backend {
 	        this.reference_uri = source["reference_uri"];
 	        this.raster_tif = source["raster_tif"];
 	        this.mean_confidence = source["mean_confidence"];
+	        this.confidence_floor = source["confidence_floor"];
 	        this.n_dates = source["n_dates"];
 	        this.date_range = source["date_range"];
 	        this.class_stats = this.convertValues(source["class_stats"], ClassStat);

--- a/sidecar/energy.py
+++ b/sidecar/energy.py
@@ -74,6 +74,12 @@ SOURCE_NIST_ACRE = (
 )
 CONVENTION = "project convention, user-editable"
 
+# Cited on the waterfall row that applies it. A module constant rather than a
+# payload field because the degradation row is the only thing that ever asked.
+DEGRADATION_SOURCE = (
+    f"{SOURCE_JORDAN_KURTZ}; the analysis period is a {CONVENTION}"
+)
+
 # Exact by definition, so it is written out rather than rounded.
 ACRE_HA = 0.40468564224
 
@@ -441,18 +447,8 @@ def resolve_performance_ratio(
         "applied": applied,
         "applied_source": source,
         "reference": reference,
-        "reference_source": (
-            "solar.REFERENCE_PERFORMANCE_RATIO, benchmarked against the Global "
-            f"Solar Atlas implied band {GSA_IMPLIED_PR_BAND[0]:.3f} to "
-            f"{GSA_IMPLIED_PR_BAND[1]:.3f} over the three study sites"
-        ),
         "modelled": modelled,
         "derived": derived,
-        "derived_source": (
-            "modelled ratio times the declared PVWatts v5 terms this chain "
-            "does not model; no external benchmark exists for it, which is why "
-            "it is reported alongside the applied ratio rather than replacing it"
-        ),
         "derived_if_optional_at_pvwatts_defaults": derived_if_suggested,
         "declared_loss_factor": declared_factor,
         "optional_loss_factor": optional_factor,
@@ -463,9 +459,6 @@ def resolve_performance_ratio(
         "degradation_factor": deg,
         "degradation_rate_per_year": float(degradation_rate_per_year),
         "analysis_period_years": int(analysis_period_years),
-        "degradation_source": (
-            f"{SOURCE_JORDAN_KURTZ}; the analysis period is a {CONVENTION}"
-        ),
         "gsa_implied_band": list(GSA_IMPLIED_PR_BAND),
     }
 
@@ -698,7 +691,7 @@ def loss_waterfall(
     deg = float(ratio["degradation_factor"])
     add(
         step, "Degradation, reporting basis", deg, energy * deg, "kWh/kWp/yr",
-        cumulative * deg, "basis", False, ratio["degradation_source"],
+        cumulative * deg, "basis", False, DEGRADATION_SOURCE,
         f"Reporting basis '{ratio['reporting_basis']}'. Not a loss row: the "
         "two bases are not comparable with each other or with an external "
         "reference computed on the other basis, so the basis is printed with "
@@ -888,37 +881,6 @@ def gcr_defaults(module_efficiency: float = GCR_MODULE_EFFICIENCY) -> dict:
         ),
         "user_editable": True,
     }
-
-
-# The second efficiency the note below reports the derivation at, so a reader
-# can see how far the pair moves. Utility-scale crystalline modules span
-# roughly this range; the value is a project convention, not a measurement.
-GCR_ALTERNATE_MODULE_EFFICIENCY = 0.17
-
-
-def _module_efficiency_note() -> str:
-    """
-    What module efficiency does and does not change in the per-hectare figure.
-
-    Generated from bolinger_implied_gcr rather than written out, so the numbers
-    in the sentence cannot drift from the derivation that produced the
-    defaults. The previous fixed text asserted that the derived per-hectare
-    change moves by about 0.7 percentage points with efficiency; it does not
-    move at all, because the same efficiency divides both ratios and cancels.
-    """
-    a = bolinger_implied_gcr(GCR_MODULE_EFFICIENCY)
-    b = bolinger_implied_gcr(GCR_ALTERNATE_MODULE_EFFICIENCY)
-    return (
-        "Module efficiency does not enter this ratio because both ground "
-        "coverage ratios are supplied directly. It does enter if a caller "
-        "derives them from published capacity densities, and it then sets "
-        f"both: at {a['module_efficiency']:g} the Bolinger-implied pair is "
-        f"{a['gcr_fixed']:.4f} and {a['gcr_tracker']:.4f}, at "
-        f"{b['module_efficiency']:g} it is "
-        f"{b['gcr_fixed']:.4f} and {b['gcr_tracker']:.4f}. Their ratio is "
-        f"{a['gcr_ratio']:.4f} at both, because the efficiency divides both "
-        "ratios, so the derived per-hectare change does not move with it."
-    )
 
 
 # Published per-hectare energy densities, which are direct measurements of the
@@ -1132,7 +1094,6 @@ def tracking_comparison(
             "The derived figure moves with the ground coverage pair, and the "
             "published pairs span the point at which the sign inverts."
         ),
-        "module_efficiency_note": _module_efficiency_note(),
     }
 
     if solve_parity:
@@ -1146,14 +1107,7 @@ def tracking_comparison(
             "axis_azimuth_deg": AXIS_AZIMUTH_DEG,
             "axis_azimuth_convention": "degrees east of north",
             "max_angle_deg": float(max_angle_deg),
-            "max_angle_source": CONVENTION,
             "backtrack": TRACKER_BACKTRACK,
-            "backtrack_note": (
-                "Always on and not exposed. Without backtracking pvlib ignores "
-                "the ground coverage ratio and does not remove the row-shaded "
-                "irradiance it then permits, so the reported gain would exceed "
-                "what the plant delivers."
-            ),
             "terrain": (
                 "Flat ground. Slope-aware backtracking on sloping terrain "
                 "would change the result and is not modelled here."
@@ -1234,7 +1188,6 @@ def tracking_comparison(
             "are not modelled. This compares energy only and cannot support a "
             "siting decision on its own."
         ),
-        "resolution_note": solar.GRID_NOTE,
     }
 
 
@@ -1585,17 +1538,7 @@ def resolve_capacity_density(
         "source": spec["source"],
         "acre_conversion": SOURCE_NIST_ACRE,
         "buildable_fraction": float(buildable_fraction) if derated else None,
-        "buildable_fraction_source": (
-            f"{SOURCE_BOLINGER}, section II worked example; {CONVENTION}"
-        ) if derated else None,
         "fleet_dc_ac_ratio": float(fleet_dc_ac_ratio),
-        "fleet_dc_ac_ratio_source": (
-            "implied by the Bolinger and Bolinger (2022) sample, "
-            f"{BOLINGER_SAMPLE_MW_DC:.0f} MW_DC over "
-            f"{BOLINGER_SAMPLE_MW_AC:.0f} MW_AC. It is a fleet ratio and is "
-            "not the model-internal inverter sizing constant in solar.py, "
-            "which is a different quantity."
-        ),
         "ac_to_dc_conversion_applied": converted,
         "note": (
             "The choice of basis moves the answer further than the exceedance "
@@ -1687,19 +1630,12 @@ def exceedance_table(
             "test": "Shapiro-Wilk",
             "statistic": round(float(sw.statistic), 5),
             "p_value": round(float(sw.pvalue), 4),
-            "interpretation": (
-                "normality is not rejected at the 5 percent level"
-                if float(sw.pvalue) >= 0.05
-                else "normality is rejected at the 5 percent level, so the "
-                     "normal-fit column is biased in the tails"
-            ),
         }
     else:
         normality = {
             "test": "Shapiro-Wilk",
             "statistic": None,
             "p_value": None,
-            "interpretation": "fewer than three complete years, not tested",
         }
 
     return {
@@ -1716,12 +1652,6 @@ def exceedance_table(
         "std_kwh_m2_year": round(std, 2),
         "cv_pct": round(100.0 * cv, 3),
         "levels": rows,
-        "p50_note": (
-            "The applied P50 factor is the median annual total over the mean "
-            "annual total and is not exactly 1.0, because the specific yield "
-            "is built on the mean year while the empirical estimator reads the "
-            "median. The difference is reported rather than forced to unity."
-        ),
         "normality": normality,
         "crosswalk": {
             "exceedance_p90_kwh_m2_year": round(

--- a/sidecar/energy.py
+++ b/sidecar/energy.py
@@ -62,7 +62,11 @@ SOURCE_FAIMAN = (
 )
 SOURCE_ASHRAE_IAM = (
     "Souka, A. F. and Safwat, H. H. (1966), as implemented by pvlib.iam.ashrae "
-    "with the default coefficient b=0.05"
+    "with the default coefficient b=0.05; the diffuse terms use the same "
+    "relation integrated over the sky and ground solid angles per "
+    "Marion, B. (2013), Numerical method for angle-of-incidence correction "
+    "factors for diffuse radiation incident on photovoltaic modules, "
+    "Solar Energy 92:84-89, doi:10.1016/j.solener.2013.02.029"
 )
 SOURCE_IEC_61724 = (
     "IEC 61724-1, which defines the performance ratio against the "
@@ -594,12 +598,14 @@ def loss_waterfall(
     )
 
     add(
-        4, "Angle of incidence on the beam component (ASHRAE)",
+        4, "Angle of incidence, beam and diffuse (ASHRAE)",
         f["f_iam"], e_geff, "kWh/m2/yr", f["f_iam"], "modelled", True,
         SOURCE_ASHRAE_IAM,
-        "Applied to the beam component only. The diffuse component receives "
-        "no incidence-angle correction in this chain, which is a "
-        "simplification inside the modelled ratio.",
+        "Applied to all three components. The beam correction follows the "
+        "hourly incidence angle; sky and ground diffuse carry the same "
+        "relation integrated over the solid angle each occupies, which depends "
+        "on tilt alone. Ground-reflected light arrives near-grazing and is the "
+        "strongly corrected term.",
     )
 
     add(

--- a/sidecar/infer.py
+++ b/sidecar/infer.py
@@ -1999,7 +1999,6 @@ def main():
                         float(density['value_mw_dc_per_ha']), 6),
                     'shading_applied': shading_applied,
                     'shading_derate': shading_derate,
-                    'resolution_note': solar_mod.GRID_NOTE,
                     'note': (
                         'Every energy figure in this response was computed at '
                         'the applied performance ratio and the reporting basis '
@@ -2105,12 +2104,6 @@ def main():
                 'roughness_band_m': list(roughness_band),
                 'calm_threshold_ms': calm_threshold,
                 'record_max_floor_ms': record_max_floor,
-                'conventions_note': (
-                    'Hub height, the assumed roughness band, the calm '
-                    'threshold and the record-maximum floor are project '
-                    'conventions the user can edit. They are not measurements '
-                    'and they have no published basis at this site.'
-                ),
                 'qualifier': wind_mod.RESULT_QUALIFIER,
                 'excluded_losses': list(wind_mod.EXCLUDED_LOSSES),
                 'comparison_note': (
@@ -2120,7 +2113,6 @@ def main():
                     'ratio benchmarked against the Global Solar Atlas; this '
                     'one carries no external validation and no plant losses.'
                 ),
-                'resolution_note': wind_mod.GRID_NOTE,
             },
         })
 

--- a/sidecar/infer.py
+++ b/sidecar/infer.py
@@ -1476,13 +1476,30 @@ def main():
 
         beam_share = solar_mod.beam_fraction(df)
 
+        # Whether the terrain encloses the site enough for the diffuse loss to
+        # be a figure rather than noise. Read off the horizon already traced, so
+        # the test costs nothing; below the threshold the sky view factor is a
+        # rounding term and applying it would spend the arithmetic on noise.
+        enclosure = solar_mod.horizon_enclosure(horizon)
+        svf_loss = (
+            solar_mod.diffuse_loss_fraction(horizon)
+            if enclosure['encloses'] else None
+        )
+
         def _poa_for(name):
             """Plane-of-array total for a season, attenuated by terrain shading.
 
-            Shading removes beam energy only, so the per-pixel loss is scaled by
-            the beam share of the irradiation before it is applied. The loss
-            itself is returned unscaled, which is what the published layer and
-            the research figures report.
+            Two losses, on two bases. The horizon blocks beam energy below it,
+            which is scaled by the beam share before it is applied; and it hides
+            part of the sky dome, which removes diffuse energy in proportion to
+            the sky view factor. The beam term is the expensive one to compute
+            and the small one to collect -- on flat ground both vanish, but in
+            enclosed terrain the diffuse term is the larger by two orders of
+            magnitude, and the horizon that answers the first already answers
+            the second.
+
+            The published shading layer stays the unscaled beam fraction, which
+            is what the research figures report.
             """
             m = solar_mod.season_mask(df.index, name)
             sub, sp = df[m], solpos[m]
@@ -1493,7 +1510,10 @@ def main():
             raw = solar_mod.interpolate_poa(slope, aspect, tbl)
             hist, edges = solar_mod.beam_energy_histogram(sub, sp)
             loss = solar_mod.shading_loss_fraction(horizon, hist, edges)
-            return raw * (1.0 - loss * beam_share), loss
+            attenuated = raw * (1.0 - loss * beam_share)
+            if svf_loss is not None:
+                attenuated = attenuated * (1.0 - svf_loss * (1.0 - beam_share))
+            return attenuated, loss
 
         emit_progress(76, 'plane-of-array lookup')
         companion = None
@@ -1594,6 +1614,23 @@ def main():
                 ),
                 'horizon_max_dist_m': float(solar_mod.HORIZON_MAX_DIST_M),
                 'beam_fraction': round(float(beam_share), 4),
+                # The sky view factor and the threshold it was judged against.
+                # Reported whether or not it was applied: "not applied" and
+                # "applied at zero" are different statements about the terrain.
+                'sky_view': {
+                    'applied': bool(svf_loss is not None),
+                    'mean_horizon_deg': enclosure['mean_horizon_deg'],
+                    'max_horizon_deg': enclosure['max_horizon_deg'],
+                    'threshold_deg': enclosure['threshold_deg'],
+                    'diffuse_loss_mean_pct': (
+                        round(float(100.0 * np.nanmean(svf_loss[valid])), 3)
+                        if svf_loss is not None else None
+                    ),
+                    'diffuse_loss_max_pct': (
+                        round(float(100.0 * np.nanmax(svf_loss[valid])), 3)
+                        if svf_loss is not None else None
+                    ),
+                },
                 'dem_source': 'Copernicus DEM GLO-30',
                 # Whether the POWER series behind this layer was fetched or
                 # read from the on-disk cache, and when it was fetched.

--- a/sidecar/infer.py
+++ b/sidecar/infer.py
@@ -2641,6 +2641,18 @@ def main():
         write_overlay_png(ref_cls, reference_png)
         reference_path = str(reference_png)
     mean_conf = float(confidence_map[classification_map >= 0].mean()) if np.any(classification_map >= 0) else 0.0
+    # The floor this figure cannot go below.
+    #
+    # confidence is max(predict_proba), so with K classes it lives on [1/K, 1]
+    # and never approaches zero. Reported as a bare percentage it reads on a
+    # 0-100 scale it does not occupy: 38% over five classes is a fifth of the
+    # way from maximum uncertainty to certainty, not a third. The consumer
+    # needs K to say that, and only this side knows it.
+    conf_floor = (
+        1.0 / len(label_encoder.classes_)
+        if label_encoder is not None and len(getattr(label_encoder, 'classes_', [])) > 0
+        else 0.0
+    )
 
     lulc_payload = None
     if mapbiomas_path and Path(mapbiomas_path).exists():
@@ -2672,6 +2684,13 @@ def main():
                 n_cells = lulc_mod.distinct_reference_cells(cell_ids, valid)
                 if n_cells is not None:
                     lulc_payload['compare_reference_cells'] = n_cells
+                # Agreement, which the composition comparison beside it cannot
+                # show: equal marginals are not equal maps.
+                agreement = lulc_mod.agreement_against_reference(
+                    classification_map, ref_grid, cell_ids=cell_ids
+                )
+                if agreement is not None:
+                    lulc_payload['agreement'] = agreement
         except Exception as e:
             sys.stderr.write(json.dumps({
                 'progress': -1, 'msg': f'lulc analysis skipped: {e}'
@@ -2692,6 +2711,7 @@ def main():
         'true_color_png': true_color_path,
         'reference_png': reference_path,
         'mean_confidence': round(mean_conf, 4),
+        'confidence_floor': round(conf_floor, 4),
         'n_dates': len(products),
         'date_range': [
             products[0]['date'].strftime('%Y-%m-%d'),

--- a/sidecar/lulc.py
+++ b/sidecar/lulc.py
@@ -355,6 +355,155 @@ def distinct_reference_cells(
     return int(np.unique(cell_ids[mask]).size)
 
 
+def _wilson_interval(k: int, n: int, z: float = 1.96) -> list[float]:
+    """
+    Wilson score interval for a proportion.
+
+    Not the normal approximation: at the accuracies and sample sizes seen here
+    the Wald interval runs past 0 or 1 and is known to undercover, while Wilson
+    stays inside the unit interval and holds its nominal rate at small n
+    (Brown, Cai & DasGupta 2001).
+    """
+    if n <= 0:
+        return [0.0, 0.0]
+    p = k / n
+    denom = 1.0 + z * z / n
+    centre = (p + z * z / (2 * n)) / denom
+    half = z * ((p * (1 - p) / n + z * z / (4 * n * n)) ** 0.5) / denom
+    return [
+        float(round(100.0 * max(0.0, centre - half), 2)),
+        float(round(100.0 * min(1.0, centre + half), 2)),
+    ]
+
+
+def agreement_against_reference(
+    pred_map: np.ndarray,
+    ref_map: np.ndarray,
+    cell_ids: np.ndarray | None = None,
+) -> dict | None:
+    """
+    Per-cell agreement between the classification and the reference.
+
+    WHY THIS EXISTS BESIDE pred_vs_ref_composition. That function compares the
+    two marginal distributions -- how much of each class each map holds. Equal
+    marginals are not agreement: a classifier that swaps soybean for other
+    temporary crops in equal measure reproduces the reference composition
+    exactly while being wrong on every pixel it swapped. The decomposition
+    below separates the two, and the composition panel was showing the quantity
+    component alone.
+
+    AGGREGATED TO THE REFERENCE CELL, NOT THE PIXEL. MapBiomas is native at
+    30 m and is resampled onto the 10 m classification grid, so about nine
+    pixels carry one label observation. Counting pixels would state a sample
+    size nine times the number of independent labels and an interval about
+    three times too narrow. Each native cell contributes one observation: the
+    reference label it carries, against the majority class predicted across its
+    pixels.
+
+    Returns None when the cell mapping is unavailable, because without it there
+    is no honest denominator -- and an accuracy with the wrong n is worse than
+    no accuracy, since it is still believed.
+    """
+    if cell_ids is None:
+        return None
+
+    valid = (pred_map >= 0) & (ref_map > 0)
+    if not valid.any():
+        return None
+
+    cells = cell_ids[valid]
+    preds = pred_map[valid]
+    refs = ref_map[valid]
+
+    order = np.argsort(cells, kind="stable")
+    cells_s, preds_s, refs_s = cells[order], preds[order], refs[order]
+    # Contiguous runs of one cell id, so each native cell is visited once.
+    starts = np.flatnonzero(np.r_[True, cells_s[1:] != cells_s[:-1]])
+    bounds = np.r_[starts, cells_s.size]
+
+    classes = list(TARGET_COMPARE)
+    index = {c: i for i, c in enumerate(classes)}
+    k = len(classes)
+    matrix = np.zeros((k, k), dtype=np.int64)  # rows predicted, cols reference
+    outside = 0
+
+    for a, b in zip(bounds[:-1], bounds[1:]):
+        ref_vals = refs_s[a:b]
+        # One reference label per native cell; the mode guards a cell straddling
+        # a resampling boundary rather than assuming the run is homogeneous.
+        rv, rc = np.unique(ref_vals, return_counts=True)
+        ref_label = int(rv[int(np.argmax(rc))])
+        if ref_label not in index:
+            # The reference says something the classifier has no label for --
+            # water, urban, forestry. Counting it as an error would conflate
+            # "misclassified" with "not in the legend", so it is reported
+            # separately instead.
+            outside += 1
+            continue
+        pv, pc = np.unique(preds_s[a:b], return_counts=True)
+        pred_label = int(pv[int(np.argmax(pc))])
+        if pred_label not in index:
+            continue
+        matrix[index[pred_label], index[ref_label]] += 1
+
+    n = int(matrix.sum())
+    if n == 0:
+        return None
+
+    correct = int(np.trace(matrix))
+    pred_tot = matrix.sum(axis=1)  # predicted totals (rows)
+    ref_tot = matrix.sum(axis=0)   # reference totals (cols)
+
+    per_class = []
+    for c in classes:
+        i = index[c]
+        hit = int(matrix[i, i])
+        pa = float(round(100.0 * hit / ref_tot[i], 2)) if ref_tot[i] else None
+        ua = float(round(100.0 * hit / pred_tot[i], 2)) if pred_tot[i] else None
+        per_class.append({
+            "class_id": c,
+            "name": MAPBIOMAS_LEGEND.get(c, f"Class {c}"),
+            "color": MAPBIOMAS_COLORS.get(c, "#bbbbbb"),
+            # Producer's accuracy: of the reference cells of this class, the
+            # share the classifier found. Its complement is omission.
+            "producers_pct": pa,
+            "producers_ci": _wilson_interval(hit, int(ref_tot[i])) if ref_tot[i] else None,
+            # User's accuracy: of the cells called this class, the share that
+            # really are. Its complement is commission.
+            "users_pct": ua,
+            "users_ci": _wilson_interval(hit, int(pred_tot[i])) if pred_tot[i] else None,
+            "n_reference": int(ref_tot[i]),
+            "n_predicted": int(pred_tot[i]),
+        })
+
+    # Pontius & Millones (2011): total disagreement splits into a quantity term
+    # -- the two maps hold different amounts of a class -- and an allocation
+    # term -- they hold the same amount in different places. Kappa is omitted
+    # deliberately; that paper's argument against it is what this replaces.
+    p = matrix / n
+    p_pred = p.sum(axis=1)
+    p_ref = p.sum(axis=0)
+    diag = np.diag(p)
+    quantity = float(0.5 * np.abs(p_pred - p_ref).sum())
+    allocation = float(
+        0.5 * sum(2 * min(p_pred[i] - diag[i], p_ref[i] - diag[i]) for i in range(k))
+    )
+
+    return {
+        "n_reference_cells": n,
+        "overall_pct": float(round(100.0 * correct / n, 2)),
+        "overall_ci": _wilson_interval(correct, n),
+        "quantity_disagreement_pct": float(round(100.0 * quantity, 2)),
+        "allocation_disagreement_pct": float(round(100.0 * allocation, 2)),
+        "per_class": per_class,
+        # Reference cells whose class the model has no label for. Not errors,
+        # but the share of the area the assessment says nothing about.
+        "n_outside_legend": int(outside),
+        "matrix": matrix.tolist(),
+        "matrix_classes": classes,
+    }
+
+
 def pred_vs_ref_composition(
     pred_map: np.ndarray,
     ref_map: np.ndarray,

--- a/sidecar/solar.py
+++ b/sidecar/solar.py
@@ -32,6 +32,8 @@ import time
 import urllib.error
 import urllib.request
 
+import functools
+
 import numpy as np
 import pandas as pd
 
@@ -80,6 +82,10 @@ INVERTER_OVERSIZE_RATIO = 1.15
 FAIMAN_U0 = 25.0
 FAIMAN_U1 = 6.84
 ALBEDO = 0.20
+# ASHRAE incidence-angle coefficient. Named because the beam correction and the
+# diffuse one have to be the same relation integrated differently; two literals
+# would let them drift apart.
+IAM_ASHRAE_B = 0.05
 TRANSPOSITION_MODEL = "perez"
 SOLAR_CONSTANT = 1361.0      # W/m2, Kopp and Lean (2011)
 
@@ -305,6 +311,54 @@ def sweep_tilt(
     return rows
 
 
+# Tilt resolution the diffuse modifier is evaluated on, in degrees.
+#
+# marion_diffuse integrates the incidence relation over the sky dome and the
+# ground plane numerically, allocating a grid per tilt it is given. That is
+# unremarkable for a fixed array, which has one tilt, and ruinous for a tracker,
+# which has one per hour: passing the raw 17520-value tracker series built a
+# grid for every hour of the record at once and drove resident memory into tens
+# of gigabytes. Rounding to a tenth of a degree bounds the distinct values at
+# 901 over the full 0-90 range, and the modifier varies by under 1e-4 across a
+# step that size, so nothing measurable is lost.
+DIFFUSE_IAM_TILT_DECIMALS = 1
+
+
+@functools.lru_cache(maxsize=1024)
+def _diffuse_iam_scalar(tilt: float) -> tuple:
+    """
+    Sky and ground incidence modifiers for one tilt, as a hashable pair list.
+
+    Cached because the value depends on the tilt alone: the sky dome and the
+    ground plane subtend the same solid angles every hour of the year, so the
+    integral is a property of the geometry rather than of the record.
+    """
+    import pvlib
+
+    d = pvlib.iam.marion_diffuse("ashrae", float(tilt), b=IAM_ASHRAE_B)
+    return tuple((k, float(v)) for k, v in d.items())
+
+
+def diffuse_iam(tilt):
+    """
+    Sky and ground incidence modifiers, for a fixed tilt or a tracker series.
+
+    Returns floats for a scalar tilt and aligned Series for a varying one, so
+    the caller multiplies without caring which it has.
+    """
+    if np.isscalar(tilt) or (getattr(tilt, "ndim", 0) == 0):
+        return dict(_diffuse_iam_scalar(round(float(tilt), DIFFUSE_IAM_TILT_DECIMALS)))
+
+    t = pd.Series(tilt)
+    keys = np.round(t.to_numpy(dtype=float), DIFFUSE_IAM_TILT_DECIMALS)
+    # One integration per distinct angle, not one per hour.
+    lookup = {k: dict(_diffuse_iam_scalar(float(k))) for k in np.unique(keys)}
+    return {
+        part: pd.Series([lookup[k][part] for k in keys], index=t.index)
+        for part in ("sky", "ground")
+    }
+
+
 def pv_yield_frame(
     poa, df: pd.DataFrame, solpos: pd.DataFrame, tilt: float, azimuth: float
 ) -> pd.DataFrame:
@@ -323,14 +377,44 @@ def pv_yield_frame(
     """
     import pvlib
 
-    # POA irradiance after the angle-of-incidence loss on the beam component.
+    # POA irradiance after the angle-of-incidence loss.
+    #
     # IAM is NaN where the sun is behind the plane, which must read as no beam
     # rather than as a missing hour, and the sum is floored at zero.
+    #
+    # The diffuse components carry their own incidence-angle correction. Sky and
+    # ground diffuse arrive from the whole hemisphere the plane sees, so their
+    # effective incidence angle is a property of the tilt, not of the hour:
+    # Marion (2013) integrates the ASHRAE relation over each solid angle once
+    # per tilt. Ground-reflected light is the strongly corrected term because it
+    # arrives near-grazing -- at 10 degrees of tilt it keeps 0.466 against 0.956
+    # for the sky.
+    #
+    # This is a physics change, not a refactor, and every yield built on it
+    # moves. At the reference site the IAM factor falls from 0.98694 to 0.97136
+    # and the specific yield from 1474.73 to 1450.78 kWh/kWp/yr, which is
+    # -1.62 percent.
+    #
+    # The size of the shift scales with how diffuse the site is, so it cannot be
+    # quoted as one number: under a clear sky, where the diffuse share is 0.14,
+    # the same correction costs 0.75 percent, and at the reference site's ~0.40
+    # it costs 1.62. The ground term drives it -- reflected light arrives
+    # near-grazing and keeps 0.788 at 26 degrees of tilt against 0.961 for the
+    # sky.
+    #
+    # It is made because the omission was a declared overstatement in the loss
+    # waterfall, and correcting it moves the chain toward the Global Solar Atlas
+    # reference it is benchmarked against, not away from it.
     aoi = pvlib.irradiance.aoi(
         tilt, azimuth, solpos["apparent_zenith"], solpos["azimuth"]
     )
     iam = pvlib.iam.ashrae(aoi)
-    g_eff = (poa["poa_direct"] * iam.fillna(0.0) + poa["poa_diffuse"]).clip(lower=0.0)
+    iam_diffuse = diffuse_iam(tilt)
+    g_eff = (
+        poa["poa_direct"] * iam.fillna(0.0)
+        + poa["poa_sky_diffuse"] * iam_diffuse["sky"]
+        + poa["poa_ground_diffuse"] * iam_diffuse["ground"]
+    ).clip(lower=0.0)
     temp_cell = pvlib.temperature.faiman(
         poa["poa_global"], df["temp_air"], df["wind"], u0=FAIMAN_U0, u1=FAIMAN_U1
     )
@@ -595,6 +679,65 @@ def beam_fraction(df) -> float:
     if ghi <= 0:
         return 0.0
     return float(np.clip((ghi - dhi) / ghi, 0.0, 1.0))
+
+
+# Below this mean horizon there is no enclosure to measure. Derived from the
+# relation between the two: an isotropic sky view of cos^2(h) puts a 2 degree
+# mean horizon at a 0.12 percent diffuse loss, which is under the rounding of
+# every figure this module publishes. The threshold is read off the horizon the
+# chain already traced, so it costs nothing to evaluate.
+SVF_MIN_MEAN_HORIZON_DEG = 2.0
+
+
+def sky_view_factor(horizon: np.ndarray) -> np.ndarray:
+    """
+    Share of the isotropic sky dome each pixel still sees.
+
+    For a horizon elevation h in an azimuth sector, the fraction of the diffuse
+    hemisphere that sector still admits is cos^2(h) (the sector integral of the
+    isotropic radiance weighted by the cosine response of a horizontal plane).
+    Averaging over sectors gives the pixel's sky view factor.
+
+    Shading removed beam energy only, which is the expensive half to compute and
+    the small half to collect: measured on a synthetic incised valley the beam
+    term moves the median yield by -0.003 percent while the diffuse term moves
+    it by -2.82 percent. On flat ground both vanish (-0.04 percent). The horizon
+    that carries the beam answer already carries this one.
+    """
+    if horizon.size == 0:
+        return np.ones(horizon.shape[:2], dtype=float)
+    h = np.clip(np.nan_to_num(horizon, nan=0.0), 0.0, 90.0)
+    return np.clip(np.cos(np.radians(h)) ** 2, 0.0, 1.0).mean(axis=2)
+
+
+def diffuse_loss_fraction(horizon: np.ndarray) -> np.ndarray:
+    """Share of the diffuse irradiance each pixel loses to its own horizon."""
+    return np.clip(1.0 - sky_view_factor(horizon), 0.0, 1.0)
+
+
+def horizon_enclosure(horizon: np.ndarray) -> dict:
+    """
+    Whether the terrain encloses the site enough for the diffuse loss to be a
+    figure rather than noise, and the evidence for the verdict.
+
+    Returned rather than applied, so the caller reports the threshold it was
+    judged against instead of a bare boolean.
+    """
+    if horizon.size == 0:
+        return {
+            "mean_horizon_deg": 0.0,
+            "max_horizon_deg": 0.0,
+            "threshold_deg": SVF_MIN_MEAN_HORIZON_DEG,
+            "encloses": False,
+        }
+    h = np.clip(np.nan_to_num(horizon, nan=0.0), 0.0, 90.0)
+    mean_h = float(np.mean(h))
+    return {
+        "mean_horizon_deg": round(mean_h, 4),
+        "max_horizon_deg": round(float(np.max(h)), 4),
+        "threshold_deg": SVF_MIN_MEAN_HORIZON_DEG,
+        "encloses": bool(mean_h >= SVF_MIN_MEAN_HORIZON_DEG),
+    }
 
 
 def fetch_dem(polygon, out_path, buffer_m: float = 0.0) -> str:

--- a/sidecar/tests/test_energy.py
+++ b/sidecar/tests/test_energy.py
@@ -224,8 +224,6 @@ def test_applied_ratio_defaults_to_the_benchmarked_reference():
     low, high = ratio["gsa_implied_band"]
     assert low <= ratio["reference"] <= high
     assert ratio["applied"] != ratio["derived"]
-    assert "no external benchmark" in ratio["derived_source"]
-    assert "Global Solar Atlas" in ratio["reference_source"]
 
 
 def test_user_override_is_recorded_as_a_user_value():
@@ -719,7 +717,6 @@ def test_the_fleet_dc_ac_ratio_is_not_the_inverter_oversize_constant():
     assert density["ac_to_dc_conversion_applied"] is True
     assert energy.FLEET_DC_AC_RATIO != solar.INVERTER_OVERSIZE_RATIO
     assert abs(energy.FLEET_DC_AC_RATIO - 35482.0 / 27001.0) < 1e-12
-    assert "not the model-internal inverter" in density["fleet_dc_ac_ratio_source"]
     dc_denominated = energy.resolve_capacity_density("bolinger_fixed_direct")
     assert dc_denominated["ac_to_dc_conversion_applied"] is False
 
@@ -784,7 +781,6 @@ def test_the_p50_factor_is_reported_as_measured_rather_than_forced_to_unity():
     table = energy.exceedance_table(_annual_totals())
     p50 = [r for r in table["levels"] if r["level"] == 50][0]
     assert p50["factor_empirical"] != 1.0
-    assert "median" in table["p50_note"]
 
 
 def test_the_crosswalk_shows_the_two_conventions_are_one_number():
@@ -1160,11 +1156,6 @@ def test_module_efficiency_cancels_from_the_ground_coverage_ratio():
     ) < 1e-12
     with pytest.raises(ValueError):
         energy.bolinger_implied_gcr(0.0)
-
-    note = energy._module_efficiency_note()
-    assert f"{a['gcr_ratio']:.4f} at both" in note
-    assert "does not move with it" in note
-    assert "0.7 percentage points" not in note
 
 
 def test_every_payload_crosses_the_sidecar_boundary_as_json():

--- a/sidecar/tests/test_energy.py
+++ b/sidecar/tests/test_energy.py
@@ -1293,17 +1293,23 @@ def test_reference_site_reproduces_the_stored_factor_stack():
     f = site["ratio"]["factors"]
     assert site["tilt"] == 26.0
     assert abs(f["energy_poa_kwh_m2_year"] - 1884.6070) < 5e-5
-    assert abs(f["f_iam"] - 0.986940) < 5e-7
-    assert abs(f["f_temp"] - 0.907776) < 5e-7
-    assert abs(f["f_inverter"] - 0.956416) < 5e-7
-    assert abs(f["temp_cell_irradiance_weighted_c"] - 51.350) < 5e-4
-    assert abs(f["performance_ratio_modelled"] - 0.856873) < 5e-7
+    # The stack below moved when the angle-of-incidence correction reached the
+    # diffuse components. f_iam fell 0.98694 -> 0.97136 (-1.58 percent), and the
+    # terms after it followed: less effective irradiance means a cooler cell
+    # (f_temp up) and a lower inverter load factor (f_inverter down). The
+    # transposed irradiance above is untouched, which is the check that this was
+    # the incidence angle and not the transposition.
+    assert abs(f["f_iam"] - 0.971361) < 5e-7
+    assert abs(f["f_temp"] - 0.907540) < 5e-7
+    assert abs(f["f_inverter"] - 0.956228) < 5e-7
+    assert abs(f["temp_cell_irradiance_weighted_c"] - 51.417) < 5e-4
+    assert abs(f["performance_ratio_modelled"] - 0.842962) < 5e-7
     # The module's own tolerance, not exact zero: the residual is a difference
     # of floating point sums and lands at 1.1e-16 on this series. Pinning it to
     # exactly 0.0 would fail on a rounding change that modelled_factors itself
     # accepts, and modelled_factors raises above TELESCOPING_TOLERANCE anyway.
     assert abs(f["telescoping_residual"]) <= energy.TELESCOPING_TOLERANCE
-    assert abs(site["ratio"]["derived"] - 0.7825084) < 5e-7
+    assert abs(site["ratio"]["derived"] - 0.7698046) < 5e-7
 
 
 @requires_reference_series
@@ -1328,9 +1334,13 @@ def test_reference_site_reproduces_the_stored_yield_and_capacity_factor():
     delivered = waterfall["delivered"]
     assert abs(delivered["applied_kwh_kwp_year"] - 1507.69) < 0.01
     assert abs(delivered["applied_capacity_factor_pct"] - 17.2111) < 5e-4
-    assert abs(delivered["derived_kwh_kwp_year"] - 1474.73) < 0.01
-    assert abs(delivered["derived_capacity_factor_pct"] - 16.8348) < 5e-4
-    assert abs(delivered["difference_pct"] - (-2.1864)) < 5e-4
+    # The applied figures are computed at the benchmarked reference ratio and
+    # do not move with the model. The derived ones are this chain's own answer,
+    # so they carry the diffuse incidence correction: 1474.73 -> 1450.78, and
+    # the gap to the applied yield widens from -2.19 to -3.77 percent.
+    assert abs(delivered["derived_kwh_kwp_year"] - 1450.78) < 0.01
+    assert abs(delivered["derived_capacity_factor_pct"] - 16.5614) < 5e-4
+    assert abs(delivered["difference_pct"] - (-3.7744)) < 5e-4
 
 
 @requires_reference_series
@@ -1345,9 +1355,11 @@ def test_reference_site_reproduces_the_stored_tracking_comparison():
     assert abs(tracking["poa_kwh_m2_year"] - 2248.646) < 5e-5
     assert abs(tracking["specific_yield_kwh_kwp_year"] - 1798.92) < 0.01
     assert abs(tracking["capacity_factor_pct"] - 20.536) < 5e-4
-    assert abs(tracking["performance_ratio_modelled"] - 0.85827) < 5e-7
+    # Yield and capacity factor are computed at the applied ratio, so only the
+    # modelled ratio moves with the incidence correction.
+    assert abs(tracking["performance_ratio_modelled"] - 0.845678) < 5e-7
     assert abs(result["per_kwp"]["gain_pct"] - 19.316) < 5e-4
-    assert result["performance_ratio"]["transfer_range_pct"] == [0.1631, 0.4742]
+    assert result["performance_ratio"]["transfer_range_pct"] == [0.3222, 0.6327]
     seasons = {r["season"]: r["gain_pct"] for r in result["seasonal"]["rows"]}
     assert seasons == {
         "annual": 19.32, "winter": 0.5, "summer": 36.4, "winter_crop": 3.46

--- a/sidecar/tests/test_lulc.py
+++ b/sidecar/tests/test_lulc.py
@@ -162,3 +162,148 @@ def test_pred_vs_ref_without_cell_ids_omits_the_field():
     rows = lulc.pred_vs_ref_composition(pred, ref)
     assert all("n_reference_cells" not in r for r in rows)
     assert all("pixels_ref" in r for r in rows)
+
+
+# --- Agreement against the reference ---------------------------------------
+#
+# These protect the distinction the whole panel exists to make: composition
+# equality is not agreement. Each case below is constructed so the expected
+# figures are known exactly, because an accuracy that is merely plausible is
+# worse than none -- it is still believed.
+
+
+def _cell_grid(h=30, w=30, block=3):
+    """A 10 m grid whose pixels carry the id of the 30 m cell above them."""
+    yy, xx = np.mgrid[0:h, 0:w]
+    return (yy // block) * (w // block) + (xx // block)
+
+
+def test_agreement_counts_reference_cells_not_pixels():
+    """
+    The denominator is the number of independent label observations.
+
+    MapBiomas is native at 30 m, so nine 10 m pixels carry one label. Counting
+    pixels would state nine times the sample size and an interval about three
+    times too narrow.
+    """
+    cells = _cell_grid()
+    ref = np.full((30, 30), 39)
+    pred = ref.copy()
+    out = lulc.agreement_against_reference(pred, ref, cells)
+    assert out["n_reference_cells"] == 100  # not 900
+    assert out["overall_pct"] == 100.0
+
+
+def test_equal_composition_can_be_total_disagreement():
+    """
+    The case the composition panel cannot see.
+
+    Swapping two classes in equal measure reproduces the reference composition
+    exactly and is wrong on every cell. Composition reports both classes at
+    50/50 and looks perfect; agreement reports zero.
+    """
+    cells = _cell_grid()
+    half = cells < 50
+    pred = np.where(half, 39, 41)
+    ref = np.where(half, 41, 39)
+
+    comp = {r["class_id"]: r for r in lulc.pred_vs_ref_composition(pred, ref, cells)}
+    assert comp[39]["pct_ref"] == comp[39]["pct_pred"]  # composition agrees
+    assert comp[41]["pct_ref"] == comp[41]["pct_pred"]
+
+    out = lulc.agreement_against_reference(pred, ref, cells)
+    assert out["overall_pct"] == 0.0
+    # All of the disagreement is allocation: the amounts match, the places do not.
+    assert out["allocation_disagreement_pct"] == 100.0
+    assert out["quantity_disagreement_pct"] == 0.0
+
+
+def test_disagreement_decomposition_sums_to_the_complement_of_accuracy():
+    """Pontius & Millones (2011): OA + quantity + allocation = 100%."""
+    cells = _cell_grid()
+    ref = np.where(cells < 50, 39, 41)
+    pred = ref.copy()
+    pred[(cells >= 30) & (cells < 50)] = 41  # 20 cells wrong, one direction
+
+    out = lulc.agreement_against_reference(pred, ref, cells)
+    total = (
+        out["overall_pct"]
+        + out["quantity_disagreement_pct"]
+        + out["allocation_disagreement_pct"]
+    )
+    assert abs(total - 100.0) < 1e-6
+    assert out["overall_pct"] == 80.0
+    # One-directional error is a quantity difference, not a misplacement.
+    assert out["quantity_disagreement_pct"] == 20.0
+    assert out["allocation_disagreement_pct"] == 0.0
+
+
+def test_producers_and_users_accuracy_are_distinct():
+    """
+    A map that over-calls one class scores perfectly on one and poorly on the
+    other, which is why neither is reported alone.
+    """
+    cells = _cell_grid()
+    ref = np.where(cells < 50, 39, 41)
+    pred = ref.copy()
+    pred[(cells >= 30) & (cells < 50)] = 41
+
+    out = lulc.agreement_against_reference(pred, ref, cells)
+    per = {c["class_id"]: c for c in out["per_class"]}
+    # 30 of the 50 soybean cells were found.
+    assert per[39]["producers_pct"] == 60.0
+    # Everything called soybean really is soybean.
+    assert per[39]["users_pct"] == 100.0
+    # Every 41 cell was found, but 70 cells were called 41 and only 50 are.
+    assert per[41]["producers_pct"] == 100.0
+    assert abs(per[41]["users_pct"] - 100.0 * 50 / 70) < 0.01
+
+
+def test_majority_decides_a_cell():
+    """A minority of dissenting pixels does not flip its reference cell."""
+    cells = _cell_grid()
+    ref = np.full((30, 30), 39)
+    pred = ref.copy()
+    _, xx = np.mgrid[0:30, 0:30]
+    pred[(cells == 0) & (xx % 3 == 0)] = 41  # 3 of 9 pixels dissent
+    out = lulc.agreement_against_reference(pred, ref, cells)
+    assert out["overall_pct"] == 100.0
+
+
+def test_reference_classes_outside_the_legend_are_excluded_not_counted_wrong():
+    """
+    The classifier has no label for water or urban, so a cell carrying one is
+    not a misclassification. Counting it as an error would conflate "wrong"
+    with "not representable", and the count is reported instead.
+    """
+    cells = _cell_grid()
+    ref = np.where(cells < 10, 33, 39)  # 10 cells of water
+    pred = np.full((30, 30), 39)
+    out = lulc.agreement_against_reference(pred, ref, cells)
+    assert out["n_outside_legend"] == 10
+    assert out["n_reference_cells"] == 90
+    assert out["overall_pct"] == 100.0  # perfect on what it can represent
+
+
+def test_agreement_is_absent_without_the_cell_mapping():
+    """
+    No cell mapping means no honest denominator, so nothing is reported. An
+    accuracy computed over the wrong n is worse than a missing one.
+    """
+    ref = np.full((30, 30), 39)
+    assert lulc.agreement_against_reference(ref.copy(), ref, None) is None
+
+
+def test_wilson_interval_stays_inside_the_unit_interval():
+    """
+    The reason it is Wilson and not Wald: at a proportion of 1 the normal
+    approximation gives a zero-width interval, and near 0 it runs negative.
+    """
+    lo, hi = lulc._wilson_interval(20, 20)
+    assert lo > 0 and hi <= 100.0 and lo < 100.0
+    lo, hi = lulc._wilson_interval(0, 20)
+    assert lo >= 0.0 and hi > 0.0
+    # Wider at n=20 than at n=2000 for the same proportion.
+    n_small = lulc._wilson_interval(16, 20)
+    n_large = lulc._wilson_interval(1600, 2000)
+    assert (n_small[1] - n_small[0]) > (n_large[1] - n_large[0])

--- a/sidecar/tests/test_solar.py
+++ b/sidecar/tests/test_solar.py
@@ -328,3 +328,89 @@ def test_beam_fraction_is_the_direct_share_of_the_horizontal_total():
     df = pd.DataFrame({"ghi": [100.0, 100.0], "dhi": [30.0, 30.0]})
     assert abs(solar.beam_fraction(df) - 0.7) < 1e-9
     assert solar.beam_fraction(pd.DataFrame({"ghi": [0.0], "dhi": [0.0]})) == 0.0
+
+
+def _uniform_horizon(deg: float, n: int = 36, shape=(4, 4)) -> np.ndarray:
+    """A horizon of one elevation in every azimuth, where the SVF is closed."""
+    return np.full(shape + (n,), float(deg), dtype=np.float32)
+
+
+def test_sky_view_factor_is_the_closed_form_for_a_uniform_horizon():
+    """
+    A uniform horizon at elevation h admits cos^2(h) of the isotropic dome. The
+    closed form is the check on the sector integral: an implementation that
+    averaged the angle rather than its cosine squared would pass a zero test and
+    a ninety test and be wrong everywhere between.
+    """
+    for deg in (0.0, 10.0, 30.0, 45.0, 60.0, 90.0):
+        got = solar.sky_view_factor(_uniform_horizon(deg))[0, 0]
+        assert abs(got - np.cos(np.radians(deg)) ** 2) < 1e-6, deg
+    assert solar.sky_view_factor(_uniform_horizon(0.0))[0, 0] == 1.0
+    # Not an exact zero: cos(pi/2) is 6.1e-17 in floating point, so a sky walled
+    # to the zenith lands at 1.9e-15 rather than at 0.
+    assert solar.sky_view_factor(_uniform_horizon(90.0))[0, 0] < 1e-12
+
+
+def test_sky_view_factor_averages_over_sectors_not_within_them():
+    """Half the sky walled to 45 degrees is the mean of the two sector values."""
+    mixed = np.zeros((1, 1, 36), dtype=np.float32)
+    mixed[:, :, :18] = 45.0
+    want = 0.5 * np.cos(np.radians(45.0)) ** 2 + 0.5
+    assert abs(solar.sky_view_factor(mixed)[0, 0] - want) < 1e-6
+
+
+def test_diffuse_loss_is_the_complement_and_stays_bounded():
+    loss = solar.diffuse_loss_fraction(_uniform_horizon(30.0))
+    assert abs(loss[0, 0] - 0.25) < 1e-6
+    assert solar.diffuse_loss_fraction(_uniform_horizon(0.0)).max() == 0.0
+    assert solar.diffuse_loss_fraction(_uniform_horizon(90.0)).max() == 1.0
+
+
+def test_diffuse_loss_reproduces_the_measured_valley_and_plain():
+    """
+    The study that motivated this measured -2.82 percent in an incised valley
+    and -0.04 percent on a plain. Those are the magnitudes the implementation
+    has to land on, or it is measuring something else.
+    """
+    valley = solar.diffuse_loss_fraction(_uniform_horizon(9.7))[0, 0]
+    plain = solar.diffuse_loss_fraction(_uniform_horizon(1.0))[0, 0]
+    assert 0.025 < valley < 0.032, valley
+    assert plain < 0.001, plain
+
+
+def test_enclosure_gates_on_the_horizon_it_reports():
+    """
+    The verdict travels with the evidence: a caller that applies the loss has to
+    be able to print the horizon and the threshold it was judged against.
+    """
+    below = solar.horizon_enclosure(_uniform_horizon(1.9))
+    at = solar.horizon_enclosure(_uniform_horizon(2.0))
+    assert below["encloses"] is False
+    assert at["encloses"] is True
+    assert at["threshold_deg"] == solar.SVF_MIN_MEAN_HORIZON_DEG
+    assert abs(at["mean_horizon_deg"] - 2.0) < 1e-6
+    # The threshold is where the loss is still under the rounding of every
+    # figure this module publishes.
+    assert solar.diffuse_loss_fraction(
+        _uniform_horizon(solar.SVF_MIN_MEAN_HORIZON_DEG)
+    ).max() < 0.002
+
+
+def test_sky_view_factor_of_an_absent_horizon_is_open_sky():
+    """No horizon traced must read as nothing blocking, not as everything."""
+    assert solar.sky_view_factor(np.zeros((2, 2, 0), dtype=np.float32))[0, 0] == 1.0
+    assert solar.horizon_enclosure(np.zeros((2, 2, 0)))["encloses"] is False
+
+
+def test_diffuse_incidence_correction_is_applied_and_lowers_the_yield():
+    """
+    The angle-of-incidence correction reaches the diffuse components, not the
+    beam alone. Ground-reflected light arrives near-grazing, so it is the
+    strongly corrected term; the omission overstated the yield by ~0.75 percent.
+    """
+    import pvlib
+    sky = pvlib.iam.marion_diffuse("ashrae", 20.0, b=solar.IAM_ASHRAE_B)
+    assert sky["ground"] < sky["sky"] < 1.0
+    assert 0.9 < sky["sky"] < 1.0
+    # The beam relation and the diffuse one are the same coefficient.
+    assert solar.IAM_ASHRAE_B == 0.05

--- a/sidecar/tests/test_wind.py
+++ b/sidecar/tests/test_wind.py
@@ -208,7 +208,6 @@ def test_shear_plausibility_reports_the_band_it_judged_against():
     assert inside["consistent_with_assumed_cover"] is True
     assert inside["assumed_roughness_band_m"] == [0.03, 0.10]
     assert inside["expected_shear_exponent_band"] == [0.1520, 0.1862]
-    assert "convention" in inside["roughness_band_note"]
 
     outside = wind.shear_plausibility(0.3797)
     assert outside["consistent_with_assumed_cover"] is False
@@ -340,8 +339,6 @@ def test_power_curve_is_the_published_table():
     assert wind.CURVE_SPEED_MS[-1] == 25.0
     assert abs(wind.CURVE_POWER_W.max() - 3370104.925) < 1e-3
     spec = wind.turbine_specification()
-    assert "3.370105" in spec["drivetrain_note"]
-    assert "3.597987" in spec["drivetrain_note"]
     assert spec["curve_source_commit"] == "d0e12b296d025a1c8aa99d5ba7630654837cc59e"
     assert "NREL/TP-5000-73492" in spec["citation"]
     assert spec["power_curve_column"] == "rotor electrical power"
@@ -453,15 +450,12 @@ def test_equivalent_speed_reduces_the_speed_below_reference_density():
     assert float(wind.equivalent_speed(v, dense).iloc[0]) > 8.0
 
 
-def test_density_note_states_the_exponent_without_citing_an_unverified_clause():
+def test_density_normalisation_applies_the_cube_root_to_the_speed():
     """
-    The attribution of the speed-side normalisation to a clause of
-    IEC 61400-12-1 was not checked against the standard in this project. The
-    note may state the exponent and its basis; it must not cite the clause.
+    The exponent follows from the cubic dependence of the power flux on speed.
+    Its attribution to a clause of IEC 61400-12-1 was never checked against the
+    standard, which is why no clause is cited for it anywhere.
     """
-    note = wind.DENSITY_NORMALISATION_NOTE
-    assert "(rho / 1.225)^(1/3)" in note
-    assert "has not been checked" in note
     assert abs(wind.DENSITY_EXPONENT - 1.0 / 3.0) < 1e-12
 
 
@@ -672,7 +666,6 @@ def test_every_result_carries_the_gross_and_unvalidated_qualifier():
     assert "Global Wind Atlas" in wind.RESULT_QUALIFIER
     assert "per turbine" in wind.RESULT_QUALIFIER
     assert "not been compared" in wind.MEASURED_QUALIFIER
-    assert "turbulence intensity" in out["loads_note"]
 
 
 def test_qualifier_names_every_excluded_loss():
@@ -795,7 +788,6 @@ def test_project_conventions_are_labelled_as_conventions():
     assert wind.SENSITIVITY_ROUGHNESS_M == (0.01, 0.40)
     assert "no published basis" in wind.RECORD_MAX_FLOOR_NOTE
     assert "no published basis" in wind.CALM_2M_NOTE
-    assert "project convention" in wind.ROUGHNESS_BAND_NOTE
 
 
 def test_grid_note_states_what_the_cell_does_and_does_not_resolve():

--- a/sidecar/tests/test_wind.py
+++ b/sidecar/tests/test_wind.py
@@ -725,7 +725,7 @@ def test_shear_sensitivity_names_a_surface_for_every_exponent():
     assert len(rows) >= 4
     derived = [r for r in rows if r["roughness_length_m"] is None]
     assert len(derived) == 1
-    assert derived[0]["basis"] == "derived from the record"
+    assert derived[0]["basis"] == "measured"
     for row in rows:
         assert row["basis"]
         assert row["capacity_factor_pct"] is not None

--- a/sidecar/wind.py
+++ b/sidecar/wind.py
@@ -801,8 +801,10 @@ def shear_sensitivity(df: pd.DataFrame, alpha_bulk: float, hub_height_m: float,
         rows.append({
             "shear_exponent": _round(float(alpha), 4),
             "roughness_length_m": None if z0 is None else z0,
-            "basis": "derived from the record" if z0 is None
-                     else "neutral log profile at the stated roughness length",
+            # The roughness column beside it already states the length, and
+            # every derived row uses the same profile, so the repeated clause
+            # said nothing the table did not.
+            "basis": "measured" if z0 is None else "log profile",
             "hub_speed_ms": _round(float(v_hub.mean()), 4),
             "capacity_factor_pct": _round(capacity_factor(power), 3),
             "annual_energy_mwh": _round(annual_energy_mwh(power), 1),

--- a/sidecar/wind.py
+++ b/sidecar/wind.py
@@ -115,37 +115,25 @@ RHO_REFERENCE = 1.225
 #   61400-1 normal wind profile exponent of 0.2, which is quoted nowhere in the
 #   assumptions for that reason."
 #
-# Consequence for this module: DENSITY_NORMALISATION_NOTE is what a caller
-# displays, and it says the exponent is applied to the speed without citing a
-# clause number.
+# Consequence for this module: the exponent is applied to the SPEED, as
+# (rho / 1.225)^(1/3), and follows from the cubic dependence of the wind power
+# flux on speed. Attributing that rule, rather than a power-side correction, to
+# a clause of IEC 61400-12-1 has not been checked against the standard text in
+# this project, so no clause is cited anywhere for it.
 DENSITY_EXPONENT = 1.0 / 3.0
 
-DENSITY_NORMALISATION_NOTE = (
-    "Site air density is computed hourly from surface pressure and "
-    "temperature for dry air and the wind speed is normalised by "
-    "(rho / 1.225)^(1/3) before the power curve is applied. The exponent "
-    "follows from the cubic dependence of the wind power flux on speed. The "
-    "attribution of this rule, rather than a power-side correction, to a "
-    "clause of IEC 61400-12-1 has not been checked against the standard text "
-    "in this project and is not cited here."
-)
-
-# Humidity is not carried in the density calculation. The magnitude of the
-# neglect was measured on one year of QV2M at one of the study cells: the
-# virtual-temperature form lowers mean density by 0.765 percent, which is
-# 0.256 percent on the normalised speed. Stated rather than omitted.
-HUMIDITY_NEGLECT_NOTE = (
-    "Air density uses the dry-air gas constant. Including specific humidity "
-    "through the virtual temperature lowered mean density by 0.765 percent "
-    "over one year at the study cell, which is 0.256 percent on the "
-    "density-normalised wind speed."
-)
-
+# Humidity is not carried in the density calculation: air density uses the
+# dry-air gas constant. The magnitude of the neglect was measured on one year
+# of QV2M at one of the study cells: the virtual-temperature form lowers mean
+# density by 0.765 percent, which is 0.256 percent on the normalised speed.
 # Project conventions, editable by the caller. None is a measured value.
 HUB_HEIGHT_M = 110.0            # the reference turbine hub
 RECORD_YEARS = 10               # mirrors the hourly window of solar_resource
 CALM_THRESHOLD_MS = 0.5         # taken from the project's existing diagnostic
-ROUGHNESS_BAND_M = (0.03, 0.10)  # open agricultural land, assumed not measured
+# Open agricultural land with scattered buildings and windbreaks; an assumed
+# land-cover property, not a measurement at any AOI. The shear plausibility
+# band moves with it.
+ROUGHNESS_BAND_M = (0.03, 0.10)
 RECORD_MAX_FLOOR_MS = 10.0      # no published basis; see RECORD_MAX_FLOOR_NOTE
 CALM_FRACTION_2M_FLAG_PCT = 50.0  # no published basis; see CALM_2M_NOTE
 
@@ -168,13 +156,6 @@ CALM_2M_NOTE = (
 # a rough one, so the table shows the exponent the result is sensitive to rather
 # than only the two values the band supplies. Each row states its roughness.
 SENSITIVITY_ROUGHNESS_M = (0.01, 0.40)
-
-ROUGHNESS_BAND_NOTE = (
-    "The roughness band is an assumed land-cover property for open "
-    "agricultural terrain with scattered buildings and windbreaks. It is a "
-    "project convention, not a measurement at this AOI, and the shear "
-    "plausibility band moves with it."
-)
 
 # Mean Gregorian year. sidecar/solar.py divides by 8760 in its capacity-factor
 # denominator, so a user comparing the two blocks sees a 0.07 percent
@@ -297,12 +278,11 @@ MEASURED_QUALIFIER = (
     "the data-quality diagnostics."
 )
 
-LOADS_NOTE = (
-    "Hourly reanalysis means do not resolve gusts or short-duration extremes. "
-    "Nothing here supports a turbine suitability or loads assessment, which "
-    "requires turbulence intensity and extreme wind statistics that hourly "
-    "means cannot supply."
-)
+# Hourly reanalysis means do not resolve gusts or short-duration extremes.
+# Nothing this module produces supports a turbine suitability or loads
+# assessment, which requires turbulence intensity and extreme wind statistics
+# that hourly means cannot supply. Kept as a boundary on what may be added
+# here, not as a string for the caller.
 
 DIRECTION_CONVENTION_NOTE = (
     "The direction is reported as the direction the wind comes from. The API "
@@ -519,7 +499,6 @@ def shear_plausibility(alpha: float,
         "assumed_roughness_band_m": [z0_lo, z0_hi],
         "expected_shear_exponent_band": [_round(alpha_lo, 4), _round(alpha_hi, 4)],
         "consistent_with_assumed_cover": consistent,
-        "roughness_band_note": ROUGHNESS_BAND_NOTE,
     }
 
 
@@ -695,7 +674,7 @@ def air_density(df: pd.DataFrame) -> pd.Series:
     rho = PS * 1000 / (R_dry * (T2M + 273.15)), with PS published in kPa and
     T2M in degrees Celsius. Pressure is a property of the same MERRA-2 cell as
     the wind, so the two are internally consistent. Humidity is neglected; see
-    HUMIDITY_NEGLECT_NOTE for the measured magnitude.
+    the constant block above for the measured magnitude.
     """
     return df["PS"] * 1000.0 / (R_DRY * (df["T2M"] + 273.15))
 
@@ -954,9 +933,7 @@ def data_quality(df: pd.DataFrame, lon: float, alpha_bulk: float,
         "record_maximum_ms": maxima,
         "record_maximum_floor_ms": float(record_max_floor_ms),
         "record_maximum_plausible": max_plausible,
-        "record_maximum_floor_note": RECORD_MAX_FLOOR_NOTE,
         "calm_fraction_2m_flag_pct": CALM_FRACTION_2M_FLAG_PCT,
-        "calm_fraction_2m_note": CALM_2M_NOTE,
         "nan_count": fill,
         "shear": shear,
         "flags": flags,
@@ -1081,7 +1058,6 @@ def assess(df: pd.DataFrame, lon: float, lat: float,
         "grid_note": GRID_NOTE,
         "record_years": _round(n_years, 3),
         "qualifier": RESULT_QUALIFIER,
-        "loads_note": LOADS_NOTE,
 
         "measured": {
             "qualifier": MEASURED_QUALIFIER,
@@ -1096,7 +1072,6 @@ def assess(df: pd.DataFrame, lon: float, lat: float,
             "air_density_mean_kg_m3": _round(float(rho.mean()), 4),
             "air_density_min_kg_m3": _round(float(rho.min()), 4),
             "air_density_max_kg_m3": _round(float(rho.max()), 4),
-            "humidity_note": HUMIDITY_NEGLECT_NOTE,
             "monthly_mean_speed_50m": monthly_mean_speed(df, "WS50M"),
             "direction": prevailing_direction(df),
             "direction_energy_rose_50m": direction_energy_rose(df),
@@ -1114,15 +1089,7 @@ def assess(df: pd.DataFrame, lon: float, lat: float,
             "gross_annual_energy_mwh_per_turbine": _round(
                 annual_energy_mwh(power, hours_per_year), 1),
             "operating_regime": operating_regime_fractions(v_eq),
-            "density_normalisation_note": DENSITY_NORMALISATION_NOTE,
             "hours_per_year": float(hours_per_year),
-            "hours_per_year_note": (
-                "Annual energy uses 8766 hours, the mean Gregorian year. "
-                "sidecar/solar.py uses 8760 in its capacity-factor "
-                "denominator, so the two blocks differ by 0.07 percent on any "
-                "comparison. The solar constant is not changed because it "
-                "produced the capacity factors in runs already saved."
-            ),
             "excluded_losses": list(EXCLUDED_LOSSES),
         },
 
@@ -1154,12 +1121,6 @@ def turbine_specification() -> dict:
             "master/performance/performance_ccblade.dat"
         ),
         "curve_source_commit": "d0e12b296d025a1c8aa99d5ba7630654837cc59e",
-        "drivetrain_note": (
-            "The electrical column carries drivetrain and generator loss; the "
-            "electrical maximum of 3.370105 MW against the aerodynamic "
-            "3.597987 MW is a ratio of 0.9367. It carries none of the plant "
-            "losses listed under excluded_losses."
-        ),
     }
 
 


### PR DESCRIPTION
## Summary

Twelve commits, in three groups.

**Accuracy assessment.** A classification run is now scored against the reference rather than only compared with it by composition: a confusion matrix over native 30 m cells, producer's and user's accuracy with Wilson intervals, and quantity against allocation disagreement (Pontius & Millones 2011). On area A/2023 the composition agrees to 0.3 points while the producer's accuracy for that class is 41.5% — the two numbers were never the same claim.

**The analyses stop explaining themselves in prose.** Every panel put a figure in the middle of a sentence about the figure, so reading one value meant reading a paragraph. The wind, solar and energy panels became labelled figures; 27 payload fields no reader consumed were removed from the Python, the Go structs and the TypeScript mirror. Where a bare number would be misread, the qualifier moved into the label rather than a following sentence.

**Two gaps the audit measured, both about light that is not a direct beam.** The horizon was traced and only the beam loss collected, which is the expensive half for the small effect; the sky view factor is now applied, conditionally, on a threshold read from that same horizon. And the angle-of-incidence correction reached only the beam — the diffuse terms now carry it too.

## Figures that move

This changes shipped numbers, deliberately. At the reference site the IAM factor falls 0.98694 → 0.97136 and the derived specific yield 1474.73 → 1450.78 kWh/kWp/yr, −1.62%. The applied yield is unchanged, being computed at the benchmarked reference ratio. The shift scales with how diffuse the site is — 0.75% under a clear sky at 0.14 diffuse share, 1.62% at the reference site's ~0.40 — so it is recorded as a pair of measurements rather than one constant. It moves the chain toward the Global Solar Atlas reference it is benchmarked against, not away.

## Also here

- Compositions are filed under the run that produced them, so one run's gallery stops showing another's.
- Series charts derive their break threshold from the record's own cadence instead of a fixed 16 days, which had severed 10 of 12 intervals on a monthly-best run.
- A `marion_diffuse` call was moved out of a hot loop: passing a tracker's 17520-value tilt series built a sky-dome grid per hour and drove resident memory into tens of gigabytes, hanging the test suite.

## Testing

208 sidecar tests, both Go packages, `tsc`, `vite build` and the contrast check all pass. The reference-site values that moved were updated with the reason stated beside each.