### PR TITLE
A dock layout for the map and energy screens

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2300,22 +2300,25 @@ function AppBody(props: {
           The column is in flow, not floating, so omitting it returns 13.5rem
           of width to the stage and the map fills it without being told.
         */}
-        {(layoutMode === "docked" || screen !== "map") && (
-        <AppNav
-          hasAnalysis={!!props.result || runs.length > 0}
-          onAnalysisClick={() => {
-            // Tested on the payload the page is actually showing, not on the
-            // classification: a water or solar run has no classification and
-            // would otherwise leave the list unreachable.
-            if (screen === "analysis" && resultWithWater) backToAnalysesList()
-            else goAnalysis()
-          }}
-          leftPanel={leftPanel}
-          onLeftPanelChange={setLeftPanel}
-          energyTab={energyTab}
-          onEnergyTabChange={setEnergyTab}
-        />
-        )}
+        <AnimatePresence initial={false}>
+          {(layoutMode === "docked" || screen !== "map") && (
+            <AppNav
+              key="app-nav"
+              hasAnalysis={!!props.result || runs.length > 0}
+              onAnalysisClick={() => {
+                // Tested on the payload the page is actually showing, not on the
+                // classification: a water or solar run has no classification and
+                // would otherwise leave the list unreachable.
+                if (screen === "analysis" && resultWithWater) backToAnalysesList()
+                else goAnalysis()
+              }}
+              leftPanel={leftPanel}
+              onLeftPanelChange={setLeftPanel}
+              energyTab={energyTab}
+              onEnergyTabChange={setEnergyTab}
+            />
+          )}
+        </AnimatePresence>
         <div className="relative min-h-0 min-w-0 flex-1">
           <AnimatePresence mode="wait" initial={false}>
             {screen === "map" && (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2292,16 +2292,17 @@ function AppBody(props: {
 
       <div className="flex min-h-0 flex-1">
         {/*
-          The workspace layout replaces this column with surfaces inside the
-          map, so it is withheld there and nowhere else: every other screen
-          still navigates by it, and hiding it on all of them would strand a
-          user on the energy screen with no way out.
+          The dock layout replaces this column with surfaces inside the map, so
+          it is withheld on the two screens that draw one. The project hub and
+          settings keep it: they have no map to put a bar over, and hiding it
+          there would leave them with no navigation at all.
 
           The column is in flow, not floating, so omitting it returns 13.5rem
           of width to the stage and the map fills it without being told.
         */}
         <AnimatePresence initial={false}>
-          {(layoutMode === "docked" || screen !== "map") && (
+          {(layoutMode === "docked" ||
+            (screen !== "map" && screen !== "energy")) && (
             <AppNav
               key="app-nav"
               hasAnalysis={!!props.result || runs.length > 0}
@@ -2486,6 +2487,7 @@ function AppBody(props: {
                 transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
               >
                 <EnergyScreen
+                  layoutMode={layoutMode}
                   solar={solar}
                   solarDispatch={solarDispatch}
                   wind={wind}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import {
 import { EventsOn, EventsOff } from "../wailsjs/runtime/runtime"
 import type {
   Area,
+  LayoutMode,
   PredictResult,
   PredictRequest,
   ProgressEvent,
@@ -59,7 +60,11 @@ import type {
   WindAnalysis,
   WindRequest,
 } from "@/lib/types"
-import { parsePreferenceExtras } from "@/lib/preferenceExtras"
+import {
+  layoutModeFromPrefs,
+  mergePreferenceExtras,
+  parsePreferenceExtras,
+} from "@/lib/preferenceExtras"
 import { makeRunLabel, resolveAoiDisplayLabel, aoiLabelFromRunSummary } from "@/lib/aoiLabel"
 import {
   projectOverlayToComposition,
@@ -580,6 +585,49 @@ function AppBody(props: {
    * panel on every return.
    */
   const [leftPanel, setLeftPanel] = useState<MapToolId | null>("classify")
+  /**
+   * Which map layout is drawn.
+   *
+   * Read in exactly two places -- here, to decide whether the navigation column
+   * is rendered, and inside MapScreen -- which are a parent and its direct
+   * child. That is one level of travel, so it stays a useState rather than
+   * joining the auth context, which already carries user, prefs, runs,
+   * projects, screen and settings page.
+   *
+   * Seeded from prefs below rather than in the initialiser: prefs arrive after
+   * the first render, so an initialiser would read null and pin every session
+   * to docked.
+   */
+  const [layoutMode, setLayoutMode] = useState<LayoutMode>("docked")
+  const didSeedLayoutRef = useRef(false)
+  useEffect(() => {
+    if (didSeedLayoutRef.current || !prefs) return
+    didSeedLayoutRef.current = true
+    setLayoutMode(layoutModeFromPrefs(prefs))
+  }, [prefs])
+
+  const changeLayoutMode = useCallback(
+    (mode: LayoutMode) => {
+      setLayoutMode(mode)
+      if (!prefs) return
+      // Silent: this fires on a toggle the user just watched happen, and a
+      // "Preferences saved" toast on every flip is noise about a result that
+      // is already on screen.
+      void savePrefs(
+        {
+          ...prefs,
+          extras_json: mergePreferenceExtras(prefs.extras_json, {
+            layout_mode: mode,
+          }),
+        },
+        { silent: true }
+      ).catch(() => {
+        // A layout that fails to persist still applies for this session. The
+        // next start falls back to docked, which is the safe direction.
+      })
+    },
+    [prefs, savePrefs]
+  )
   /**
    * Open tab of the energy screen, held here for the same reason as the dock
    * tab above: that screen unmounts on every navigation away, so a local value
@@ -2217,6 +2265,8 @@ function AppBody(props: {
         view={props.view}
         result={props.result}
         runLabel={currentRunLabel}
+        layoutMode={layoutMode}
+        onLayoutModeChange={changeLayoutMode}
         /*
           Wherever a run is filed under the active project. The energy handlers
           send project_id exactly as the classification ones do, so a solar or
@@ -2241,6 +2291,16 @@ function AppBody(props: {
       />
 
       <div className="flex min-h-0 flex-1">
+        {/*
+          The workspace layout replaces this column with surfaces inside the
+          map, so it is withheld there and nowhere else: every other screen
+          still navigates by it, and hiding it on all of them would strand a
+          user on the energy screen with no way out.
+
+          The column is in flow, not floating, so omitting it returns 13.5rem
+          of width to the stage and the map fills it without being told.
+        */}
+        {(layoutMode === "docked" || screen !== "map") && (
         <AppNav
           hasAnalysis={!!props.result || runs.length > 0}
           onAnalysisClick={() => {
@@ -2255,6 +2315,7 @@ function AppBody(props: {
           energyTab={energyTab}
           onEnergyTabChange={setEnergyTab}
         />
+        )}
         <div className="relative min-h-0 min-w-0 flex-1">
           <AnimatePresence mode="wait" initial={false}>
             {screen === "map" && (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -599,6 +599,29 @@ function AppBody(props: {
    * to docked.
    */
   const [layoutMode, setLayoutMode] = useState<LayoutMode>("docked")
+
+  /**
+   * Go to a destination from the dock layout's bar.
+   *
+   * Written here because navigating is two moves that live at this level: the
+   * screen, which is in the auth context, and the sub-tab, which is the state
+   * just above. The navigation table in lib/navigation carries the structure
+   * and deliberately not this, so the table cannot reach into either.
+   */
+  const navigateTo = useCallback(
+    (groupId: string, itemId?: string) => {
+      if (groupId === "energy") {
+        if (itemId) setEnergyTab(itemId as EnergyTab)
+        goEnergy()
+      } else if (groupId === "analysis") {
+        goAnalysis()
+      } else {
+        if (itemId) setLeftPanel(itemId as MapToolId)
+        goMap()
+      }
+    },
+    [goEnergy, goAnalysis, goMap]
+  )
   const didSeedLayoutRef = useRef(false)
   useEffect(() => {
     if (didSeedLayoutRef.current || !prefs) return
@@ -2335,6 +2358,7 @@ function AppBody(props: {
                   initialView={initialMapView}
                   leftPanel={leftPanel}
                   layoutMode={layoutMode}
+                  onNavigate={navigateTo}
                   onLeftPanelChange={setLeftPanel}
                   areas={props.areas}
                   activeExample={props.activeExample}
@@ -2488,6 +2512,7 @@ function AppBody(props: {
               >
                 <EnergyScreen
                   layoutMode={layoutMode}
+                  onNavigate={navigateTo}
                   solar={solar}
                   solarDispatch={solarDispatch}
                   wind={wind}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -89,6 +89,7 @@ import { WhatsNewGate } from "@/components/WhatsNewGate"
 import { AppNav } from "@/components/AppNav"
 import { MapScreen } from "@/pages/MapScreen"
 import type { MapToolId } from "@/lib/mapTools"
+import type { BasemapKind } from "@/lib/basemaps"
 import { EnergyScreen, type EnergyTab } from "@/pages/EnergyScreen"
 import { useSolarState, useWindState } from "@/lib/energyState"
 import type {
@@ -598,6 +599,16 @@ function AppBody(props: {
    * the first render, so an initialiser would read null and pin every session
    * to docked.
    */
+  /**
+   * Which basemap the map is showing, for the credit line in the title bar.
+   *
+   * Held here rather than in either screen because both draw a map and the bar
+   * is above both: a credit owned by one screen would be blank on the other.
+   */
+  const [credit, setCredit] = useState<{
+    kind: BasemapKind
+    date: string | null
+  }>({ kind: "esri", date: null })
   const [layoutMode, setLayoutMode] = useState<LayoutMode>("docked")
 
   /**
@@ -2290,6 +2301,7 @@ function AppBody(props: {
         runLabel={currentRunLabel}
         layoutMode={layoutMode}
         onLayoutModeChange={changeLayoutMode}
+        credit={credit}
         /*
           Wherever a run is filed under the active project. The energy handlers
           send project_id exactly as the classification ones do, so a solar or
@@ -2355,6 +2367,7 @@ function AppBody(props: {
                 transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
               >
                 <MapScreen
+                  onCreditChange={setCredit}
                   initialView={initialMapView}
                   leftPanel={leftPanel}
                   layoutMode={layoutMode}
@@ -2511,6 +2524,7 @@ function AppBody(props: {
                 transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
               >
                 <EnergyScreen
+                  onCreditChange={setCredit}
                   layoutMode={layoutMode}
                   onNavigate={navigateTo}
                   solar={solar}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -633,16 +633,28 @@ function AppBody(props: {
     },
     [goEnergy, goAnalysis, goMap]
   )
-  const didSeedLayoutRef = useRef(false)
+  /**
+   * The last value this component wrote, so its own save does not echo back.
+   *
+   * The mode is state rather than derived from prefs because savePrefs
+   * round-trips to Go and SQLite before the context updates, and a layout
+   * toggle that waits on a disk write does not feel like a toggle. But the
+   * settings page writes the same preference, so a stored value this component
+   * did not write is one to follow -- which is also how it is seeded on start.
+   */
+  const lastWrittenLayoutRef = useRef<LayoutMode | null>(null)
   useEffect(() => {
-    if (didSeedLayoutRef.current || !prefs) return
-    didSeedLayoutRef.current = true
-    setLayoutMode(layoutModeFromPrefs(prefs))
+    if (!prefs) return
+    const stored = layoutModeFromPrefs(prefs)
+    if (stored === lastWrittenLayoutRef.current) return
+    lastWrittenLayoutRef.current = stored
+    setLayoutMode(stored)
   }, [prefs])
 
   const changeLayoutMode = useCallback(
     (mode: LayoutMode) => {
       setLayoutMode(mode)
+      lastWrittenLayoutRef.current = mode
       if (!prefs) return
       // Silent: this fires on a toggle the user just watched happen, and a
       // "Preferences saved" toast on every flip is noise about a result that

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2330,6 +2330,7 @@ function AppBody(props: {
                 <MapScreen
                   initialView={initialMapView}
                   leftPanel={leftPanel}
+                  layoutMode={layoutMode}
                   onLeftPanelChange={setLeftPanel}
                   areas={props.areas}
                   activeExample={props.activeExample}

--- a/frontend/src/components/AppNav.tsx
+++ b/frontend/src/components/AppNav.tsx
@@ -31,6 +31,7 @@ import { useAuth, type AppScreen } from "@/lib/auth"
 import { cn } from "@/lib/utils"
 import { AvatarCircle } from "@/components/AvatarCircle"
 import { MAP_TOOLS, type MapToolId } from "@/lib/mapTools"
+import { ENERGY_TABS } from "@/lib/navigation"
 import type { EnergyTab } from "@/pages/EnergyScreen"
 
 export interface AppNavProps {
@@ -100,17 +101,12 @@ export function AppNav({
     },
   }))
 
-  const energyChildren: NavChild[] = (
-    [
-      { key: "solar", label: "Solar" },
-      { key: "wind", label: "Wind" },
-    ] as const
-  ).map((c) => ({
-    key: c.key,
+  const energyChildren: NavChild[] = ENERGY_TABS.map((c) => ({
+    key: c.id,
     label: c.label,
-    active: onEnergy && energyTab === c.key,
+    active: onEnergy && energyTab === c.id,
     onSelect: () => {
-      onEnergyTabChange(c.key)
+      onEnergyTabChange(c.id as typeof energyTab)
       goEnergy()
     },
   }))

--- a/frontend/src/components/AppNav.tsx
+++ b/frontend/src/components/AppNav.tsx
@@ -25,6 +25,7 @@ import {
   UserRound,
   Zap,
 } from "lucide-react"
+import { motion } from "motion/react"
 import { useState, type ReactNode } from "react"
 import { useAuth, type AppScreen } from "@/lib/auth"
 import { cn } from "@/lib/utils"
@@ -115,7 +116,21 @@ export function AppNav({
   }))
 
   return (
-    <aside className="app-no-drag flex w-[13.5rem] shrink-0 flex-col border-r border-border/60 bg-ink">
+    /*
+      The width animates, the contents do not. This column is a flex item, so
+      withholding it is a layout change rather than a fade: collapsing the
+      outer width lets the map take the space over the same beat, while the
+      inner element keeps its full measure so the labels slide out of view
+      instead of reflowing into a narrower column on the way.
+    */
+    <motion.aside
+      className="app-no-drag shrink-0 overflow-hidden border-r border-border/60 bg-ink"
+      initial={{ width: 0 }}
+      animate={{ width: "13.5rem" }}
+      exit={{ width: 0 }}
+      transition={{ type: "spring", stiffness: 360, damping: 34 }}
+    >
+    <div className="flex h-full w-[13.5rem] flex-col">
       {projectSwitcher && (
         <div className="border-b border-border/60 p-2">{projectSwitcher}</div>
       )}
@@ -173,7 +188,8 @@ export function AppNav({
           />
         )}
       </div>
-    </aside>
+    </div>
+    </motion.aside>
   )
 }
 

--- a/frontend/src/components/CompositionPanel.tsx
+++ b/frontend/src/components/CompositionPanel.tsx
@@ -1,7 +1,5 @@
 import { forwardRef, useMemo, useState } from "react"
-import { motion } from "motion/react"
 import {
-  ChevronLeft,
   Loader2,
   CheckCircle2,
   Pencil,
@@ -17,28 +15,11 @@ import { RGB_PRESETS, INDICES } from "@/lib/compositeCatalog"
 import { cn } from "@/lib/utils"
 import { todayISO } from "@/lib/dates"
 import { btnPrimary } from "@/components/ui/buttons"
+import type { PanelPlacement } from "@/components/ui/PanelShell"
+import { PanelShell } from "@/components/ui/PanelShell"
+import { PanelSection as Section } from "@/components/ui/PanelSection"
 
 const S2_BANDS = ["B02", "B03", "B04", "B05", "B06", "B07", "B08", "B8A", "B11", "B12"] as const
-
-function Section({
-  step,
-  title,
-  children,
-}: {
-  step: string
-  title: string
-  children: React.ReactNode
-}) {
-  return (
-    <div className="flex flex-col gap-2">
-      <div className="flex items-center gap-2">
-        <span className="telemetry text-[10px] text-primary">{step}</span>
-        <span className="eyebrow !text-foreground">{title}</span>
-      </div>
-      {children}
-    </div>
-  )
-}
 
 export interface CompositionPanelProps {
   hasArea: boolean
@@ -71,8 +52,8 @@ export interface CompositionPanelProps {
   onApply: () => void
   onClear: () => void
   onCollapse: () => void
-  /** Tailwind left offset, e.g. left-3 or left-14 */
-  panelOffsetClass?: string
+  /** Which container draws this panel. See ui/PanelShell. */
+  placement?: PanelPlacement
 }
 
 export const CompositionPanel = forwardRef<
@@ -122,25 +103,12 @@ export const CompositionPanel = forwardRef<
   }, [scenes, selectedSceneId])
 
   return (
-      <motion.div
+      <PanelShell
         ref={ref}
-        className={`panel app-no-drag panel-scroll absolute ${props.panelOffsetClass ?? "left-3"} top-3 bottom-3 z-[1000] flex w-[19rem] flex-col gap-4 overflow-y-auto rounded-md p-4`}
-        initial={{ opacity: 0, x: -28 }}
-        animate={{ opacity: 1, x: 0 }}
-        exit={{ opacity: 0, x: -28 }}
-        transition={{ type: "spring", stiffness: 360, damping: 34 }}
+        title="Compositions"
+        placement={props.placement}
+        onCollapse={onCollapse}
       >
-        <div className="flex items-center justify-between">
-          <h1 className="text-sm font-semibold">Compositions</h1>
-          <button
-            type="button"
-            onClick={onCollapse}
-            className="text-muted-foreground hover:text-foreground"
-            title="Hide panel"
-          >
-            <ChevronLeft className="size-4" />
-          </button>
-        </div>
 
         <Section step="01" title="Area">
           <p className="text-xs leading-relaxed text-muted-foreground">
@@ -414,6 +382,6 @@ export const CompositionPanel = forwardRef<
             opacity from Overlay Tools.
           </p>
         </Section>
-      </motion.div>
+      </PanelShell>
   )
 })

--- a/frontend/src/components/CompositionStatusPanel.tsx
+++ b/frontend/src/components/CompositionStatusPanel.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils"
 import { forwardRef, useMemo, useState } from "react"
 import { motion } from "motion/react"
 import { X, ChevronDown, ChevronUp, Trash2, SlidersHorizontal } from "lucide-react"
@@ -15,6 +16,11 @@ interface CompositionStatusPanelProps {
   sceneDate?: string | null
   composeOpacity: number
   onClear: () => void
+  /**
+   * Left inset, which decides what the panel is centred within. See
+   * statusPanelInset in analysisPrimitives.
+   */
+  leftOffsetClass?: string
 }
 
 function CmapLegend({
@@ -46,7 +52,7 @@ export const CompositionStatusPanel = forwardRef<
   HTMLDivElement,
   CompositionStatusPanelProps
 >(function CompositionStatusPanel(
-  { composition, sceneDate, composeOpacity, onClear },
+  { composition, sceneDate, composeOpacity, onClear, leftOffsetClass = "left-[23.5rem]" },
   ref
 ) {
   const [collapsed, setCollapsed] = useState(false)
@@ -105,7 +111,10 @@ export const CompositionStatusPanel = forwardRef<
   return (
     <motion.div
       ref={ref}
-      className="panel app-no-drag absolute bottom-[calc(var(--map-foot,0px)+0.75rem)] left-[23.5rem] right-16 z-[1000] mx-auto max-w-[36rem] rounded-md"
+      className={cn(
+          "panel app-no-drag absolute bottom-[calc(var(--map-foot,0px)+0.75rem)] right-16 z-[1000] mx-auto max-w-[36rem] rounded-md",
+          leftOffsetClass
+        )}
       initial={{ opacity: 0, y: 24 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: 24 }}

--- a/frontend/src/components/ControlPanel.tsx
+++ b/frontend/src/components/ControlPanel.tsx
@@ -1,12 +1,10 @@
 import { forwardRef } from "react"
-import { motion } from "motion/react"
 import {
   Play,
   Loader2,
   Pencil,
   Upload,
   Trash2,
-  ChevronLeft,
   CheckCircle2,
   Circle,
   Globe2,
@@ -16,6 +14,8 @@ import { cn } from "@/lib/utils"
 import { todayISO } from "@/lib/dates"
 import { btnPrimaryCommit } from "@/components/ui/buttons"
 import { PanelSection as Section } from "@/components/ui/PanelSection"
+import type { PanelPlacement } from "@/components/ui/PanelShell"
+import { PanelShell } from "@/components/ui/PanelShell"
 
 interface ControlPanelProps {
   activeExample: string
@@ -45,8 +45,8 @@ interface ControlPanelProps {
   lulcRunning?: boolean
   /** Hide this panel (dock tabs remain). */
   onCollapse?: () => void
-  /** Tailwind left offset, e.g. left-3 or left-14 */
-  panelOffsetClass?: string
+  /** Which container draws this panel. See ui/PanelShell. */
+  placement?: PanelPlacement
 }
 
 export const ControlPanel = forwardRef<HTMLDivElement, ControlPanelProps>(
@@ -84,25 +84,12 @@ export const ControlPanel = forwardRef<HTMLDivElement, ControlPanelProps>(
   const busy = running || lulcRunning
 
   return (
-      <motion.div
+      <PanelShell
         ref={ref}
-        className={`panel app-no-drag panel-scroll absolute ${props.panelOffsetClass ?? "left-3"} top-3 bottom-3 z-[1000] flex w-[19rem] flex-col gap-4 overflow-y-auto rounded-md p-4`}
-        initial={{ opacity: 0, x: -28 }}
-        animate={{ opacity: 1, x: 0 }}
-        exit={{ opacity: 0, x: -28 }}
-        transition={{ type: "spring", stiffness: 360, damping: 34 }}
+        title="New classification"
+        placement={props.placement}
+        onCollapse={() => onCollapse?.()}
       >
-      <div className="flex items-center justify-between">
-        <h1 className="text-sm font-semibold">New classification</h1>
-        <button
-          type="button"
-          onClick={() => onCollapse?.()}
-          className="text-muted-foreground hover:text-foreground"
-          title="Hide panel"
-        >
-          <ChevronLeft className="size-4" />
-        </button>
-      </div>
 
       {/* STEP 1 — area */}
       <Section step="01" title="Area">
@@ -363,6 +350,6 @@ export const ControlPanel = forwardRef<HTMLDivElement, ControlPanelProps>(
           )}
         </button>
       </div>
-      </motion.div>
+      </PanelShell>
   )
 })

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -16,6 +16,7 @@ import L from "leaflet"
 import "./leafletDrawPatch"
 import type { LatLngBoundsExpression } from "leaflet"
 import type { Area, PredictResult, GeoJSONGeometry, CompositionOverlay } from "@/lib/types"
+import { BASEMAPS, basemapByName, type BasemapKind } from "@/lib/basemaps"
 import { majoritySmoothOverlay } from "@/lib/smoothOverlay"
 import {
   polygonOuterRing,
@@ -85,6 +86,8 @@ interface MapViewProps {
   onAoiContourSchemeChange: (id: AoiContourSchemeId) => void
   onClearArea: () => void
   onViewChange: (v: { lat: number; lon: number; zoom: number }) => void
+  /** Which basemap is showing, so its credit can be drawn outside the map. */
+  onCreditChange?: (c: { kind: BasemapKind; date: string | null }) => void
 }
 
 // Report map center/zoom to the telemetry readout.
@@ -110,13 +113,6 @@ function ViewReporter({
   return null
 }
 
-type BasemapKind = "esri" | "eox" | "osm"
-
-function basemapKindFromLayerName(name: string): BasemapKind {
-  if (/sentinel|eox/i.test(name)) return "eox"
-  if (/osm|openstreet/i.test(name) || /^map\b/i.test(name)) return "osm"
-  return "esri"
-}
 
 function formatYmd(ymd: string): string {
   if (/^\d{8}$/.test(ymd)) {
@@ -192,17 +188,30 @@ async function fetchEsriImageryDate(
 }
 
 /**
- * Shows the active basemap imagery date next to the Leaflet attribution prefix.
- * Esri: acquisition date at map center (updates on pan/zoom). EOX: mosaic year.
+ * Reports which basemap is showing and, for the ones that have one, the date of
+ * the imagery under the map centre.
+ *
+ * It used to write this into Leaflet's own attribution control. The credit now
+ * renders in the title bar beside the coordinates, so this reports upward and
+ * the obligation is met by whoever draws it -- which is why the reporting is
+ * unconditional and not gated on anything.
+ *
+ * Esri: acquisition date at map centre, refreshed on pan and zoom. EOX: the
+ * mosaic year. OSM: none, it is not imagery.
  */
-function BasemapDateAttribution() {
+function BasemapDateAttribution({
+  onCreditChange,
+}: {
+  onCreditChange?: (credit: { kind: BasemapKind; date: string | null }) => void
+}) {
   const map = useMap()
   const [basemap, setBasemap] = useState<BasemapKind>("esri")
   const [dateLabel, setDateLabel] = useState<string | null>(null)
 
   useEffect(() => {
     const onBase = (e: L.LayersControlEvent) => {
-      setBasemap(basemapKindFromLayerName(e.name))
+      // Exact, because the table that names the layer is the table read here.
+      setBasemap(basemapByName(e.name).kind)
     }
     map.on("baselayerchange", onBase)
     return () => {
@@ -253,15 +262,8 @@ function BasemapDateAttribution() {
   }, [map, basemap])
 
   useEffect(() => {
-    // Leaflet's default prefix carries a flag emoji. The attribution itself is
-    // a licensing requirement and stays; the emoji is not part of it, and no
-    // string this application renders carries one.
-    const leaflet =
-      '<a href="https://leafletjs.com" title="A JavaScript library for interactive maps">Leaflet</a>'
-    map.attributionControl.setPrefix(
-      dateLabel ? `${leaflet} · imagery ${dateLabel}` : leaflet
-    )
-  }, [map, dateLabel])
+    onCreditChange?.({ kind: basemap, date: dateLabel })
+  }, [basemap, dateLabel, onCreditChange])
 
   return null
 }
@@ -1034,6 +1036,7 @@ export function MapView({
   onAoiContourSchemeChange,
   onClearArea,
   onViewChange,
+  onCreditChange,
 }: MapViewProps) {
   // Continental default, used only when there is no remembered view.
   const center = useMemo<[number, number]>(
@@ -1278,31 +1281,26 @@ export function MapView({
       zoom={initialZoom}
       className="h-full w-full"
       zoomControl={false}
+      attributionControl={false}
     >
       <ZoomControl position="bottomright" />
       <LayersControl position="topright">
-        <LayersControl.BaseLayer checked name="Satellite (Esri)">
-          <TileLayer
-            attribution="Tiles &copy; Esri"
-            url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
-            maxZoom={19}
-          />
-        </LayersControl.BaseLayer>
-        <LayersControl.BaseLayer name="Sentinel-2 2025 (EOX)">
-          <TileLayer
-            attribution='&copy; <a href="https://cloudless.eox.at">EOX</a> &mdash; <a href="https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi">Contains modified Copernicus Sentinel data 2025</a>'
-            url="https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless-2025_3857/default/g/{z}/{y}/{x}.jpg"
-            maxNativeZoom={14}
-            maxZoom={19}
-          />
-        </LayersControl.BaseLayer>
-        <LayersControl.BaseLayer name="Map (OSM)">
-          <TileLayer
-            attribution="&copy; OpenStreetMap"
-            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-            maxZoom={19}
-          />
-        </LayersControl.BaseLayer>
+        {/*
+          Built from the table rather than written out, so the URL a layer
+          fetches from and the source the credit names cannot drift apart.
+          The attribution prop is gone with Leaflet's control: the credit is
+          rendered in the title bar now, and a second copy here would be a
+          second thing to keep true.
+        */}
+        {BASEMAPS.map((b, i) => (
+          <LayersControl.BaseLayer key={b.kind} checked={i === 0} name={b.name}>
+            <TileLayer
+              url={b.url}
+              maxZoom={b.maxZoom}
+              maxNativeZoom={b.maxNativeZoom}
+            />
+          </LayersControl.BaseLayer>
+        ))}
       </LayersControl>
 
       {compositionLayer}
@@ -1331,7 +1329,7 @@ export function MapView({
         onOpen={setAoiMenu}
       />
       <ViewReporter onViewChange={onViewChange} />
-      <BasemapDateAttribution />
+      <BasemapDateAttribution onCreditChange={onCreditChange} />
       <MapDragLock locked={swipeDragging} />
     </MapContainer>
     {swipeActive && (

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type RefObject } from "react"
+import { createPortal } from "react-dom"
 import {
   MapContainer,
   TileLayer,
@@ -86,6 +87,8 @@ interface MapViewProps {
   onAoiContourSchemeChange: (id: AoiContourSchemeId) => void
   onClearArea: () => void
   onViewChange: (v: { lat: number; lon: number; zoom: number }) => void
+  /** Placed in Leaflet's bottom-right stack, under the zoom and draw tools. */
+  bottomRightSlot?: React.ReactNode
   /** Which basemap is showing, so its credit can be drawn outside the map. */
   onCreditChange?: (c: { kind: BasemapKind; date: string | null }) => void
 }
@@ -266,6 +269,46 @@ function BasemapDateAttribution({
   }, [basemap, dateLabel, onCreditChange])
 
   return null
+}
+
+/**
+ * Renders its children into Leaflet's own bottom-right control stack.
+ *
+ * The alternative was to place the button absolutely and clear the stack by
+ * hand, which this file already has one victim of: ConfidenceLegend sits at a
+ * hand-tuned `bottom: 15.25rem` measured against the zoom and draw toolbars as
+ * they were. The stack's height is not constant -- the draw toolbar grows an
+ * edit button once a polygon exists -- so anything that clears it by arithmetic
+ * is right until the map is used.
+ *
+ * Inside the stack Leaflet does the arithmetic, and a control added after the
+ * others lands under them, which is where the caller wants this one: away from
+ * the top-right corner the panels open from, so a panel no longer looks like
+ * something that button produced.
+ */
+function BottomRightSlot({ children }: { children: React.ReactNode }) {
+  const map = useMap()
+  const [host, setHost] = useState<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const control = new L.Control({ position: "bottomright" })
+    control.onAdd = () => {
+      const div = L.DomUtil.create("div", "leaflet-control")
+      // Without these a click reaches the map underneath and starts a drag, and
+      // a wheel over the button zooms the map behind it.
+      L.DomEvent.disableClickPropagation(div)
+      L.DomEvent.disableScrollPropagation(div)
+      setHost(div)
+      return div
+    }
+    control.addTo(map)
+    return () => {
+      control.remove()
+      setHost(null)
+    }
+  }, [map])
+
+  return host ? createPortal(children, host) : null
 }
 
 function FlyToController({
@@ -1037,6 +1080,7 @@ export function MapView({
   onClearArea,
   onViewChange,
   onCreditChange,
+  bottomRightSlot,
 }: MapViewProps) {
   // Continental default, used only when there is no remembered view.
   const center = useMemo<[number, number]>(
@@ -1319,6 +1363,7 @@ export function MapView({
 
       <DrawControl customPolygon={customPolygon} onPolygonDrawn={onPolygonDrawn} />
       <ContainerResizeSync />
+      {bottomRightSlot && <BottomRightSlot>{bottomRightSlot}</BottomRightSlot>}
       <FlyToController flyTo={flyTo} />
       <FitBounds customPolygon={customPolygon} result={result} />
       <FitComposition composition={composition} hasPrediction={!!result} />

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -278,6 +278,34 @@ function FlyToController({
   return null
 }
 
+/**
+ * Tells Leaflet when its container changed size.
+ *
+ * Leaflet caches the container's dimensions and only re-reads them on a window
+ * resize. Every other way the container can change -- the navigation column
+ * being withheld by the workspace layout, a panel opening, the window entering
+ * full screen with the frame unchanged -- leaves it drawing at the old size:
+ * tiles stop at the former edge, and the projection maths that converts a click
+ * to a coordinate is computed against a viewport that is no longer there, so
+ * drawing an AOI lands it off the cursor.
+ *
+ * Observing the element rather than reacting to the layout mode keeps this true
+ * for the next thing that resizes it, without that thing having to know Leaflet
+ * exists.
+ */
+function ContainerResizeSync() {
+  const map = useMap()
+  useEffect(() => {
+    const el = map.getContainer()
+    // Leaflet's own animation would interpolate from the stale size, which
+    // reads as the map sliding rather than as the frame changing.
+    const observer = new ResizeObserver(() => map.invalidateSize({ animate: false }))
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [map])
+  return null
+}
+
 function FitBounds({
   customPolygon,
   result,
@@ -1292,6 +1320,7 @@ export function MapView({
       )}
 
       <DrawControl customPolygon={customPolygon} onPolygonDrawn={onPolygonDrawn} />
+      <ContainerResizeSync />
       <FlyToController flyTo={flyTo} />
       <FitBounds customPolygon={customPolygon} result={result} />
       <FitComposition composition={composition} hasPrediction={!!result} />

--- a/frontend/src/components/OverlayToolsPanel.tsx
+++ b/frontend/src/components/OverlayToolsPanel.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, type ReactNode } from "react"
 import { AnimatePresence, motion } from "motion/react"
 import {
+  Blend,
   SlidersHorizontal,
   Download,
   Palette,
@@ -734,12 +735,26 @@ export function OverlayToolsButton({
       aria-pressed={active}
       onClick={onClick}
       className={cn(
-        "overlay-tools-btn panel app-no-drag absolute right-[10px] top-[3.35rem] z-[1000] flex h-8 w-8 items-center justify-center rounded-sm text-muted-foreground transition-colors",
+        // No anchor of its own: it is handed to Leaflet's bottom-right stack,
+        // which places it under the zoom and draw tools. It used to sit at the
+        // top-right, a few pixels from where this panel opens, so the panel
+        // read as something the button had produced.
+        //
+        // Sized to the stack it joins rather than to the 2rem it was: the zoom
+        // and draw buttons are 2.125rem, and a narrower one beside them reads
+        // as a different kind of control.
+        "overlay-tools-btn panel app-no-drag flex h-[2.125rem] w-[2.125rem] items-center justify-center rounded-sm text-muted-foreground transition-colors",
         "hover:bg-secondary hover:text-foreground",
         active && "border-primary/50 bg-primary/15 text-foreground"
       )}
     >
-      <SlidersHorizontal className="size-3.5" strokeWidth={1.75} />
+      {/*
+        Blend, not sliders. Two sliders icons had come to mean two different
+        things a few pixels apart -- this one and the dock bar's parameters --
+        and overlapping discs say what this panel actually governs: how the
+        layers sit over one another, their opacity and their comparison.
+      */}
+      <Blend className="size-3.5" strokeWidth={1.75} />
     </button>
   )
 }

--- a/frontend/src/components/OverlayToolsPanel.tsx
+++ b/frontend/src/components/OverlayToolsPanel.tsx
@@ -492,10 +492,21 @@ export function OverlayToolsPanel(props: OverlayToolsPanelProps) {
     <AnimatePresence>
       {open && (
         <motion.div
-          className="panel app-no-drag absolute right-14 top-14 z-[1100] flex max-h-[min(36rem,calc(100%-5rem))] w-[19rem] flex-col overflow-hidden rounded-md"
-          initial={{ opacity: 0, x: 16, y: -8 }}
+          className={cn(
+            "panel app-no-drag absolute right-14 z-[1100] flex w-[19rem] flex-col overflow-hidden rounded-md",
+            // Bottom-aligned with the control column it belongs to, growing
+            // upward. It used to open at top-14, and once its button moved
+            // into Leaflet's bottom-right stack that put the panel at one end
+            // of the screen and the thing that opened it at the other.
+            //
+            // 0.625rem is Leaflet's own margin under the last control, so the
+            // two share a baseline. right-14 already clears the column.
+            "bottom-[calc(var(--map-foot,0px)+0.625rem)]",
+            "max-h-[min(36rem,calc(100%-var(--map-foot,0px)-5rem))]"
+          )}
+          initial={{ opacity: 0, x: 16, y: 8 }}
           animate={{ opacity: 1, x: 0, y: 0 }}
-          exit={{ opacity: 0, x: 16, y: -8 }}
+          exit={{ opacity: 0, x: 16, y: 8 }}
           transition={{ type: "spring", stiffness: 380, damping: 32 }}
         >
           <div className="flex items-center justify-between px-3 py-2">

--- a/frontend/src/components/PeriodTimeline.tsx
+++ b/frontend/src/components/PeriodTimeline.tsx
@@ -88,7 +88,27 @@ export interface PeriodTimelineProps {
    * start handle sit behind it: the edge a user reaches for to widen the window
    * backwards is the one the panel covers.
    */
-  leftOffsetClass?: string
+  /**
+   * How far the track's left edge is pushed in, as a CSS length.
+   *
+   * A length rather than a class because what it clears is not always a fixed
+   * width: the docked column is 19rem by construction, but the workspace
+   * layout's island is sized by its own contents and changes with the label on
+   * its run button. The rounded corner follows automatically -- a retracted
+   * track meets something at that edge, and a square corner there reads as the
+   * track having been cut off rather than as having made room.
+   */
+  leftOffset?: string
+  /**
+   * Whether what the track retracts for sits on the frame rather than floating
+   * above it.
+   *
+   * The rounded corner exists to meet a floating panel, which carries its own
+   * radius and its own gutter off the bottom. Against a segment flush with the
+   * frame there is nothing to meet: the two are one band, and a curve on one
+   * side of the seam reads as a misalignment.
+   */
+  flushLeft?: boolean
 }
 
 export function PeriodTimeline({
@@ -101,7 +121,8 @@ export function PeriodTimeline({
   onListScenes,
   onOpenListing,
   disabled,
-  leftOffsetClass = "left-0",
+  leftOffset,
+  flushLeft = false,
 }: PeriodTimelineProps) {
   const trackRef = useRef<HTMLDivElement | null>(null)
   const [dragging, setDragging] = useState<"start" | "end" | null>(null)
@@ -216,8 +237,9 @@ export function PeriodTimeline({
         // Animated, because the panel it clears opens and closes: a track that
         // jumped its left edge would read as a different control appearing.
         "transition-[left] duration-200 ease-out",
-        leftOffsetClass
+        leftOffset && !flushLeft ? "rounded-tl-md" : null
       )}
+      style={{ left: leftOffset ?? 0 }}
       initial={{ opacity: 0, y: 16 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: 16 }}

--- a/frontend/src/components/ResultsPanel.tsx
+++ b/frontend/src/components/ResultsPanel.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils"
 import { forwardRef, useState } from "react"
 import { motion } from "motion/react"
 import { X, ChevronDown, ChevronUp, ChartColumn, Plus } from "lucide-react"
@@ -8,10 +9,18 @@ interface ResultsPanelProps {
   result: PredictResult
   onClose: () => void
   onNewClassification: () => void
+  /**
+   * Left inset, which decides what the panel is centred within. See
+   * statusPanelInset in analysisPrimitives.
+   */
+  leftOffsetClass?: string
 }
 
 export const ResultsPanel = forwardRef<HTMLDivElement, ResultsPanelProps>(
-  function ResultsPanel({ result, onClose, onNewClassification }, ref) {
+  function ResultsPanel(
+    { result, onClose, onNewClassification, leftOffsetClass = "left-[23.5rem]" },
+    ref
+  ) {
     const [collapsed, setCollapsed] = useState(false)
     const { goAnalysis } = useAuth()
 
@@ -39,7 +48,10 @@ export const ResultsPanel = forwardRef<HTMLDivElement, ResultsPanelProps>(
     return (
       <motion.div
         ref={ref}
-        className="panel app-no-drag absolute bottom-[calc(var(--map-foot,0px)+0.75rem)] left-[23.5rem] right-16 z-[1000] mx-auto max-w-[36rem] rounded-md"
+        className={cn(
+          "panel app-no-drag absolute bottom-[calc(var(--map-foot,0px)+0.75rem)] right-16 z-[1000] mx-auto max-w-[36rem] rounded-md",
+          leftOffsetClass
+        )}
         initial={{ opacity: 0, y: 24 }}
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: 24 }}

--- a/frontend/src/components/TitleBar.tsx
+++ b/frontend/src/components/TitleBar.tsx
@@ -1,4 +1,13 @@
-import { Minus, PanelBottom, PanelLeft, Square, X } from "lucide-react"
+import {
+  LogIn,
+  Minus,
+  PanelBottom,
+  PanelLeft,
+  Square,
+  UserRound,
+  X,
+} from "lucide-react"
+import { AvatarCircle } from "@/components/AvatarCircle"
 import type { ReactNode } from "react"
 import {
   WindowMinimise,
@@ -103,7 +112,7 @@ export function TitleBar({
   onLayoutModeChange,
   credit,
 }: TitleBarProps) {
-  const { screen } = useAuth()
+  const { screen, user, loading, goProfile, goAuth } = useAuth()
   const onMap = screen === "map"
   const hasMap = onMap || screen === "energy"
   const run = runLabel?.trim()
@@ -191,6 +200,34 @@ export function TitleBar({
               </>
             )}
           </div>
+        )}
+
+        {/*
+          The way into settings while the navigation column is withheld.
+          Exactly when the column is gone: on the two screens that draw a map,
+          in the layout that replaces the column with surfaces inside it. The
+          column carries this item everywhere else, and two of them at once
+          would be two answers to one question.
+
+          Icon only. The column can afford the word beside it down 13.5rem;
+          here it would sit between the coordinate readout and the window
+          buttons, which is the narrowest part of the bar.
+        */}
+        {hasMap && layoutMode === "workspace" && !loading && (
+          <button
+            type="button"
+            onClick={() => (user ? goProfile() : goAuth())}
+            className="app-no-drag flex h-7 w-7 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-surface-raised/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            title={user ? "Settings" : "Sign in"}
+          >
+            {user?.avatar_uri ? (
+              <AvatarCircle uri={user.avatar_uri} size="sm" />
+            ) : user ? (
+              <UserRound className="size-4" />
+            ) : (
+              <LogIn className="size-4" />
+            )}
+          </button>
         )}
 
         {/* Wherever there is a map to lay out. */}

--- a/frontend/src/components/TitleBar.tsx
+++ b/frontend/src/components/TitleBar.tsx
@@ -6,6 +6,12 @@ import {
   Quit,
 } from "../../wailsjs/runtime/runtime"
 import type { LayoutMode, PredictResult } from "@/lib/types"
+import {
+  LEAFLET_CREDIT,
+  basemapByKind,
+  type BasemapKind,
+  type CreditPart,
+} from "@/lib/basemaps"
 import { useAuth, type AppScreen } from "@/lib/auth"
 
 interface TitleBarProps {
@@ -30,6 +36,30 @@ interface TitleBarProps {
    */
   layoutMode?: LayoutMode
   onLayoutModeChange?: (mode: LayoutMode) => void
+  /**
+   * Which basemap is showing, and the date of the imagery under the centre.
+   *
+   * Drawn here rather than over the map's bottom-right corner, where Leaflet
+   * puts it by default. It is a licensing obligation and not chrome, so it
+   * moved rather than went: the links each licence asks for are rendered as
+   * real anchors from the table in lib/basemaps.
+   */
+  credit?: { kind: BasemapKind; date: string | null }
+}
+
+/** One credited party, as a link where its licence asks to be reachable. */
+function Credit({ part }: { part: CreditPart }) {
+  if (!part.href) return <span>{part.label}</span>
+  return (
+    <a
+      href={part.href}
+      target="_blank"
+      rel="noreferrer"
+      className="hover:text-foreground hover:underline"
+    >
+      {part.label}
+    </a>
+  )
 }
 
 /**
@@ -71,6 +101,7 @@ export function TitleBar({
   runLabel,
   layoutMode = "docked",
   onLayoutModeChange,
+  credit,
 }: TitleBarProps) {
   const { screen } = useAuth()
   const onMap = screen === "map"
@@ -128,6 +159,23 @@ export function TitleBar({
             <span>
               Z <span className="text-foreground">{view.zoom.toFixed(0)}</span>
             </span>
+            {credit && (
+              <>
+                <span className="hairline h-4 w-px self-center border-l" />
+                {/* Not telemetry, so it is not in the mono face the readings
+                    use -- it is a sentence about who the imagery belongs to. */}
+                <span className="hidden max-w-[26rem] truncate font-sans normal-case xl:inline">
+                  <Credit part={LEAFLET_CREDIT} />
+                  {credit.date ? ` \u00b7 imagery ${credit.date}` : ""}
+                  {basemapByKind(credit.kind).credit.map((c, i) => (
+                    <span key={c.label}>
+                      {i === 0 ? " | " : " \u2014 "}
+                      <Credit part={c} />
+                    </span>
+                  ))}
+                </span>
+              </>
+            )}
             {/* The pill counts the scenes behind a classification, which the
                 energy products never read, so it stays on the map screen. */}
             {onMap && result && (

--- a/frontend/src/components/TitleBar.tsx
+++ b/frontend/src/components/TitleBar.tsx
@@ -1,11 +1,11 @@
-import { Minus, Square, X } from "lucide-react"
+import { Minus, PanelBottom, PanelLeft, Square, X } from "lucide-react"
 import type { ReactNode } from "react"
 import {
   WindowMinimise,
   WindowToggleMaximise,
   Quit,
 } from "../../wailsjs/runtime/runtime"
-import type { PredictResult } from "@/lib/types"
+import type { LayoutMode, PredictResult } from "@/lib/types"
 import { useAuth, type AppScreen } from "@/lib/auth"
 
 interface TitleBarProps {
@@ -18,6 +18,18 @@ interface TitleBarProps {
    * placeholder standing in for a run that does not exist.
    */
   runLabel?: string | null
+  /**
+   * The map layout, and the way to change it.
+   *
+   * This bar is the only chrome mounted in both layouts, which is why the
+   * control lives here: in the workspace layout the navigation column is gone,
+   * so a toggle placed there would be unreachable from the mode it exits.
+   *
+   * It is a view mode rather than a destination, so it does not contradict this
+   * bar's rule against per-page navigation icons.
+   */
+  layoutMode?: LayoutMode
+  onLayoutModeChange?: (mode: LayoutMode) => void
 }
 
 /**
@@ -57,6 +69,8 @@ export function TitleBar({
   result,
   projectSwitcher,
   runLabel,
+  layoutMode = "docked",
+  onLayoutModeChange,
 }: TitleBarProps) {
   const { screen } = useAuth()
   const onMap = screen === "map"
@@ -129,6 +143,32 @@ export function TitleBar({
               </>
             )}
           </div>
+        )}
+
+        {/* Only where there is a map to lay out. */}
+        {onMap && onLayoutModeChange && (
+          <button
+            type="button"
+            onClick={() =>
+              onLayoutModeChange(layoutMode === "docked" ? "workspace" : "docked")
+            }
+            className="app-no-drag flex h-7 w-7 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-surface-raised/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            title={
+              layoutMode === "docked"
+                ? "Switch to workspace layout"
+                : "Switch to docked layout"
+            }
+            aria-pressed={layoutMode === "workspace"}
+          >
+            {/* The icon names the layout it switches TO, not the one in use:
+                the button is read as an action, and showing the current state
+                made every user press it to find out what it did. */}
+            {layoutMode === "docked" ? (
+              <PanelBottom className="size-4" />
+            ) : (
+              <PanelLeft className="size-4" />
+            )}
+          </button>
         )}
 
         <div className="app-no-drag flex items-center gap-1">

--- a/frontend/src/components/TitleBar.tsx
+++ b/frontend/src/components/TitleBar.tsx
@@ -145,8 +145,8 @@ export function TitleBar({
           </div>
         )}
 
-        {/* Only where there is a map to lay out. */}
-        {onMap && onLayoutModeChange && (
+        {/* Wherever there is a map to lay out. */}
+        {hasMap && onLayoutModeChange && (
           <button
             type="button"
             onClick={() =>

--- a/frontend/src/components/TitleBar.tsx
+++ b/frontend/src/components/TitleBar.tsx
@@ -10,6 +10,7 @@ import {
 import { AvatarCircle } from "@/components/AvatarCircle"
 import type { ReactNode } from "react"
 import {
+  BrowserOpenURL,
   WindowMinimise,
   WindowToggleMaximise,
   Quit,
@@ -56,18 +57,25 @@ interface TitleBarProps {
   credit?: { kind: BasemapKind; date: string | null }
 }
 
-/** One credited party, as a link where its licence asks to be reachable. */
+/**
+ * One credited party, reachable where its licence asks it to be.
+ *
+ * A button calling BrowserOpenURL rather than an anchor with target="_blank".
+ * This is a WKWebView, and Wails declares WKUIDelegate without implementing
+ * createWebViewWith, so a blank-target link is silently ignored -- the click
+ * does nothing at all. On a link the ODbL requires to be reachable, silently
+ * nothing is the one outcome that cannot be shipped.
+ */
 function Credit({ part }: { part: CreditPart }) {
   if (!part.href) return <span>{part.label}</span>
   return (
-    <a
-      href={part.href}
-      target="_blank"
-      rel="noreferrer"
+    <button
+      type="button"
+      onClick={() => BrowserOpenURL(part.href!)}
       className="hover:text-foreground hover:underline"
     >
       {part.label}
-    </a>
+    </button>
   )
 }
 

--- a/frontend/src/components/WaterPanel.tsx
+++ b/frontend/src/components/WaterPanel.tsx
@@ -1,11 +1,12 @@
 import { forwardRef } from "react"
-import { motion } from "motion/react"
-import { ChevronLeft, CheckCircle2, Loader2, Play, Trash2, Waves } from "lucide-react"
+import { CheckCircle2, Loader2, Play, Trash2, Waves } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { todayISO } from "@/lib/dates"
 import { btnGhost, btnPrimary, btnPrimaryCommit } from "@/components/ui/buttons"
 import { PanelSection as Section } from "@/components/ui/PanelSection"
 import type { WaterIndex } from "@/lib/types"
+import type { PanelPlacement } from "@/components/ui/PanelShell"
+import { PanelShell } from "@/components/ui/PanelShell"
 
 const INDICES: { id: WaterIndex; label: string; detail: string }[] = [
   {
@@ -26,7 +27,8 @@ const INDICES: { id: WaterIndex; label: string; detail: string }[] = [
 ]
 
 export interface WaterPanelProps {
-  panelOffsetClass?: string
+  /** Which container draws this panel. See ui/PanelShell. */
+  placement?: PanelPlacement
   hasArea: boolean
   start: string
   end: string
@@ -78,25 +80,12 @@ export const WaterPanel = forwardRef<HTMLDivElement, WaterPanelProps>(
     } = props
 
     return (
-      <motion.div
+      <PanelShell
         ref={ref}
-        className={`panel app-no-drag panel-scroll absolute ${props.panelOffsetClass ?? "left-3"} top-3 bottom-3 z-[1000] flex w-[19rem] flex-col gap-4 overflow-y-auto rounded-md p-4`}
-        initial={{ opacity: 0, x: -28 }}
-        animate={{ opacity: 1, x: 0 }}
-        exit={{ opacity: 0, x: -28 }}
-        transition={{ type: "spring", stiffness: 360, damping: 34 }}
+        title="Surface water"
+        placement={props.placement}
+        onCollapse={onCollapse}
       >
-        <div className="flex items-center justify-between">
-          <h1 className="text-sm font-semibold">Surface water</h1>
-          <button
-            type="button"
-            onClick={onCollapse}
-            className="text-muted-foreground hover:text-foreground"
-            title="Hide panel"
-          >
-            <ChevronLeft className="size-4" />
-          </button>
-        </div>
 
         <Section step="01" title="Area">
           <p className="text-xs leading-relaxed text-muted-foreground">
@@ -240,7 +229,7 @@ export const WaterPanel = forwardRef<HTMLDivElement, WaterPanelProps>(
             no trained legend.
           </p>
         </Section>
-      </motion.div>
+      </PanelShell>
     )
   }
 )

--- a/frontend/src/components/WaterStatusPanel.tsx
+++ b/frontend/src/components/WaterStatusPanel.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils"
 import { forwardRef, useState } from "react"
 import { motion } from "motion/react"
 import { AlertTriangle, ChevronDown, ChevronUp, Trash2, X } from "lucide-react"
@@ -7,6 +8,11 @@ import { BLUES_STOPS } from "@/lib/compositeCatalog"
 interface WaterStatusPanelProps {
   water: WaterAnalysis | null
   onClear: () => void
+  /**
+   * Left inset, which decides what the panel is centred within. See
+   * statusPanelInset in analysisPrimitives.
+   */
+  leftOffsetClass?: string
 }
 
 function Ramp({
@@ -69,7 +75,10 @@ function Metric({
 export const WaterStatusPanel = forwardRef<
   HTMLDivElement,
   WaterStatusPanelProps
->(function WaterStatusPanel({ water, onClear }, ref) {
+>(function WaterStatusPanel(
+  { water, onClear, leftOffsetClass = "left-[23.5rem]" },
+  ref
+) {
   const [collapsed, setCollapsed] = useState(false)
   const hasResult = !!water
 
@@ -85,7 +94,10 @@ export const WaterStatusPanel = forwardRef<
   return (
     <motion.div
       ref={ref}
-      className="panel app-no-drag absolute bottom-[calc(var(--map-foot,0px)+0.75rem)] left-[23.5rem] right-16 z-[1000] mx-auto max-w-[36rem] rounded-md"
+      className={cn(
+          "panel app-no-drag absolute bottom-[calc(var(--map-foot,0px)+0.75rem)] right-16 z-[1000] mx-auto max-w-[36rem] rounded-md",
+          leftOffsetClass
+        )}
       initial={{ opacity: 0, y: 24 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: 24 }}

--- a/frontend/src/components/WorkspaceBar.tsx
+++ b/frontend/src/components/WorkspaceBar.tsx
@@ -4,23 +4,28 @@
  * It is an island, not a bar. PeriodTimeline already runs edge to edge along
  * the very bottom, welded to the frame by a `.panel` with its side and bottom
  * borders removed, and a second full-width strip above it would read as a
- * thicker version of the same thing. This one floats: centred, sized to its
- * contents, clear of both side edges, with a larger corner radius than any
- * docked panel so the difference is legible before anything is read.
+ * thicker version of the same thing. This one floats above the track's left
+ * end, aligned with the label the track starts with, sized to its contents and
+ * clear of the right edge entirely -- which is what leaves the tile attribution
+ * at that edge docked to the track instead of being pushed off it.
  *
  * It carries the two things the navigation column and the panel footer used to
- * carry between them -- which of the three map products is in view, and the
- * action that runs it. It carries nothing else. Energy and the project hub are
- * deliberately absent: three peers is a segmented control, and adding a fourth
- * kind of destination would rebuild the sidebar lying down.
+ * carry between them: which of the three map products is in view, and the
+ * action that runs it.
+ *
+ * The products are aggregated behind one item rather than listed as three
+ * peers, matching how the navigation column groups them. Three labels in a row
+ * made the island as wide as half the window for a choice that changes rarely,
+ * and the grouping leaves room for the destinations this bar does not yet
+ * carry -- energy and the project hub -- to arrive as siblings of Map rather
+ * than as a second kind of thing.
  *
  * The way out of the workspace layout is the toggle in the title bar, which is
- * mounted in both layouts. That is a decision rather than an omission: a route
- * to the other screens belongs here only once the layout has been used enough
- * to say what it should look like.
+ * mounted in both layouts.
  */
-import { motion } from "motion/react"
-import { Loader2, Play, Settings2 } from "lucide-react"
+import { useEffect, useRef, useState } from "react"
+import { AnimatePresence, motion } from "motion/react"
+import { ChevronUp, Loader2, Map as MapIcon, Play, Settings2 } from "lucide-react"
 import { MAP_TOOLS, type MapToolId } from "@/lib/mapTools"
 import { cn } from "@/lib/utils"
 import { btnPrimaryCommit } from "@/components/ui/buttons"
@@ -36,6 +41,7 @@ export function WorkspaceBar({
   onRun,
   configOpen,
   onConfigToggle,
+  onWidthChange,
 }: {
   tool: MapToolId | null
   onToolChange: (id: MapToolId) => void
@@ -48,107 +54,207 @@ export function WorkspaceBar({
   onRun: () => void
   configOpen: boolean
   onConfigToggle: () => void
+  /** The island's measured width, for whatever has to make room for it. */
+  onWidthChange?: (px: number) => void
 }) {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const islandRef = useRef<HTMLDivElement>(null)
+
+  /*
+    The island is sized by its contents, and the contents change: the run
+    button reads "Classify" or "Classifying", "Map water" or "Mapping". What
+    retracts to sit beside it therefore cannot use a constant, so the measure
+    is reported rather than assumed.
+  */
+  useEffect(() => {
+    const el = islandRef.current
+    if (!el || !onWidthChange) return
+    const ro = new ResizeObserver(([entry]) =>
+      onWidthChange(entry.contentRect.width)
+    )
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [onWidthChange])
+
+  // A menu that opens over the map has to close on the next thing the user
+  // does, or it sits on top of the imagery they were trying to reach.
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: PointerEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false)
+    }
+    document.addEventListener("pointerdown", onDown)
+    document.addEventListener("keydown", onKey)
+    return () => {
+      document.removeEventListener("pointerdown", onDown)
+      document.removeEventListener("keydown", onKey)
+    }
+  }, [open])
+
   // The clamp the surface-water panel uses, which is the only one of the three
   // that is right: a bare Math.max(4, ...) draws a started run before it has
   // started, and a bare Math.max(0, ...) lets a stale value run past the end.
   const pct = Math.max(0, Math.min(100, progress))
+  const active = MAP_TOOLS.find((t) => t.id === tool)
 
   return (
     <motion.div
+      ref={rootRef}
       className={cn(
-        "panel app-no-drag absolute left-1/2 z-[1000] -translate-x-1/2",
-        // Above whatever the foot already reserves. --map-foot is the total
-        // reservation, not the timeline's own height; see index.css.
-        "bottom-[calc(var(--map-foot,0px)+1rem)]",
-        // h-12 is the commit button's 36px plus 6px of breathing room on each
-        // side. Stated because the foot reservation is derived from it.
-        "flex h-12 items-center gap-1 overflow-hidden rounded-lg px-2"
+        "app-no-drag absolute z-[1000]",
+        // Flush into the corner, beside the track rather than above it. The
+        // track retracts to make room, so the two read as two segments of one
+        // foot; a gutter under or left of the island would have broken that by
+        // letting map show through beneath a bar that is part of the frame.
+        "left-0 bottom-0"
       )}
+      // On the root, not on the island inside it: the caller wraps this in an
+      // AnimatePresence, which can only animate the element it is given.
       initial={{ opacity: 0, y: 16 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: 16 }}
       transition={{ type: "spring", stiffness: 380, damping: 34 }}
     >
-      {/*
-        A segmented control rather than a menu. Three is where a segment beats a
-        dropdown, and it keeps the sidebar's most valuable property: every
-        destination visible without an interaction. The labels come from
-        MAP_TOOLS so this cannot drift from the column that lists the same three.
-      */}
-      <div className="flex items-center gap-0.5" role="tablist" aria-label="Map products">
-        {MAP_TOOLS.map((t) => {
-          const active = tool === t.id
-          return (
-            <button
-              key={t.id}
-              type="button"
-              role="tab"
-              aria-selected={active}
-              onClick={() => onToolChange(t.id)}
-              className={cn(
-                "flex h-9 items-center rounded-sm px-3 text-emphasis transition-colors",
-                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-                active
-                  ? "bg-surface-raised text-foreground"
-                  : "text-muted-foreground hover:bg-surface-raised/70 hover:text-foreground"
-              )}
-            >
-              {t.label}
-            </button>
-          )
-        })}
-      </div>
-
-      <span className="hairline mx-1 h-5 w-px self-center border-l" />
-
-      <button
-        type="button"
-        onClick={onConfigToggle}
-        aria-pressed={configOpen}
-        title={tool ? `${MAP_TOOLS.find((t) => t.id === tool)?.label} parameters` : "Parameters"}
-        className={cn(
-          "flex h-9 w-9 items-center justify-center rounded-sm transition-colors",
-          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-          configOpen
-            ? "bg-surface-raised text-foreground"
-            : "text-muted-foreground hover:bg-surface-raised/70 hover:text-foreground"
+      <AnimatePresence>
+        {open && (
+          <motion.ul
+            // Centred on the island rather than aligned to the button that
+            // opens it. The island is flush in the corner, so a menu hung from
+            // its left edge sits against the window frame with nothing under
+            // its outer half.
+            className="panel absolute bottom-[calc(100%+0.5rem)] left-1/2 w-[13rem] -translate-x-1/2 overflow-hidden rounded-md py-1"
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 8 }}
+            transition={{ type: "spring", stiffness: 400, damping: 32 }}
+          >
+            {MAP_TOOLS.map((t) => (
+              <li key={t.id}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    onToolChange(t.id)
+                    setOpen(false)
+                  }}
+                  aria-current={t.id === tool ? "true" : undefined}
+                  className={cn(
+                    "flex h-8 w-full items-center px-3 text-left text-emphasis transition-colors",
+                    "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
+                    t.id === tool
+                      ? "bg-surface-raised text-foreground"
+                      : "text-muted-foreground hover:bg-surface-raised/70 hover:text-foreground"
+                  )}
+                >
+                  <span className="min-w-0 truncate">{t.label}</span>
+                </button>
+              </li>
+            ))}
+          </motion.ul>
         )}
-      >
-        <Settings2 className="size-4" />
-      </button>
-
-      <button
-        type="button"
-        onClick={onRun}
-        disabled={!canRun || running}
-        className={cn(btnPrimaryCommit, "ml-1")}
-        // The progress message is the button's tooltip rather than a second row
-        // of text: it changes several times a second, and a line that reflows
-        // on every change costs more attention than it returns.
-        title={running && progressMsg ? progressMsg : undefined}
-      >
-        {running ? (
-          <Loader2 className="size-3.5 animate-spin" />
-        ) : (
-          <Play className="size-3.5" />
-        )}
-        {runLabel}
-      </button>
+      </AnimatePresence>
 
       {/*
-        The progress hairline rides the island's own bottom edge, so it reports
-        without taking height. Only while running: a track drawn at rest would
-        assert that a run exists.
+        The track's own height, taken from the variable that declares it, so the
+        two segments cannot drift apart by a pixel. It leaves 13px around the
+        36px commit button, which is the tallest thing inside.
+
+        Square on every corner. It sits on the window frame on three sides,
+        where a radius shows map through the gap it opens, and it meets the
+        period track on the fourth -- the two are segments of one flat band, and
+        a curve on either side of the seam reads as two things that failed to
+        line up. The border is dropped on the two framed edges, inline because
+        .panel is unlayered in index.css and outranks the border utilities --
+        they compile, they simply never apply.
       */}
-      {running && (
-        <div className="absolute inset-x-0 bottom-0 h-0.5 bg-surface-raised">
-          <div
-            className="h-full bg-primary transition-[width] duration-200 ease-out"
-            style={{ width: `${pct}%` }}
+      <div
+        ref={islandRef}
+        className="panel relative flex h-[var(--map-foot,3.0625rem)] items-center gap-1 overflow-hidden px-2"
+        style={{ borderInlineStartWidth: 0, borderBlockEndWidth: 0 }}
+      >
+        {/*
+          One item, named for the group and showing what is selected under it.
+          The column above says "Map" with the three nested; this says the same
+          thing lying down.
+        */}
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          aria-expanded={open}
+          aria-haspopup="true"
+          className={cn(
+            "flex h-9 items-center gap-2 rounded-sm px-2.5 transition-colors",
+            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+            open
+              ? "bg-surface-raised text-foreground"
+              : "text-muted-foreground hover:bg-surface-raised/70 hover:text-foreground"
+          )}
+        >
+          <MapIcon className="size-4 shrink-0 text-primary" />
+          <span className="text-emphasis text-foreground">
+            {active?.label ?? "Map"}
+          </span>
+          <ChevronUp
+            className={cn(
+              "size-3 shrink-0 transition-transform",
+              open ? "" : "rotate-180"
+            )}
           />
-        </div>
-      )}
+        </button>
+
+        <span className="hairline mx-1 h-5 w-px self-center border-l" />
+
+        <button
+          type="button"
+          onClick={onConfigToggle}
+          aria-pressed={configOpen}
+          title={active ? `${active.label} parameters` : "Parameters"}
+          className={cn(
+            "flex h-9 w-9 items-center justify-center rounded-sm transition-colors",
+            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+            configOpen
+              ? "bg-surface-raised text-foreground"
+              : "text-muted-foreground hover:bg-surface-raised/70 hover:text-foreground"
+          )}
+        >
+          <Settings2 className="size-4" />
+        </button>
+
+        <button
+          type="button"
+          onClick={onRun}
+          disabled={!canRun || running}
+          className={cn(btnPrimaryCommit, "ml-1")}
+          // The progress message is the button's tooltip rather than a second
+          // row of text: it changes several times a second, and a line that
+          // reflows on every change costs more attention than it returns.
+          title={running && progressMsg ? progressMsg : undefined}
+        >
+          {running ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <Play className="size-3.5" />
+          )}
+          {runLabel}
+        </button>
+
+        {/*
+          The progress hairline rides the island's own bottom edge, so it
+          reports without taking height. Only while running: a track drawn at
+          rest would assert that a run exists.
+        */}
+        {running && (
+          <div className="absolute inset-x-0 bottom-0 h-0.5 bg-surface-raised">
+            <div
+              className="h-full bg-primary transition-[width] duration-200 ease-out"
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+        )}
+      </div>
     </motion.div>
   )
 }

--- a/frontend/src/components/WorkspaceBar.tsx
+++ b/frontend/src/components/WorkspaceBar.tsx
@@ -26,16 +26,23 @@
  */
 import { useEffect, useRef, useState } from "react"
 import { AnimatePresence, motion } from "motion/react"
-import { ChevronUp, Loader2, Play, Settings2, type LucideIcon } from "lucide-react"
+import { ChevronUp, Loader2, Play, Settings2 } from "lucide-react"
+import { NAV_GROUPS } from "@/lib/navigation"
 import { cn } from "@/lib/utils"
 import { btnPrimaryCommit } from "@/components/ui/buttons"
 
+/** One row of the menu, in the vocabulary the navigation column already uses. */
+const ROW =
+  "flex h-8 w-full items-center px-3 text-left text-emphasis transition-colors " +
+  "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
+const ROW_ON = "bg-surface-raised text-foreground"
+const ROW_OFF =
+  "text-muted-foreground hover:bg-surface-raised/70 hover:text-foreground"
+
 export function WorkspaceBar({
-  icon: Icon,
-  groupLabel,
-  items,
+  groupId,
   activeId,
-  onSelect,
+  onNavigate,
   running,
   progress,
   progressMsg,
@@ -46,13 +53,18 @@ export function WorkspaceBar({
   onConfigToggle,
   onWidthChange,
 }: {
-  /** The group's own mark, matching the one the navigation column gives it. */
-  icon: LucideIcon
-  /** What the group is called when nothing under it is selected. */
-  groupLabel: string
-  items: readonly { id: string; label: string }[]
+  /** The group this screen belongs to, which is the one shown on the trigger. */
+  groupId: string
+  /** Which of that group's items is in view. */
   activeId: string | null
-  onSelect: (id: string) => void
+  /**
+   * Go to a destination. The item is absent for a group that is a single place.
+   *
+   * The bar carries every destination, not just the one it is on, because the
+   * dock layout hides the navigation column: without this the only way from the
+   * map to energy was to leave the layout, switch, and come back.
+   */
+  onNavigate: (groupId: string, itemId?: string) => void
   running: boolean
   progress: number
   progressMsg: string
@@ -107,7 +119,9 @@ export function WorkspaceBar({
   // that is right: a bare Math.max(4, ...) draws a started run before it has
   // started, and a bare Math.max(0, ...) lets a stale value run past the end.
   const pct = Math.max(0, Math.min(100, progress))
-  const active = items.find((t) => t.id === activeId)
+  const group = NAV_GROUPS.find((g) => g.id === groupId)
+  const Icon = group?.icon
+  const active = group?.items.find((t) => t.id === activeId)
 
   return (
     <motion.div
@@ -140,27 +154,64 @@ export function WorkspaceBar({
             exit={{ opacity: 0, y: 8 }}
             transition={{ type: "spring", stiffness: 400, damping: 32 }}
           >
-            {items.map((t) => (
-              <li key={t.id}>
-                <button
-                  type="button"
-                  onClick={() => {
-                    onSelect(t.id)
-                    setOpen(false)
-                  }}
-                  aria-current={t.id === activeId ? "true" : undefined}
-                  className={cn(
-                    "flex h-8 w-full items-center px-3 text-left text-emphasis transition-colors",
-                    "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
-                    t.id === activeId
-                      ? "bg-surface-raised text-foreground"
-                      : "text-muted-foreground hover:bg-surface-raised/70 hover:text-foreground"
+            {/*
+              Every destination, grouped as the navigation column groups them.
+              This is that column lying down: the same three headings, the same
+              children under each, so a user who learned one has learned both.
+            */}
+            {NAV_GROUPS.map((g) => {
+              const onThisGroup = g.id === groupId
+              const GroupIcon = g.icon
+              return (
+                <li key={g.id}>
+                  {g.items.length === 0 ? (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        onNavigate(g.id)
+                        setOpen(false)
+                      }}
+                      aria-current={onThisGroup ? "true" : undefined}
+                      className={cn(ROW, "gap-2", onThisGroup ? ROW_ON : ROW_OFF)}
+                    >
+                      <GroupIcon className="size-3.5 shrink-0" />
+                      <span className="min-w-0 truncate">{g.label}</span>
+                    </button>
+                  ) : (
+                    <>
+                      <div className="flex items-center gap-2 px-3 pb-0.5 pt-1.5">
+                        <GroupIcon className="size-3.5 shrink-0 text-primary" />
+                        <span className="eyebrow !text-[9px]">{g.label}</span>
+                      </div>
+                      <ul>
+                        {g.items.map((t) => {
+                          const here = onThisGroup && t.id === activeId
+                          return (
+                            <li key={t.id}>
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  onNavigate(g.id, t.id)
+                                  setOpen(false)
+                                }}
+                                aria-current={here ? "true" : undefined}
+                                className={cn(
+                                  ROW,
+                                  "pl-8",
+                                  here ? ROW_ON : ROW_OFF
+                                )}
+                              >
+                                <span className="min-w-0 truncate">{t.label}</span>
+                              </button>
+                            </li>
+                          )
+                        })}
+                      </ul>
+                    </>
                   )}
-                >
-                  <span className="min-w-0 truncate">{t.label}</span>
-                </button>
-              </li>
-            ))}
+                </li>
+              )
+            })}
           </motion.ul>
         )}
       </AnimatePresence>
@@ -201,9 +252,9 @@ export function WorkspaceBar({
               : "text-muted-foreground hover:bg-surface-raised/70 hover:text-foreground"
           )}
         >
-          <Icon className="size-4 shrink-0 text-primary" />
+          {Icon && <Icon className="size-4 shrink-0 text-primary" />}
           <span className="text-emphasis text-foreground">
-            {active?.label ?? groupLabel}
+            {active?.label ?? group?.label ?? "Go to"}
           </span>
           <ChevronUp
             className={cn(

--- a/frontend/src/components/WorkspaceBar.tsx
+++ b/frontend/src/components/WorkspaceBar.tsx
@@ -1,5 +1,5 @@
 /**
- * The workspace layout's control surface: which product, and run it.
+ * The dock layout's control surface: which product, and run it.
  *
  * It is an island, not a bar. PeriodTimeline already runs edge to edge along
  * the very bottom, welded to the frame by a `.panel` with its side and bottom
@@ -13,26 +13,29 @@
  * carry between them: which of the three map products is in view, and the
  * action that runs it.
  *
- * The products are aggregated behind one item rather than listed as three
- * peers, matching how the navigation column groups them. Three labels in a row
- * made the island as wide as half the window for a choice that changes rarely,
- * and the grouping leaves room for the destinations this bar does not yet
- * carry -- energy and the project hub -- to arrive as siblings of Map rather
- * than as a second kind of thing.
+ * The products are aggregated behind one item rather than listed as peers,
+ * matching how the navigation column groups them. Labels in a row made the
+ * island as wide as half the window for a choice that changes rarely.
+ *
+ * The group is a prop, not a constant: the map screen passes its three tools
+ * and the energy screen its two resources, and both read as the same object
+ * because they are one.
  *
  * The way out of the workspace layout is the toggle in the title bar, which is
  * mounted in both layouts.
  */
 import { useEffect, useRef, useState } from "react"
 import { AnimatePresence, motion } from "motion/react"
-import { ChevronUp, Loader2, Map as MapIcon, Play, Settings2 } from "lucide-react"
-import { MAP_TOOLS, type MapToolId } from "@/lib/mapTools"
+import { ChevronUp, Loader2, Play, Settings2, type LucideIcon } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { btnPrimaryCommit } from "@/components/ui/buttons"
 
 export function WorkspaceBar({
-  tool,
-  onToolChange,
+  icon: Icon,
+  groupLabel,
+  items,
+  activeId,
+  onSelect,
   running,
   progress,
   progressMsg,
@@ -43,8 +46,13 @@ export function WorkspaceBar({
   onConfigToggle,
   onWidthChange,
 }: {
-  tool: MapToolId | null
-  onToolChange: (id: MapToolId) => void
+  /** The group's own mark, matching the one the navigation column gives it. */
+  icon: LucideIcon
+  /** What the group is called when nothing under it is selected. */
+  groupLabel: string
+  items: readonly { id: string; label: string }[]
+  activeId: string | null
+  onSelect: (id: string) => void
   running: boolean
   progress: number
   progressMsg: string
@@ -99,7 +107,7 @@ export function WorkspaceBar({
   // that is right: a bare Math.max(4, ...) draws a started run before it has
   // started, and a bare Math.max(0, ...) lets a stale value run past the end.
   const pct = Math.max(0, Math.min(100, progress))
-  const active = MAP_TOOLS.find((t) => t.id === tool)
+  const active = items.find((t) => t.id === activeId)
 
   return (
     <motion.div
@@ -132,19 +140,19 @@ export function WorkspaceBar({
             exit={{ opacity: 0, y: 8 }}
             transition={{ type: "spring", stiffness: 400, damping: 32 }}
           >
-            {MAP_TOOLS.map((t) => (
+            {items.map((t) => (
               <li key={t.id}>
                 <button
                   type="button"
                   onClick={() => {
-                    onToolChange(t.id)
+                    onSelect(t.id)
                     setOpen(false)
                   }}
-                  aria-current={t.id === tool ? "true" : undefined}
+                  aria-current={t.id === activeId ? "true" : undefined}
                   className={cn(
                     "flex h-8 w-full items-center px-3 text-left text-emphasis transition-colors",
                     "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
-                    t.id === tool
+                    t.id === activeId
                       ? "bg-surface-raised text-foreground"
                       : "text-muted-foreground hover:bg-surface-raised/70 hover:text-foreground"
                   )}
@@ -193,9 +201,9 @@ export function WorkspaceBar({
               : "text-muted-foreground hover:bg-surface-raised/70 hover:text-foreground"
           )}
         >
-          <MapIcon className="size-4 shrink-0 text-primary" />
+          <Icon className="size-4 shrink-0 text-primary" />
           <span className="text-emphasis text-foreground">
-            {active?.label ?? "Map"}
+            {active?.label ?? groupLabel}
           </span>
           <ChevronUp
             className={cn(

--- a/frontend/src/components/WorkspaceBar.tsx
+++ b/frontend/src/components/WorkspaceBar.tsx
@@ -1,0 +1,154 @@
+/**
+ * The workspace layout's control surface: which product, and run it.
+ *
+ * It is an island, not a bar. PeriodTimeline already runs edge to edge along
+ * the very bottom, welded to the frame by a `.panel` with its side and bottom
+ * borders removed, and a second full-width strip above it would read as a
+ * thicker version of the same thing. This one floats: centred, sized to its
+ * contents, clear of both side edges, with a larger corner radius than any
+ * docked panel so the difference is legible before anything is read.
+ *
+ * It carries the two things the navigation column and the panel footer used to
+ * carry between them -- which of the three map products is in view, and the
+ * action that runs it. It carries nothing else. Energy and the project hub are
+ * deliberately absent: three peers is a segmented control, and adding a fourth
+ * kind of destination would rebuild the sidebar lying down.
+ *
+ * The way out of the workspace layout is the toggle in the title bar, which is
+ * mounted in both layouts. That is a decision rather than an omission: a route
+ * to the other screens belongs here only once the layout has been used enough
+ * to say what it should look like.
+ */
+import { motion } from "motion/react"
+import { Loader2, Play, Settings2 } from "lucide-react"
+import { MAP_TOOLS, type MapToolId } from "@/lib/mapTools"
+import { cn } from "@/lib/utils"
+import { btnPrimaryCommit } from "@/components/ui/buttons"
+
+export function WorkspaceBar({
+  tool,
+  onToolChange,
+  running,
+  progress,
+  progressMsg,
+  runLabel,
+  canRun,
+  onRun,
+  configOpen,
+  onConfigToggle,
+}: {
+  tool: MapToolId | null
+  onToolChange: (id: MapToolId) => void
+  running: boolean
+  progress: number
+  progressMsg: string
+  /** What the action is called for the product in view. */
+  runLabel: string
+  canRun: boolean
+  onRun: () => void
+  configOpen: boolean
+  onConfigToggle: () => void
+}) {
+  // The clamp the surface-water panel uses, which is the only one of the three
+  // that is right: a bare Math.max(4, ...) draws a started run before it has
+  // started, and a bare Math.max(0, ...) lets a stale value run past the end.
+  const pct = Math.max(0, Math.min(100, progress))
+
+  return (
+    <motion.div
+      className={cn(
+        "panel app-no-drag absolute left-1/2 z-[1000] -translate-x-1/2",
+        // Above whatever the foot already reserves. --map-foot is the total
+        // reservation, not the timeline's own height; see index.css.
+        "bottom-[calc(var(--map-foot,0px)+1rem)]",
+        // h-12 is the commit button's 36px plus 6px of breathing room on each
+        // side. Stated because the foot reservation is derived from it.
+        "flex h-12 items-center gap-1 overflow-hidden rounded-lg px-2"
+      )}
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 16 }}
+      transition={{ type: "spring", stiffness: 380, damping: 34 }}
+    >
+      {/*
+        A segmented control rather than a menu. Three is where a segment beats a
+        dropdown, and it keeps the sidebar's most valuable property: every
+        destination visible without an interaction. The labels come from
+        MAP_TOOLS so this cannot drift from the column that lists the same three.
+      */}
+      <div className="flex items-center gap-0.5" role="tablist" aria-label="Map products">
+        {MAP_TOOLS.map((t) => {
+          const active = tool === t.id
+          return (
+            <button
+              key={t.id}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => onToolChange(t.id)}
+              className={cn(
+                "flex h-9 items-center rounded-sm px-3 text-emphasis transition-colors",
+                "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                active
+                  ? "bg-surface-raised text-foreground"
+                  : "text-muted-foreground hover:bg-surface-raised/70 hover:text-foreground"
+              )}
+            >
+              {t.label}
+            </button>
+          )
+        })}
+      </div>
+
+      <span className="hairline mx-1 h-5 w-px self-center border-l" />
+
+      <button
+        type="button"
+        onClick={onConfigToggle}
+        aria-pressed={configOpen}
+        title={tool ? `${MAP_TOOLS.find((t) => t.id === tool)?.label} parameters` : "Parameters"}
+        className={cn(
+          "flex h-9 w-9 items-center justify-center rounded-sm transition-colors",
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+          configOpen
+            ? "bg-surface-raised text-foreground"
+            : "text-muted-foreground hover:bg-surface-raised/70 hover:text-foreground"
+        )}
+      >
+        <Settings2 className="size-4" />
+      </button>
+
+      <button
+        type="button"
+        onClick={onRun}
+        disabled={!canRun || running}
+        className={cn(btnPrimaryCommit, "ml-1")}
+        // The progress message is the button's tooltip rather than a second row
+        // of text: it changes several times a second, and a line that reflows
+        // on every change costs more attention than it returns.
+        title={running && progressMsg ? progressMsg : undefined}
+      >
+        {running ? (
+          <Loader2 className="size-3.5 animate-spin" />
+        ) : (
+          <Play className="size-3.5" />
+        )}
+        {runLabel}
+      </button>
+
+      {/*
+        The progress hairline rides the island's own bottom edge, so it reports
+        without taking height. Only while running: a track drawn at rest would
+        assert that a run exists.
+      */}
+      {running && (
+        <div className="absolute inset-x-0 bottom-0 h-0.5 bg-surface-raised">
+          <div
+            className="h-full bg-primary transition-[width] duration-200 ease-out"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      )}
+    </motion.div>
+  )
+}

--- a/frontend/src/components/analysisPrimitives.tsx
+++ b/frontend/src/components/analysisPrimitives.tsx
@@ -202,3 +202,22 @@ export function PowerProvenanceNote({
     </p>
   )
 }
+
+/**
+ * Where a status panel's left edge sits, which decides what it is centred in.
+ *
+ * The four panels are all `right-16 mx-auto` with a capped width, so the left
+ * inset is the whole of the horizontal placement. Two cases, and they are not
+ * the same rule:
+ *
+ * - The docked layout clears the 19rem column plus its gutters, which centres
+ *   the panel in the map's free width. Centred on the window it would sit half
+ *   under the column.
+ * - The dock layout has no column, so the inset matches the right one and the
+ *   panel centres on the window itself. `right-16` is there to clear Leaflet's
+ *   zoom stack, and only a matching left inset makes mx-auto find the true
+ *   centre rather than a point 2rem left of it.
+ */
+export function statusPanelInset(dock: boolean): string {
+  return dock ? "left-16" : "left-[23.5rem]"
+}

--- a/frontend/src/components/energy/RecordWindowBar.tsx
+++ b/frontend/src/components/energy/RecordWindowBar.tsx
@@ -58,8 +58,20 @@ export interface RecordWindowBarProps {
   bands: RecordBand[]
   endYear: number
   disabled?: boolean
-  /** Left edge, so the bar starts after whatever column is open beside it. */
-  leftOffsetClass?: string
+  /**
+   * How far the bar's left edge is pushed in, as a CSS length.
+   *
+   * A length rather than a class, matching PeriodTimeline: the docked column is
+   * 19rem by construction, but the dock layout's island sizes to its own
+   * contents and reports what it measured.
+   */
+  leftOffset?: string
+  /**
+   * Whether what the bar retracts for sits on the frame rather than floating
+   * above it. The rounded corner exists to meet a floating panel; against a
+   * flush segment the two are one band and a curve reads as a misalignment.
+   */
+  flushLeft?: boolean
   /**
    * The bar's rendered height, reported rather than assumed.
    *
@@ -121,7 +133,8 @@ export function RecordWindowBar({
   bands,
   endYear,
   disabled,
-  leftOffsetClass = "left-0",
+  leftOffset,
+  flushLeft = false,
   onHeightChange,
 }: RecordWindowBarProps) {
   const ruleRef = useRef<HTMLDivElement | null>(null)
@@ -191,8 +204,9 @@ export function RecordWindowBar({
         // opens and closes, and an edge that jumped would read as a different
         // control appearing.
         "transition-[left] duration-200 ease-out",
-        leftOffsetClass
+        leftOffset && !flushLeft ? "rounded-tl-md" : null
       )}
+      style={{ left: leftOffset ?? 0 }}
       initial={{ opacity: 0, y: 16 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: 16 }}

--- a/frontend/src/components/ui/PanelShell.tsx
+++ b/frontend/src/components/ui/PanelShell.tsx
@@ -113,23 +113,31 @@ export const PanelShell = forwardRef<
     >
       <div className="flex items-center justify-between">
         <h1 className="text-sm font-semibold">{title}</h1>
-        <button
-          type="button"
-          onClick={() => onCollapse?.()}
-          className="text-muted-foreground hover:text-foreground"
-          title="Hide panel"
-        >
-          {/*
-            A chevron pointing left means "fold back against the left edge",
-            which is what the docked column does and what a right-edge drawer
-            cannot do. The drawer closes instead, so it says so.
-          */}
-          {placement === "docked" ? (
-            <ChevronLeft className="size-4" />
-          ) : (
-            <X className="size-4" />
-          )}
-        </button>
+        {/*
+          Only where there is something to dismiss to. The energy screen's
+          column has never been collapsible -- it is the screen's only control
+          surface -- and a button that renders without a handler is one that
+          does nothing when pressed.
+        */}
+        {onCollapse && (
+          <button
+            type="button"
+            onClick={onCollapse}
+            className="text-muted-foreground hover:text-foreground"
+            title="Hide panel"
+          >
+            {/*
+              A chevron pointing left means "fold back against the left edge",
+              which is what the docked column does and what a right-edge drawer
+              cannot do. The drawer closes instead, so it says so.
+            */}
+            {placement === "docked" ? (
+              <ChevronLeft className="size-4" />
+            ) : (
+              <X className="size-4" />
+            )}
+          </button>
+        )}
       </div>
       {children}
     </motion.div>

--- a/frontend/src/components/ui/PanelShell.tsx
+++ b/frontend/src/components/ui/PanelShell.tsx
@@ -1,0 +1,137 @@
+/**
+ * The container a map product's controls are drawn in.
+ *
+ * The three map panels -- classification, compositions, surface water -- were
+ * each written as their own positioned, animated box, and the box was the same
+ * string in all three:
+ *
+ *     panel app-no-drag panel-scroll absolute left-3 top-3 bottom-3 z-[1000]
+ *     flex w-[19rem] flex-col gap-4 overflow-y-auto rounded-md p-4
+ *
+ * Everything below that line -- 840 to 1100px of sections per panel -- is
+ * position-agnostic. So the panels' coupling to the left column was one line,
+ * written three times, and moving them anywhere meant editing three files that
+ * had already drifted in every other respect.
+ *
+ * That line lives here now, and it takes a placement. `docked` reproduces the
+ * left column exactly; `drawer` anchors to the right edge, for the workspace
+ * layout where there is no column to dock to. The panel bodies do not know
+ * which one they are in.
+ *
+ * The width stays 19rem in both. The bodies were authored for that measure --
+ * the date pairs, the radio cards, the band selects all lay out against it --
+ * so changing it in the drawer would turn a re-host into a redesign.
+ */
+import { forwardRef } from "react"
+import { motion } from "motion/react"
+import { ChevronLeft, X } from "lucide-react"
+
+/**
+ * Which container the panel is drawn in.
+ *
+ * Named for what each one is rather than for the layout mode that uses it: a
+ * placement is a fact about this box, and the modes are free to change which
+ * placement they ask for.
+ */
+export type PanelPlacement = "docked" | "drawer"
+
+/**
+ * Docked is the left column: full height between 0.75rem gutters, sliding in
+ * from the left edge it is attached to.
+ *
+ * Drawer is the right-edge overlay, following OverlayToolsPanel, which is the
+ * established vocabulary for a right-anchored surface on this screen. It stops
+ * short of the foot rather than running to `bottom-3`, because these bodies are
+ * genuinely 840 to 1100px tall and would otherwise run under whatever the
+ * workspace layout puts at the bottom. --map-foot is what that reservation is
+ * measured in; see index.css.
+ */
+const CONTAINER: Record<PanelPlacement, string> = {
+  docked:
+    "panel app-no-drag panel-scroll absolute left-3 top-3 bottom-3 z-[1000] " +
+    "flex w-[19rem] flex-col gap-4 overflow-y-auto rounded-md p-4",
+  drawer:
+    "panel app-no-drag panel-scroll absolute right-14 top-14 z-[1100] " +
+    "flex max-h-[calc(100%-var(--map-foot,0px)-5rem)] w-[19rem] flex-col gap-4 " +
+    "overflow-y-auto rounded-md p-4",
+}
+
+/**
+ * Entry offset per placement, so a panel enters from the edge it belongs to.
+ *
+ * This is the reason the animation has to live on the container and not on the
+ * body: the docked column slides in from the left and the drawer from the
+ * right, and a body that carried its own transition would fight whichever
+ * container it was placed in.
+ */
+const ENTER: Record<PanelPlacement, { x: number; y?: number }> = {
+  docked: { x: -28 },
+  drawer: { x: 16, y: -8 },
+}
+
+/**
+ * Where each placement settles. Written out per placement rather than as one
+ * `{ x: 0, y: 0 }`, so the docked panel animates the two values it offsets and
+ * not a third it never touches -- an axis listed here that the entry offset
+ * does not set is inert on screen but still costs a computed-style read per
+ * mount to find the value it is animating from.
+ */
+const REST: Record<PanelPlacement, { x: number; y?: number }> = {
+  docked: { x: 0 },
+  drawer: { x: 0, y: 0 },
+}
+
+/** The spring each placement's neighbours already use. */
+const SPRING: Record<PanelPlacement, { stiffness: number; damping: number }> = {
+  docked: { stiffness: 360, damping: 34 },
+  drawer: { stiffness: 380, damping: 32 },
+}
+
+export const PanelShell = forwardRef<
+  HTMLDivElement,
+  {
+    title: string
+    children: React.ReactNode
+    placement?: PanelPlacement
+    /**
+     * Dismiss. Optional because one of the three panels has always treated it
+     * so, and a shell that demanded it would be a change to that panel's
+     * contract rather than to its container.
+     */
+    onCollapse?: () => void
+  }
+>(function PanelShell({ title, children, placement = "docked", onCollapse }, ref) {
+  const enter = ENTER[placement]
+  return (
+    <motion.div
+      ref={ref}
+      className={CONTAINER[placement]}
+      initial={{ opacity: 0, ...enter }}
+      animate={{ opacity: 1, ...REST[placement] }}
+      exit={{ opacity: 0, ...enter }}
+      transition={{ type: "spring", ...SPRING[placement] }}
+    >
+      <div className="flex items-center justify-between">
+        <h1 className="text-sm font-semibold">{title}</h1>
+        <button
+          type="button"
+          onClick={() => onCollapse?.()}
+          className="text-muted-foreground hover:text-foreground"
+          title="Hide panel"
+        >
+          {/*
+            A chevron pointing left means "fold back against the left edge",
+            which is what the docked column does and what a right-edge drawer
+            cannot do. The drawer closes instead, so it says so.
+          */}
+          {placement === "docked" ? (
+            <ChevronLeft className="size-4" />
+          ) : (
+            <X className="size-4" />
+          )}
+        </button>
+      </div>
+      {children}
+    </motion.div>
+  )
+})

--- a/frontend/src/components/ui/PanelShell.tsx
+++ b/frontend/src/components/ui/PanelShell.tsx
@@ -40,18 +40,19 @@ export type PanelPlacement = "docked" | "drawer"
  * from the left edge it is attached to.
  *
  * Drawer is the right-edge overlay, following OverlayToolsPanel, which is the
- * established vocabulary for a right-anchored surface on this screen. It stops
- * short of the foot rather than running to `bottom-3`, because these bodies are
- * genuinely 840 to 1100px tall and would otherwise run under whatever the
- * workspace layout puts at the bottom. --map-foot is what that reservation is
- * measured in; see index.css.
+ * established vocabulary for a right-anchored surface on this screen. It sits
+ * on the foot and grows upward, sharing a baseline with the map's own control
+ * column: these bodies are genuinely 840 to 1100px tall, so anchoring them at
+ * the top left them running off the bottom of the screen. --map-foot is what
+ * the reservation is measured in; see index.css.
  */
 const CONTAINER: Record<PanelPlacement, string> = {
   docked:
     "panel app-no-drag panel-scroll absolute left-3 top-3 bottom-3 z-[1000] " +
     "flex w-[19rem] flex-col gap-4 overflow-y-auto rounded-md p-4",
   drawer:
-    "panel app-no-drag panel-scroll absolute right-14 top-14 z-[1100] " +
+    "panel app-no-drag panel-scroll absolute right-14 z-[1100] " +
+    "bottom-[calc(var(--map-foot,0px)+0.625rem)] " +
     "flex max-h-[calc(100%-var(--map-foot,0px)-5rem)] w-[19rem] flex-col gap-4 " +
     "overflow-y-auto rounded-md p-4",
 }
@@ -66,7 +67,7 @@ const CONTAINER: Record<PanelPlacement, string> = {
  */
 const ENTER: Record<PanelPlacement, { x: number; y?: number }> = {
   docked: { x: -28 },
-  drawer: { x: 16, y: -8 },
+  drawer: { x: 16, y: 8 },
 }
 
 /**

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -892,27 +892,14 @@
 }
 
 /*
-  Docked, not floating: it sits flush on the bar's top edge and shares its
-  border, so the two read as one piece of chrome. The control is right-anchored,
-  so the left corner is the only exposed one and the only one rounded.
+  The tile credit is not here any more. It moved to the title bar, where it sits
+  beside the coordinate readout: it is a licensing obligation rather than map
+  chrome, and over imagery it had to be given its own plate to stay legible at
+  all. Leaflet's control is switched off at the MapContainer, so the rules that
+  dressed it are gone with it -- including the accent override, which existed
+  because the accent measured 3.80 against bright imagery, under the 4.5 that
+  WCAG 1.4.3 asks for. On the title bar's own plate that problem does not arise.
 */
-.leaflet-control-attribution {
-  margin: 0 !important;
-  padding: 0.25rem 0.5rem !important;
-  background: rgb(var(--p-ink) / 0.82) !important;
-  color: rgb(var(--p-muted)) !important;
-  border: 1px solid rgb(var(--p-line) / 0.28) !important;
-  border-right: none !important;
-  border-bottom: none !important;
-  border-top-left-radius: var(--radius-md) !important;
-  backdrop-filter: blur(18px) saturate(1.05);
-  -webkit-backdrop-filter: blur(18px) saturate(1.05);
-}
-/* The accent measures 3.80 on this plate over bright imagery, under the 4.5 of
-   WCAG 1.4.3. The quiet variant is the one that reads: 5.60. */
-.leaflet-control-attribution a {
-  color: rgb(var(--p-accent-quiet)) !important;
-}
 
 .panel-scroll::-webkit-scrollbar {
   width: 8px;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -878,9 +878,14 @@
   spans the full width, and tile attribution is a licensing requirement rather
   than chrome that may be covered.
 
-  --map-foot has to be the bar's exact height. Set generously it leaves a strip
-  of map between the two, and the attribution reads as a rectangle floating over
-  the imagery rather than as chrome docked to the bar below it.
+  --map-foot is the TOTAL reservation at the foot, not one bar's height. In the
+  docked layout that is the period track alone and the attribution sits flush on
+  its top edge. In the workspace layout it also covers the floating control bar
+  above the track, so the attribution clears both.
+
+  It has to be exact for whatever it is reserving. Set generously it leaves a
+  strip of map between the two, and the attribution reads as a rectangle
+  floating over the imagery rather than as chrome docked below it.
 */
 .leaflet-bottom {
   margin-bottom: var(--map-foot, 0px);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -878,14 +878,14 @@
   spans the full width, and tile attribution is a licensing requirement rather
   than chrome that may be covered.
 
-  --map-foot is the TOTAL reservation at the foot, not one bar's height. In the
-  docked layout that is the period track alone and the attribution sits flush on
-  its top edge. In the workspace layout it also covers the floating control bar
-  above the track, so the attribution clears both.
+  --map-foot is the period track's exact height, in both layouts. Set generously
+  it leaves a strip of map between the two, and the attribution reads as a
+  rectangle floating over the imagery rather than as chrome docked to the track
+  below it.
 
-  It has to be exact for whatever it is reserving. Set generously it leaves a
-  strip of map between the two, and the attribution reads as a rectangle
-  floating over the imagery rather than as chrome docked below it.
+  Only what spans the full width belongs in it. The workspace layout's control
+  bar is an island at the left, so it is not counted here: adding it lifted this
+  attribution at the opposite edge, where nothing was ever in its way.
 */
 .leaflet-bottom {
   margin-bottom: var(--map-foot, 0px);

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -51,6 +51,10 @@ interface AuthContextValue {
   settingsPage: SettingsPage | null
   /** Clears the above, so it steers one arrival rather than every one. */
   consumeSettingsPage: () => void
+  /** The screen settings was opened from, for naming the way out. */
+  settingsReturnTo: AppScreen
+  /** Return to that screen. */
+  leaveSettings: () => void
   navigate: (screen: AppScreen) => void
   login: (email: string, password: string) => Promise<void>
   register: (email: string, password: string, displayName: string) => Promise<void>
@@ -207,13 +211,36 @@ export function AuthProvider({
 
   const consumeSettingsPage = useCallback(() => setSettingsPage(null), [])
 
+  /**
+   * Where settings was opened from, so leaving it returns there.
+   *
+   * Only the screen is kept: the sub-tabs -- which map tool, which energy
+   * resource -- are held in App precisely so they survive a screen change, so
+   * returning to the screen restores the tab that was open on it.
+   *
+   * Settings is the one screen with no work of its own to go back to. Every
+   * other destination is a place the user chose; this one is a detour, and
+   * the only way out was to pick a destination from the column, which meant
+   * remembering what you had been doing and landing somewhere adjacent to it
+   * rather than back in it.
+   */
+  const [settingsReturnTo, setSettingsReturnTo] = useState<AppScreen>("map")
+
   const goProfile = useCallback(
     (page?: SettingsPage) => {
       setSettingsPage(page ?? null)
+      // Not from settings to settings: a second visit must not overwrite the
+      // work screen the first one recorded.
+      if (screen !== "profile" && screen !== "auth") setSettingsReturnTo(screen)
       setScreen(user ? "profile" : "auth")
     },
-    [user]
+    [user, screen]
   )
+
+  /** Leave settings for the screen it was opened from. */
+  const leaveSettings = useCallback(() => {
+    setScreen(settingsReturnTo)
+  }, [settingsReturnTo])
 
   const value = useMemo<AuthContextValue>(
     () => ({
@@ -230,6 +257,8 @@ export function AuthProvider({
       goEnergy: () => setScreen("energy"),
       settingsPage,
       consumeSettingsPage,
+      settingsReturnTo,
+      leaveSettings,
       navigate: setScreen,
       login,
       register,
@@ -250,6 +279,8 @@ export function AuthProvider({
       screen,
       settingsPage,
       consumeSettingsPage,
+      settingsReturnTo,
+      leaveSettings,
       goProfile,
       login,
       register,

--- a/frontend/src/lib/basemaps.ts
+++ b/frontend/src/lib/basemaps.ts
@@ -1,0 +1,82 @@
+/**
+ * What each basemap requires to be shown, and where it comes from.
+ *
+ * The credit is a licensing obligation, not chrome: Esri's terms require the
+ * source to be attributed, EOX's require the Copernicus notice, and OSM's ODbL
+ * requires attribution with a link where the medium allows one. So the parts
+ * are structured rather than an HTML string -- the title bar renders real
+ * anchors from this, which keeps the links the obligation asks for without any
+ * component having to inject markup it did not write.
+ *
+ * One table because the tile layers and the credit line are two readers of one
+ * fact. They were two strings, and the URL a layer fetched from could have
+ * drifted from the source the map claimed to be showing.
+ */
+
+export type BasemapKind = "esri" | "eox" | "osm"
+
+export interface CreditPart {
+  label: string
+  /** Present where the licence asks the attribution to be reachable. */
+  href?: string
+}
+
+export interface Basemap {
+  kind: BasemapKind
+  /** The name the layers control shows, and the one an event reports back. */
+  name: string
+  url: string
+  maxZoom: number
+  maxNativeZoom?: number
+  credit: readonly CreditPart[]
+}
+
+export const BASEMAPS: readonly Basemap[] = [
+  {
+    kind: "esri",
+    name: "Satellite (Esri)",
+    url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+    maxZoom: 19,
+    credit: [{ label: "Tiles © Esri" }],
+  },
+  {
+    kind: "eox",
+    name: "Sentinel-2 2025 (EOX)",
+    url: "https://tiles.maps.eox.at/wmts/1.0.0/s2cloudless-2025_3857/default/g/{z}/{y}/{x}.jpg",
+    maxNativeZoom: 14,
+    maxZoom: 19,
+    credit: [
+      { label: "© EOX", href: "https://cloudless.eox.at" },
+      {
+        label: "modified Copernicus Sentinel data 2025",
+        href: "https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi",
+      },
+    ],
+  },
+  {
+    kind: "osm",
+    name: "Map (OSM)",
+    url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+    maxZoom: 19,
+    credit: [
+      {
+        label: "© OpenStreetMap",
+        href: "https://www.openstreetmap.org/copyright",
+      },
+    ],
+  },
+]
+
+/** The library itself, credited on every basemap. */
+export const LEAFLET_CREDIT: CreditPart = {
+  label: "Leaflet",
+  href: "https://leafletjs.com",
+}
+
+export function basemapByName(name: string): Basemap {
+  return BASEMAPS.find((b) => b.name === name) ?? BASEMAPS[0]
+}
+
+export function basemapByKind(kind: BasemapKind): Basemap {
+  return BASEMAPS.find((b) => b.kind === kind) ?? BASEMAPS[0]
+}

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -1,0 +1,67 @@
+/**
+ * Where the application can go, named once.
+ *
+ * This is the same argument lib/mapTools.ts makes and the same failure it
+ * avoids: a label that exists twice is a label that can disagree with itself.
+ * The navigation column had the three destinations and their children written
+ * inline, and the dock layout's bar needed the same list to let a user leave
+ * the screen they are on -- a second copy that would have drifted the first
+ * time a resource or a tool was renamed.
+ *
+ * The table is the structure only. What a selection DOES stays with the caller,
+ * because navigating means setting a screen and a sub-tab that live in App, and
+ * a table that reached into those would be a table that owns them.
+ */
+import { ChartColumn, Map as MapIcon, Zap, type LucideIcon } from "lucide-react"
+import { MAP_TOOLS } from "@/lib/mapTools"
+import type { AppScreen } from "@/lib/auth"
+
+export interface NavItem {
+  id: string
+  label: string
+}
+
+export interface NavGroup {
+  /** The screen this group is, so the active one is found by comparison. */
+  id: Extract<AppScreen, "map" | "energy" | "analysis">
+  label: string
+  icon: LucideIcon
+  /**
+   * What is under it. Empty for a destination that is a single place: the
+   * project hub is one screen, not a set of them.
+   */
+  items: readonly NavItem[]
+}
+
+/**
+ * The two energy resources.
+ *
+ * Kept beside the map tools rather than in the energy screen: the navigation
+ * column names them, the dock bar names them, and the screen itself names them,
+ * which is three readers and was two copies.
+ */
+export const ENERGY_TABS: readonly NavItem[] = [
+  { id: "solar", label: "Solar" },
+  { id: "wind", label: "Wind" },
+]
+
+export const NAV_GROUPS: readonly NavGroup[] = [
+  { id: "map", label: "Map", icon: MapIcon, items: MAP_TOOLS },
+  {
+    // Zap rather than Sun or Wind: the screen holds both resources, and either
+    // weather glyph would name one of them and read as a forecast rather than
+    // as generation.
+    id: "energy",
+    label: "Energy",
+    icon: Zap,
+    items: ENERGY_TABS,
+  },
+  {
+    // The destination is the list of projects, their saved runs and their
+    // overlays. A single analysis is one thing opened from inside it.
+    id: "analysis",
+    label: "Project hub",
+    icon: ChartColumn,
+    items: [],
+  },
+]

--- a/frontend/src/lib/preferenceExtras.ts
+++ b/frontend/src/lib/preferenceExtras.ts
@@ -1,9 +1,15 @@
-import type { LeftDockTabsMode, Preferences } from "@/lib/types"
+import type { LayoutMode, LeftDockTabsMode, Preferences } from "@/lib/types"
 
-export type { LeftDockTabsMode }
+export type { LayoutMode, LeftDockTabsMode }
 
 export interface PreferenceExtras {
   left_dock_tabs?: LeftDockTabsMode
+  /**
+   * Which map layout the session was left in. Restored on start, because the
+   * two layouts are different enough that landing in the other one reads as
+   * the application having changed rather than as a setting having persisted.
+   */
+  layout_mode?: LayoutMode
   active_project_id?: string
   /** Last custom AOI display name (survives restart with active project / prefs). */
   aoi_label?: string
@@ -33,6 +39,20 @@ export function leftDockTabsModeFromPrefs(
 ): LeftDockTabsMode {
   const mode = parsePreferenceExtras(prefs?.extras_json).left_dock_tabs
   return mode === "always" ? "always" : "retracted_only"
+}
+
+/**
+ * The stored layout, defaulting by exception.
+ *
+ * Anything that is not the exact string falls to `docked`, so an absent key, a
+ * value written by a newer build, or a corrupted blob all resolve to the layout
+ * that has always worked rather than to a half-built one.
+ */
+export function layoutModeFromPrefs(
+  prefs: Preferences | null | undefined
+): LayoutMode {
+  const mode = parsePreferenceExtras(prefs?.extras_json).layout_mode
+  return mode === "workspace" ? "workspace" : "docked"
 }
 
 export function mergePreferenceExtras(

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -284,6 +284,15 @@ export interface Preferences {
 /** How vertical left-dock tabs behave (stored in extras_json.left_dock_tabs). */
 export type LeftDockTabsMode = "retracted_only" | "always"
 
+/**
+ * Which map layout is in use (stored in extras_json.layout_mode).
+ *
+ * `docked` names what it is -- the navigation column plus a panel docked to a
+ * column beside it -- rather than "default" or "classic", either of which
+ * becomes a lie the day the other one wins.
+ */
+export type LayoutMode = "docked" | "workspace"
+
 export interface InferenceRun {
   id: string
   user_id: string

--- a/frontend/src/pages/EnergyScreen.tsx
+++ b/frontend/src/pages/EnergyScreen.tsx
@@ -27,6 +27,7 @@
  */
 import { AnimatePresence } from "motion/react"
 import type { LayoutMode } from "@/lib/types"
+import type { BasemapKind } from "@/lib/basemaps"
 import { WorkspaceBar } from "@/components/WorkspaceBar"
 import { PanelShell, type PanelPlacement } from "@/components/ui/PanelShell"
 import { statusPanelInset } from "@/components/analysisPrimitives"
@@ -178,6 +179,8 @@ export interface EnergyScreenProps {
   // where the user is looking.
   initialView?: { lat: number; lon: number; zoom: number } | null
   onViewChange: (v: { lat: number; lon: number; zoom: number }) => void
+  /** Which basemap is showing, for the credit in the title bar. */
+  onCreditChange?: (c: { kind: BasemapKind; date: string | null }) => void
   flyTo: { lat: number; lon: number; key: number } | null
 
   /**
@@ -425,6 +428,7 @@ export function EnergyScreen(props: EnergyScreenProps) {
         onAoiContourSchemeChange={props.onAoiContourSchemeChange}
         onClearArea={props.onClearArea}
         onViewChange={props.onViewChange}
+        onCreditChange={props.onCreditChange}
     />
   )
 

--- a/frontend/src/pages/EnergyScreen.tsx
+++ b/frontend/src/pages/EnergyScreen.tsx
@@ -25,7 +25,23 @@
  * screen takes it whole; the panel it replaces declared 81 props for state its
  * host did not use.
  */
-import { AnimatePresence, motion } from "motion/react"
+import { AnimatePresence } from "motion/react"
+import { Zap } from "lucide-react"
+import type { LayoutMode } from "@/lib/types"
+import { WorkspaceBar } from "@/components/WorkspaceBar"
+import { PanelShell, type PanelPlacement } from "@/components/ui/PanelShell"
+
+/**
+ * The two resources, named as the navigation column names them.
+ *
+ * Written here rather than imported because the column builds its own copy
+ * inline; if a third resource is ever added, this is the second place it has
+ * to appear, and that is a reason to lift both into lib/ at that point.
+ */
+const ENERGY_TABS = [
+  { id: "solar", label: "Solar" },
+  { id: "wind", label: "Wind" },
+] as const
 import {
   useCallback,
   useMemo,
@@ -132,6 +148,8 @@ export interface EnergyScreenProps {
   /** Starts a run for one product. The caller dispatches its result. */
   onRunSolar: (product: SolarProductId) => void
   onRunWind: () => void
+  /** Which layout draws this screen. See lib/types LayoutMode. */
+  layoutMode?: LayoutMode
   /**
    * Opens the analysis screen, where the long blocks live -- the loss
    * waterfall, the generation profile, the tracking comparison. They render
@@ -257,8 +275,47 @@ export function EnergyScreen(props: EnergyScreenProps) {
     [solar.results, staleMarks]
   )
 
+  const workspace = props.layoutMode === "workspace"
+  const [configOpen, setConfigOpen] = useState(false)
+  /** The island's measured width, so the record bar can retract past it. */
+  const [barWidthPx, setBarWidthPx] = useState(0)
   const solarBusy = solar.run.active !== null
   const windBusy = wind.run.active
+
+  /**
+   * The run action for whichever resource is in view.
+   *
+   * Gathered here for the dock layout's single button, the way the map screen
+   * gathers its three. The two tabs differ in more than the handler: solar runs
+   * whichever of its four products is selected, and names the run after that
+   * product, while wind has one.
+   *
+   * The label is the verb alone. The panels can afford "Screen the wind
+   * resource, returns figures" down a 19rem column; on a bar beside a track it
+   * would push the island past the width the track has left.
+   */
+  const run =
+    tab === "wind"
+      ? {
+          running: !!windBusy,
+          progress: wind.run.progress,
+          progressMsg: wind.run.message,
+          label: windBusy ? "Screening\u2026" : "Screen",
+          canRun: props.hasArea,
+          onRun: props.onRunWind,
+        }
+      : {
+          running: solar.run.active === selected,
+          progress: solar.run.progress,
+          progressMsg: solar.run.message,
+          label:
+            solar.run.active === selected
+              ? `${product.runningLabel}\u2026`
+              : "Run",
+          // One run at a time in the sidecar, so any solar run blocks the rest.
+          canRun: props.hasArea && !solarBusy,
+          onRun: () => props.onRunSolar(selected),
+        }
 
   // Read once per mount rather than per render: a value taken from the clock
   // inside the render body would make the axis a function of when React
@@ -498,22 +555,15 @@ export function EnergyScreen(props: EnergyScreenProps) {
    * same object two shapes and left the map letterboxed with dead space under
    * it -- the map is where the AOI is drawn, so it is not a thumbnail.
    */
-  const setupColumn = (
-    <motion.div
+  const setupColumn = (placement: PanelPlacement) => (
+    <PanelShell
       key={tab}
-      className="panel app-no-drag panel-scroll absolute bottom-3 left-3 top-3 z-[1000] flex w-[19rem] flex-col gap-4 overflow-y-auto rounded-md p-4"
-      initial={{ opacity: 0, x: -28 }}
-      animate={{ opacity: 1, x: 0 }}
-      exit={{ opacity: 0, x: -28 }}
-      transition={{ type: "spring", stiffness: 360, damping: 34 }}
+      placement={placement}
+      title={tab === "solar" ? "Solar resource" : "Wind screening"}
+      onCollapse={placement === "drawer" ? () => setConfigOpen(false) : undefined}
     >
-      <div className="flex items-baseline justify-between gap-2">
-        <h1 className="text-heading font-semibold">
-          {tab === "solar" ? "Solar resource" : "Wind screening"}
-        </h1>
-      </div>
       {tab === "solar" ? solarSetup : windSetup}
-    </motion.div>
+    </PanelShell>
   )
 
   return (
@@ -537,17 +587,61 @@ export function EnergyScreen(props: EnergyScreenProps) {
 
       <SearchBar onSelectLocation={props.onLocationSelect} />
 
+      {/*
+        The setup column, or the drawer the dock layout opens from its bar. The
+        same block either way: only the container it is given changes.
+      */}
       <AnimatePresence mode="wait" initial={false}>
-        {setupColumn}
+        {workspace ? null : setupColumn("docked")}
+      </AnimatePresence>
+      {/*
+        The presence stays mounted and its child is what comes and goes. Gating
+        the AnimatePresence itself removed the exit animation: closing the
+        drawer unmounted the thing that was supposed to be animating it out.
+      */}
+      <AnimatePresence mode="wait" initial={false}>
+        {workspace && configOpen ? setupColumn("drawer") : null}
       </AnimatePresence>
 
-      {/* The setup column is always open here, so the offset is constant --
-          the same 0.75rem the column is padded by, kept between the two. */}
+      <AnimatePresence>
+        {workspace && (
+          <WorkspaceBar
+            key="energy-bar"
+            icon={Zap}
+            groupLabel="Energy"
+            items={ENERGY_TABS}
+            activeId={tab}
+            onSelect={(id) => setTab(id as EnergyTab)}
+            running={run.running}
+            progress={run.progress}
+            progressMsg={run.progressMsg}
+            runLabel={run.label}
+            canRun={run.canRun}
+            onRun={run.onRun}
+            onWidthChange={setBarWidthPx}
+            configOpen={configOpen}
+            onConfigToggle={() => setConfigOpen((o) => !o)}
+          />
+        )}
+      </AnimatePresence>
+
+      {/*
+        Retracted past whatever holds the foot's left end: the setup column at
+        its fixed 19rem plus its two gutters, or the dock layout's island at
+        whatever width it measured, plus the gap between the two segments.
+      */}
       <RecordWindowBar
         bands={recordBands}
         endYear={endYear}
         disabled={tab === "wind" ? windBusy : solarBusy}
-        leftOffsetClass="left-[20.5rem] rounded-tl-md"
+        flushLeft={workspace}
+        leftOffset={
+          workspace
+            ? barWidthPx
+              ? `calc(${barWidthPx}px + 0.75rem)`
+              : undefined
+            : "20.5rem"
+        }
         onHeightChange={setFootPx}
       />
 

--- a/frontend/src/pages/EnergyScreen.tsx
+++ b/frontend/src/pages/EnergyScreen.tsx
@@ -26,22 +26,10 @@
  * host did not use.
  */
 import { AnimatePresence } from "motion/react"
-import { Zap } from "lucide-react"
 import type { LayoutMode } from "@/lib/types"
 import { WorkspaceBar } from "@/components/WorkspaceBar"
 import { PanelShell, type PanelPlacement } from "@/components/ui/PanelShell"
 
-/**
- * The two resources, named as the navigation column names them.
- *
- * Written here rather than imported because the column builds its own copy
- * inline; if a third resource is ever added, this is the second place it has
- * to appear, and that is a reason to lift both into lib/ at that point.
- */
-const ENERGY_TABS = [
-  { id: "solar", label: "Solar" },
-  { id: "wind", label: "Wind" },
-] as const
 import {
   useCallback,
   useMemo,
@@ -150,6 +138,8 @@ export interface EnergyScreenProps {
   onRunWind: () => void
   /** Which layout draws this screen. See lib/types LayoutMode. */
   layoutMode?: LayoutMode
+  /** Go to another destination, for the dock layout's bar. */
+  onNavigate: (groupId: string, itemId?: string) => void
   /**
    * Opens the analysis screen, where the long blocks live -- the loss
    * waterfall, the generation profile, the tracking comparison. They render
@@ -607,11 +597,9 @@ export function EnergyScreen(props: EnergyScreenProps) {
         {workspace && (
           <WorkspaceBar
             key="energy-bar"
-            icon={Zap}
-            groupLabel="Energy"
-            items={ENERGY_TABS}
+            groupId="energy"
             activeId={tab}
-            onSelect={(id) => setTab(id as EnergyTab)}
+            onNavigate={props.onNavigate}
             running={run.running}
             progress={run.progress}
             progressMsg={run.progressMsg}

--- a/frontend/src/pages/EnergyScreen.tsx
+++ b/frontend/src/pages/EnergyScreen.tsx
@@ -29,6 +29,7 @@ import { AnimatePresence } from "motion/react"
 import type { LayoutMode } from "@/lib/types"
 import { WorkspaceBar } from "@/components/WorkspaceBar"
 import { PanelShell, type PanelPlacement } from "@/components/ui/PanelShell"
+import { statusPanelInset } from "@/components/analysisPrimitives"
 
 import {
   useCallback,
@@ -636,6 +637,7 @@ export function EnergyScreen(props: EnergyScreenProps) {
       <AnimatePresence initial={false}>
         {hasResult && (
           <EnergyStatusPanel
+            leftOffsetClass={statusPanelInset(workspace)}
             key={`${tab}-${selected}`}
             tab={tab}
             selected={selected}

--- a/frontend/src/pages/MapScreen.tsx
+++ b/frontend/src/pages/MapScreen.tsx
@@ -144,10 +144,6 @@ export function MapScreen(props: MapScreenProps) {
   // raster on the map with the classification panel open beside it.
   const { leftPanel, onLeftPanelChange } = props
   const [overlayToolsOpen, setOverlayToolsOpen] = useState(false)
-  // The panel sits against the navigation column now that the tool rail is
-  // gone: the column lists the same three tools and is always visible, so a
-  // floating strip repeating them was a second answer to one question.
-  const panelOffsetClass = "left-3"
   const setLeftPanel = onLeftPanelChange
 
   // The three status panels share one slot at the bottom of the map, so only
@@ -287,7 +283,6 @@ export function MapScreen(props: MapScreenProps) {
         {leftPanel === "classify" ? (
           <ControlPanel
             key="classify"
-            panelOffsetClass={panelOffsetClass}
             activeExample={props.activeExample}
             customPolygon={props.customPolygon}
             hasArea={props.hasArea}
@@ -318,7 +313,6 @@ export function MapScreen(props: MapScreenProps) {
         ) : leftPanel === "water" ? (
           <WaterPanel
             key="water"
-            panelOffsetClass={panelOffsetClass}
             hasArea={props.hasArea}
             start={props.start}
             end={props.end}
@@ -341,7 +335,6 @@ export function MapScreen(props: MapScreenProps) {
         ) : leftPanel === "compose" ? (
           <CompositionPanel
             key="compose"
-            panelOffsetClass={panelOffsetClass}
             hasArea={props.hasArea}
             start={props.start}
             end={props.end}

--- a/frontend/src/pages/MapScreen.tsx
+++ b/frontend/src/pages/MapScreen.tsx
@@ -23,6 +23,7 @@ import { WaterPanel } from "@/components/WaterPanel"
 import { WaterStatusPanel } from "@/components/WaterStatusPanel"
 import type { MapToolId } from "@/lib/mapTools"
 import type { LayoutMode } from "@/lib/types"
+import type { BasemapKind } from "@/lib/basemaps"
 import { WorkspaceBar } from "@/components/WorkspaceBar"
 import type { PanelPlacement } from "@/components/ui/PanelShell"
 import { ResultsPanel } from "@/components/ResultsPanel"
@@ -92,6 +93,8 @@ export interface MapScreenProps {
   composeStretchHigh: number
   composeOpacity: number
   onViewChange: (v: { lat: number; lon: number; zoom: number }) => void
+  /** Which basemap is showing, for the credit in the title bar. */
+  onCreditChange?: (c: { kind: BasemapKind; date: string | null }) => void
   onPolygonDrawn: (geom: GeoJSONGeometry | null) => void
   onLocationSelect: (lat: number, lon: number) => void
   onClearArea: () => void
@@ -403,6 +406,7 @@ export function MapScreen(props: MapScreenProps) {
         onAoiContourSchemeChange={props.onAoiContourSchemeChange}
         onClearArea={props.onClearArea}
         onViewChange={props.onViewChange}
+        onCreditChange={props.onCreditChange}
       />
 
       <SearchBar onSelectLocation={props.onLocationSelect} />

--- a/frontend/src/pages/MapScreen.tsx
+++ b/frontend/src/pages/MapScreen.tsx
@@ -407,6 +407,16 @@ export function MapScreen(props: MapScreenProps) {
         onClearArea={props.onClearArea}
         onViewChange={props.onViewChange}
         onCreditChange={props.onCreditChange}
+        // Handed to Leaflet rather than positioned here: it joins the zoom and
+        // draw stack at the bottom-right, under them.
+        bottomRightSlot={
+          <OverlayToolsButton
+            active={rightDrawer === "overlays"}
+            onClick={() =>
+              setRightDrawer((d) => (d === "overlays" ? null : "overlays"))
+            }
+          />
+        }
       />
 
       <SearchBar onSelectLocation={props.onLocationSelect} />
@@ -461,12 +471,6 @@ export function MapScreen(props: MapScreenProps) {
         )}
       </AnimatePresence>
 
-      <OverlayToolsButton
-        active={rightDrawer === "overlays"}
-        onClick={() =>
-          setRightDrawer((d) => (d === "overlays" ? null : "overlays"))
-        }
-      />
       <OverlayToolsPanel
         open={rightDrawer === "overlays"}
         onClose={() => setRightDrawer(null)}

--- a/frontend/src/pages/MapScreen.tsx
+++ b/frontend/src/pages/MapScreen.tsx
@@ -22,6 +22,8 @@ import { CompositionPanel } from "@/components/CompositionPanel"
 import { WaterPanel } from "@/components/WaterPanel"
 import { WaterStatusPanel } from "@/components/WaterStatusPanel"
 import type { MapToolId } from "@/lib/mapTools"
+import type { LayoutMode } from "@/lib/types"
+import { WorkspaceBar } from "@/components/WorkspaceBar"
 import { ResultsPanel } from "@/components/ResultsPanel"
 import { CompositionStatusPanel } from "@/components/CompositionStatusPanel"
 import { DataCubeModal } from "@/components/DataCubeModal"
@@ -37,6 +39,8 @@ export interface MapScreenProps {
   /** Open tool tab, owned by the caller so it survives this screen unmounting. */
   leftPanel: MapToolId | null
   onLeftPanelChange: (id: MapToolId | null) => void
+  /** Which layout draws this screen. See lib/types LayoutMode. */
+  layoutMode?: LayoutMode
   areas: Area[]
   activeExample: string
   customPolygon: GeoJSONGeometry | null
@@ -144,6 +148,7 @@ export function MapScreen(props: MapScreenProps) {
   // raster on the map with the classification panel open beside it.
   const { leftPanel, onLeftPanelChange } = props
   const [overlayToolsOpen, setOverlayToolsOpen] = useState(false)
+  const workspace = props.layoutMode === "workspace"
   const setLeftPanel = onLeftPanelChange
 
   // The three status panels share one slot at the bottom of the map, so only
@@ -169,10 +174,64 @@ export function MapScreen(props: MapScreenProps) {
     props.composeScenes.find((s) => s.id === props.selectedSceneId)?.date ??
     null
 
+  /**
+   * The run action for whichever product is in view.
+   *
+   * The three panels each own a run button with its own label, its own progress
+   * state and its own enabling rule, and the rules genuinely differ:
+   * classification additionally requires both dates, and a composition
+   * additionally requires a selected scene. The workspace bar carries one
+   * button, so the differences are gathered here rather than being flattened
+   * into a single condition that would be wrong for two of the three.
+   *
+   * Composition is the one this fixes rather than moves: its Apply button sits
+   * inside a section called "Display", under the stretch inputs, where a reader
+   * looking for the action does not pass.
+   */
+  const run =
+    leftPanel === "water"
+      ? {
+          running: props.waterRunning,
+          progress: props.waterProgress,
+          progressMsg: props.waterProgressMsg,
+          label: props.waterRunning ? "Mapping" : "Map water",
+          canRun: props.hasArea,
+          onRun: props.onRunWater,
+        }
+      : leftPanel === "compose"
+        ? {
+            running: props.composeRunning,
+            progress: props.composeProgress,
+            progressMsg: props.composeProgressMsg,
+            label: props.composeRunning ? "Applying" : "Apply",
+            canRun: props.hasArea && !!props.selectedSceneId,
+            onRun: props.onApplyComposition,
+          }
+        : {
+            running: props.running,
+            progress: props.progress,
+            progressMsg: props.progressMsg,
+            label: props.running ? "Classifying" : "Classify",
+            canRun: props.hasArea && !!props.start && !!props.end,
+            onRun: props.onRun,
+          }
+
   return (
     <div
       className="relative h-full min-h-0 w-full"
-      style={{ "--map-foot": "3.0625rem" } as React.CSSProperties}
+      /*
+        What the foot of the map has spoken for, which every surface anchored
+        to the bottom measures from. The docked layout reserves the period
+        timeline alone; the workspace layout adds the floating bar above it --
+        its 3rem plus the 1rem it sits off the timeline.
+      */
+      style={
+        {
+          "--map-foot": workspace
+            ? "calc(3.0625rem + 4rem)"
+            : "3.0625rem",
+        } as React.CSSProperties
+      }
     >
       <MapView
         initialView={props.initialView}
@@ -224,9 +283,27 @@ export function MapScreen(props: MapScreenProps) {
         // Clears the open tool column, matching the offset the status panels
         // already use so the two agree on where the map's free width begins.
         leftOffsetClass={
-          leftPanel ? "left-[20.5rem] rounded-tl-md" : "left-0"
+          !workspace && leftPanel ? "left-[20.5rem] rounded-tl-md" : "left-0"
         }
       />
+
+      <AnimatePresence>
+        {workspace && (
+          <WorkspaceBar
+            key="workspace-bar"
+            tool={leftPanel}
+            onToolChange={setLeftPanel}
+            running={run.running}
+            progress={run.progress}
+            progressMsg={run.progressMsg}
+            runLabel={run.label}
+            canRun={run.canRun}
+            onRun={run.onRun}
+            configOpen={false}
+            onConfigToggle={() => {}}
+          />
+        )}
+      </AnimatePresence>
 
       <OverlayToolsButton
         active={overlayToolsOpen}
@@ -279,8 +356,13 @@ export function MapScreen(props: MapScreenProps) {
         }
       />
 
+      {/*
+        The docked column. The workspace layout has no column to dock to -- its
+        parameters open in a drawer from the bar instead -- so the switch is
+        withheld there rather than the panels being taught about the layout.
+      */}
       <AnimatePresence mode="wait" initial={false}>
-        {leftPanel === "classify" ? (
+        {workspace ? null : leftPanel === "classify" ? (
           <ControlPanel
             key="classify"
             activeExample={props.activeExample}

--- a/frontend/src/pages/MapScreen.tsx
+++ b/frontend/src/pages/MapScreen.tsx
@@ -29,6 +29,7 @@ import { ResultsPanel } from "@/components/ResultsPanel"
 import { CompositionStatusPanel } from "@/components/CompositionStatusPanel"
 import { DataCubeModal } from "@/components/DataCubeModal"
 import { ConfidenceLegend } from "@/components/ConfidenceLegend"
+import { statusPanelInset } from "@/components/analysisPrimitives"
 import {
   OverlayToolsButton,
   OverlayToolsPanel,
@@ -525,12 +526,14 @@ export function MapScreen(props: MapScreenProps) {
       <AnimatePresence mode="wait" initial={false}>
         {showWaterStatus ? (
           <WaterStatusPanel
+            leftOffsetClass={statusPanelInset(workspace)}
             key="water-status"
             water={props.water ?? null}
             onClear={props.onClearWater}
           />
         ) : showCompositionStatus ? (
           <CompositionStatusPanel
+            leftOffsetClass={statusPanelInset(workspace)}
             key="composition-status"
             composition={props.composition}
             sceneDate={selectedSceneDate}
@@ -539,6 +542,7 @@ export function MapScreen(props: MapScreenProps) {
           />
         ) : showPredictionStatus ? (
           <ResultsPanel
+            leftOffsetClass={statusPanelInset(workspace)}
             key="prediction-status"
             result={props.result!}
             onClose={props.onCloseResult}

--- a/frontend/src/pages/MapScreen.tsx
+++ b/frontend/src/pages/MapScreen.tsx
@@ -161,6 +161,14 @@ export function MapScreen(props: MapScreenProps) {
   const [rightDrawer, setRightDrawer] = useState<"config" | "overlays" | null>(
     null
   )
+  /**
+   * The workspace island's measured width, so the period track can retract past
+   * it the way it already retracts past the docked column.
+   *
+   * Measured rather than declared: the island sizes to its contents, and the
+   * run button's label changes with the product and with whether it is running.
+   */
+  const [barWidthPx, setBarWidthPx] = useState(0)
   const workspace = props.layoutMode === "workspace"
   const setLeftPanel = onLeftPanelChange
 
@@ -348,18 +356,16 @@ export function MapScreen(props: MapScreenProps) {
     <div
       className="relative h-full min-h-0 w-full"
       /*
-        What the foot of the map has spoken for, which every surface anchored
-        to the bottom measures from. The docked layout reserves the period
-        timeline alone; the workspace layout adds the floating bar above it --
-        its 3rem plus the 1rem it sits off the timeline.
+        The height of the period track, which is the only thing that spans the
+        foot from edge to edge. Surfaces anchored to the bottom clear it by
+        measuring from here.
+
+        The workspace bar does NOT enter this: it is an island at the left, and
+        raising the reservation to clear it lifted the tile attribution at the
+        opposite edge by four rem it had no reason to move, tearing it off the
+        track it is meant to sit flush against.
       */
-      style={
-        {
-          "--map-foot": workspace
-            ? "calc(3.0625rem + 4rem)"
-            : "3.0625rem",
-        } as React.CSSProperties
-      }
+      style={{ "--map-foot": "3.0625rem" } as React.CSSProperties}
     >
       <MapView
         initialView={props.initialView}
@@ -408,10 +414,21 @@ export function MapScreen(props: MapScreenProps) {
         onListScenes={props.onListComposeScenes}
         onOpenListing={props.onViewDataCube}
         disabled={props.running || props.composeRunning}
-        // Clears the open tool column, matching the offset the status panels
-        // already use so the two agree on where the map's free width begins.
-        leftOffsetClass={
-          !workspace && leftPanel ? "left-[20.5rem] rounded-tl-md" : "left-0"
+        /*
+          Retracted past whatever occupies the foot's left end: the docked
+          column at its fixed 19rem plus its two 0.75rem gutters, or the
+          workspace island, which is flush into the corner and so needs only
+          the gap between the two segments added to its measured width.
+        */
+        flushLeft={workspace}
+        leftOffset={
+          workspace
+            ? barWidthPx
+              ? `calc(${barWidthPx}px + 0.75rem)`
+              : undefined
+            : leftPanel
+              ? "20.5rem"
+              : undefined
         }
       />
 
@@ -427,6 +444,7 @@ export function MapScreen(props: MapScreenProps) {
             runLabel={run.label}
             canRun={run.canRun}
             onRun={run.onRun}
+            onWidthChange={setBarWidthPx}
             configOpen={rightDrawer === "config"}
             onConfigToggle={() =>
               setRightDrawer((d) => (d === "config" ? null : "config"))

--- a/frontend/src/pages/MapScreen.tsx
+++ b/frontend/src/pages/MapScreen.tsx
@@ -24,6 +24,7 @@ import { WaterStatusPanel } from "@/components/WaterStatusPanel"
 import type { MapToolId } from "@/lib/mapTools"
 import type { LayoutMode } from "@/lib/types"
 import { WorkspaceBar } from "@/components/WorkspaceBar"
+import type { PanelPlacement } from "@/components/ui/PanelShell"
 import { ResultsPanel } from "@/components/ResultsPanel"
 import { CompositionStatusPanel } from "@/components/CompositionStatusPanel"
 import { DataCubeModal } from "@/components/DataCubeModal"
@@ -147,7 +148,19 @@ export function MapScreen(props: MapScreenProps) {
   // every return -- including a return from a water run, which left a water
   // raster on the map with the classification panel open beside it.
   const { leftPanel, onLeftPanelChange } = props
-  const [overlayToolsOpen, setOverlayToolsOpen] = useState(false)
+  /**
+   * Which right-edge drawer is open, at most one.
+   *
+   * The two occupy the same slot -- same anchor, same width, same layer -- and
+   * a user reading run parameters is not simultaneously adjusting overlay
+   * opacity, so they exclude each other rather than being stacked or offset.
+   * A boolean per drawer would let both open onto the same rectangle.
+   *
+   * The docked layout never sets "config", so its behaviour is unchanged.
+   */
+  const [rightDrawer, setRightDrawer] = useState<"config" | "overlays" | null>(
+    null
+  )
   const workspace = props.layoutMode === "workspace"
   const setLeftPanel = onLeftPanelChange
 
@@ -215,6 +228,121 @@ export function MapScreen(props: MapScreenProps) {
             canRun: props.hasArea && !!props.start && !!props.end,
             onRun: props.onRun,
           }
+
+  /**
+   * The three products' controls, in whichever container the layout gives
+   * them. One switch, called from two places: the docked column below, and
+   * the workspace layout's right drawer. Writing it twice would let the two
+   * layouts drift in which props each panel receives.
+   */
+  const renderPanel = (placement: PanelPlacement) => {
+    /*
+      Dismissing means different things in the two containers. Closing the
+      docked column clears the open tool, because the column IS the tool
+      selection -- there is nothing left selected once it is gone. In the
+      workspace layout the bar keeps the selection, so closing the drawer must
+      close only the drawer; clearing the tool there would empty the segmented
+      control and leave the run button acting on nothing.
+    */
+    const dismiss =
+      placement === "drawer"
+        ? () => setRightDrawer(null)
+        : () => setLeftPanel(null)
+    return (
+      <AnimatePresence mode="wait" initial={false}>
+        {leftPanel === "classify" ? (
+          <ControlPanel
+            key="classify"
+            placement={placement}
+            activeExample={props.activeExample}
+            customPolygon={props.customPolygon}
+            hasArea={props.hasArea}
+            onClearArea={props.onClearArea}
+            onImportPolygon={props.onImportPolygon}
+            start={props.start}
+            end={props.end}
+            onStartChange={props.onStartChange}
+            onEndChange={props.onEndChange}
+            maxCloud={props.maxCloud}
+            onMaxCloudChange={props.onMaxCloudChange}
+            monthlyBest={props.monthlyBest}
+            onMonthlyBestChange={props.onMonthlyBestChange}
+            mode={props.mode}
+            onModeChange={props.onModeChange}
+            modelKind={props.modelKind}
+            onModelKindChange={props.onModelKindChange}
+            prithviMode={props.prithviMode}
+            onPrithviModeChange={props.onPrithviModeChange}
+            running={props.running}
+            progress={props.progress}
+            progressMsg={props.progressMsg}
+            onRun={props.onRun}
+            onAnalyzeLULC={props.onAnalyzeLULC}
+            lulcRunning={props.lulcRunning}
+            onCollapse={dismiss}
+          />
+        ) : leftPanel === "water" ? (
+          <WaterPanel
+            key="water"
+            placement={placement}
+            hasArea={props.hasArea}
+            start={props.start}
+            end={props.end}
+            onStartChange={props.onStartChange}
+            onEndChange={props.onEndChange}
+            maxCloud={props.maxCloud}
+            onMaxCloudChange={props.onMaxCloudChange}
+            monthlyBest={props.monthlyBest}
+            onMonthlyBestChange={props.onMonthlyBestChange}
+            index={props.waterIndex}
+            onIndexChange={props.onWaterIndexChange}
+            running={props.waterRunning}
+            progress={props.waterProgress}
+            progressMsg={props.waterProgressMsg}
+            hasResult={!!props.water}
+            onRun={props.onRunWater}
+            onClear={props.onClearWater}
+            onCollapse={dismiss}
+          />
+        ) : leftPanel === "compose" ? (
+          <CompositionPanel
+            key="compose"
+            placement={placement}
+            hasArea={props.hasArea}
+            start={props.start}
+            end={props.end}
+            onStartChange={props.onStartChange}
+            onEndChange={props.onEndChange}
+            maxCloud={props.maxCloud}
+            onMaxCloudChange={props.onMaxCloudChange}
+            monthlyBest={props.monthlyBest}
+            onMonthlyBestChange={props.onMonthlyBestChange}
+            scenes={props.composeScenes}
+            scenesLoading={props.composeScenesLoading}
+            scenesError={props.composeScenesError}
+            selectedSceneId={props.selectedSceneId}
+            onSelectScene={props.onSelectScene}
+            kind={props.composeKind}
+            onKindChange={props.onComposeKindChange}
+            bands={props.composeBands}
+            onBandsChange={props.onComposeBandsChange}
+            index={props.composeIndex}
+            onIndexChange={props.onComposeIndexChange}
+            stretchLow={props.composeStretchLow}
+            stretchHigh={props.composeStretchHigh}
+            onStretchChange={props.onComposeStretchChange}
+            running={props.composeRunning}
+            progress={props.composeProgress}
+            progressMsg={props.composeProgressMsg}
+            hasOverlay={!!props.composition}
+            onApply={props.onApplyComposition}
+            onClear={props.onClearComposition}
+            onCollapse={dismiss}
+          />
+        ) : null}
+      </AnimatePresence>
+    )
+  }
 
   return (
     <div
@@ -299,19 +427,23 @@ export function MapScreen(props: MapScreenProps) {
             runLabel={run.label}
             canRun={run.canRun}
             onRun={run.onRun}
-            configOpen={false}
-            onConfigToggle={() => {}}
+            configOpen={rightDrawer === "config"}
+            onConfigToggle={() =>
+              setRightDrawer((d) => (d === "config" ? null : "config"))
+            }
           />
         )}
       </AnimatePresence>
 
       <OverlayToolsButton
-        active={overlayToolsOpen}
-        onClick={() => setOverlayToolsOpen((o) => !o)}
+        active={rightDrawer === "overlays"}
+        onClick={() =>
+          setRightDrawer((d) => (d === "overlays" ? null : "overlays"))
+        }
       />
       <OverlayToolsPanel
-        open={overlayToolsOpen}
-        onClose={() => setOverlayToolsOpen(false)}
+        open={rightDrawer === "overlays"}
+        onClose={() => setRightDrawer(null)}
         result={props.result}
         composition={props.composition}
         compositionGallery={props.compositionGallery ?? []}
@@ -358,98 +490,11 @@ export function MapScreen(props: MapScreenProps) {
 
       {/*
         The docked column. The workspace layout has no column to dock to -- its
-        parameters open in a drawer from the bar instead -- so the switch is
-        withheld there rather than the panels being taught about the layout.
+        parameters open in a drawer from the bar instead, which is the same
+        switch in the other container.
       */}
-      <AnimatePresence mode="wait" initial={false}>
-        {workspace ? null : leftPanel === "classify" ? (
-          <ControlPanel
-            key="classify"
-            activeExample={props.activeExample}
-            customPolygon={props.customPolygon}
-            hasArea={props.hasArea}
-            onClearArea={props.onClearArea}
-            onImportPolygon={props.onImportPolygon}
-            start={props.start}
-            end={props.end}
-            onStartChange={props.onStartChange}
-            onEndChange={props.onEndChange}
-            maxCloud={props.maxCloud}
-            onMaxCloudChange={props.onMaxCloudChange}
-            monthlyBest={props.monthlyBest}
-            onMonthlyBestChange={props.onMonthlyBestChange}
-            mode={props.mode}
-            onModeChange={props.onModeChange}
-            modelKind={props.modelKind}
-            onModelKindChange={props.onModelKindChange}
-            prithviMode={props.prithviMode}
-            onPrithviModeChange={props.onPrithviModeChange}
-            running={props.running}
-            progress={props.progress}
-            progressMsg={props.progressMsg}
-            onRun={props.onRun}
-            onAnalyzeLULC={props.onAnalyzeLULC}
-            lulcRunning={props.lulcRunning}
-            onCollapse={() => setLeftPanel(null)}
-          />
-        ) : leftPanel === "water" ? (
-          <WaterPanel
-            key="water"
-            hasArea={props.hasArea}
-            start={props.start}
-            end={props.end}
-            onStartChange={props.onStartChange}
-            onEndChange={props.onEndChange}
-            maxCloud={props.maxCloud}
-            onMaxCloudChange={props.onMaxCloudChange}
-            monthlyBest={props.monthlyBest}
-            onMonthlyBestChange={props.onMonthlyBestChange}
-            index={props.waterIndex}
-            onIndexChange={props.onWaterIndexChange}
-            running={props.waterRunning}
-            progress={props.waterProgress}
-            progressMsg={props.waterProgressMsg}
-            hasResult={!!props.water}
-            onRun={props.onRunWater}
-            onClear={props.onClearWater}
-            onCollapse={() => setLeftPanel(null)}
-          />
-        ) : leftPanel === "compose" ? (
-          <CompositionPanel
-            key="compose"
-            hasArea={props.hasArea}
-            start={props.start}
-            end={props.end}
-            onStartChange={props.onStartChange}
-            onEndChange={props.onEndChange}
-            maxCloud={props.maxCloud}
-            onMaxCloudChange={props.onMaxCloudChange}
-            monthlyBest={props.monthlyBest}
-            onMonthlyBestChange={props.onMonthlyBestChange}
-            scenes={props.composeScenes}
-            scenesLoading={props.composeScenesLoading}
-            scenesError={props.composeScenesError}
-            selectedSceneId={props.selectedSceneId}
-            onSelectScene={props.onSelectScene}
-            kind={props.composeKind}
-            onKindChange={props.onComposeKindChange}
-            bands={props.composeBands}
-            onBandsChange={props.onComposeBandsChange}
-            index={props.composeIndex}
-            onIndexChange={props.onComposeIndexChange}
-            stretchLow={props.composeStretchLow}
-            stretchHigh={props.composeStretchHigh}
-            onStretchChange={props.onComposeStretchChange}
-            running={props.composeRunning}
-            progress={props.composeProgress}
-            progressMsg={props.composeProgressMsg}
-            hasOverlay={!!props.composition}
-            onApply={props.onApplyComposition}
-            onClear={props.onClearComposition}
-            onCollapse={() => setLeftPanel(null)}
-          />
-        ) : null}
-      </AnimatePresence>
+      {workspace ? null : renderPanel("docked")}
+      {workspace && rightDrawer === "config" ? renderPanel("drawer") : null}
 
       <AnimatePresence mode="wait" initial={false}>
         {showWaterStatus ? (

--- a/frontend/src/pages/MapScreen.tsx
+++ b/frontend/src/pages/MapScreen.tsx
@@ -21,8 +21,7 @@ import { ControlPanel } from "@/components/ControlPanel"
 import { CompositionPanel } from "@/components/CompositionPanel"
 import { WaterPanel } from "@/components/WaterPanel"
 import { WaterStatusPanel } from "@/components/WaterStatusPanel"
-import { Map as MapIcon } from "lucide-react"
-import { MAP_TOOLS, type MapToolId } from "@/lib/mapTools"
+import type { MapToolId } from "@/lib/mapTools"
 import type { LayoutMode } from "@/lib/types"
 import { WorkspaceBar } from "@/components/WorkspaceBar"
 import type { PanelPlacement } from "@/components/ui/PanelShell"
@@ -43,6 +42,8 @@ export interface MapScreenProps {
   onLeftPanelChange: (id: MapToolId | null) => void
   /** Which layout draws this screen. See lib/types LayoutMode. */
   layoutMode?: LayoutMode
+  /** Go to another destination, for the dock layout's bar. */
+  onNavigate: (groupId: string, itemId?: string) => void
   areas: Area[]
   activeExample: string
   customPolygon: GeoJSONGeometry | null
@@ -437,11 +438,9 @@ export function MapScreen(props: MapScreenProps) {
         {workspace && (
           <WorkspaceBar
             key="workspace-bar"
-            icon={MapIcon}
-            groupLabel="Map"
-            items={MAP_TOOLS}
+            groupId="map"
             activeId={leftPanel}
-            onSelect={(id) => setLeftPanel(id as MapToolId)}
+            onNavigate={props.onNavigate}
             running={run.running}
             progress={run.progress}
             progressMsg={run.progressMsg}

--- a/frontend/src/pages/MapScreen.tsx
+++ b/frontend/src/pages/MapScreen.tsx
@@ -21,7 +21,8 @@ import { ControlPanel } from "@/components/ControlPanel"
 import { CompositionPanel } from "@/components/CompositionPanel"
 import { WaterPanel } from "@/components/WaterPanel"
 import { WaterStatusPanel } from "@/components/WaterStatusPanel"
-import type { MapToolId } from "@/lib/mapTools"
+import { Map as MapIcon } from "lucide-react"
+import { MAP_TOOLS, type MapToolId } from "@/lib/mapTools"
 import type { LayoutMode } from "@/lib/types"
 import { WorkspaceBar } from "@/components/WorkspaceBar"
 import type { PanelPlacement } from "@/components/ui/PanelShell"
@@ -243,7 +244,7 @@ export function MapScreen(props: MapScreenProps) {
    * the workspace layout's right drawer. Writing it twice would let the two
    * layouts drift in which props each panel receives.
    */
-  const renderPanel = (placement: PanelPlacement) => {
+  const renderPanel = (placement: PanelPlacement, show: boolean) => {
     /*
       Dismissing means different things in the two containers. Closing the
       docked column clears the open tool, because the column IS the tool
@@ -258,7 +259,7 @@ export function MapScreen(props: MapScreenProps) {
         : () => setLeftPanel(null)
     return (
       <AnimatePresence mode="wait" initial={false}>
-        {leftPanel === "classify" ? (
+        {!show ? null : leftPanel === "classify" ? (
           <ControlPanel
             key="classify"
             placement={placement}
@@ -436,8 +437,11 @@ export function MapScreen(props: MapScreenProps) {
         {workspace && (
           <WorkspaceBar
             key="workspace-bar"
-            tool={leftPanel}
-            onToolChange={setLeftPanel}
+            icon={MapIcon}
+            groupLabel="Map"
+            items={MAP_TOOLS}
+            activeId={leftPanel}
+            onSelect={(id) => setLeftPanel(id as MapToolId)}
             running={run.running}
             progress={run.progress}
             progressMsg={run.progressMsg}
@@ -511,8 +515,13 @@ export function MapScreen(props: MapScreenProps) {
         parameters open in a drawer from the bar instead, which is the same
         switch in the other container.
       */}
-      {workspace ? null : renderPanel("docked")}
-      {workspace && rightDrawer === "config" ? renderPanel("drawer") : null}
+      {renderPanel("docked", !workspace)}
+      {/*
+        The presence stays mounted and its child is what comes and goes. Gating
+        the AnimatePresence itself removed the exit animation: closing the
+        drawer unmounted the thing that was supposed to be animating it out.
+      */}
+      {renderPanel("drawer", workspace && rightDrawer === "config")}
 
       <AnimatePresence mode="wait" initial={false}>
         {showWaterStatus ? (

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -3,15 +3,18 @@ import {
   ArrowLeft,
   Camera,
   ChartColumn,
+  Heart,
   Download,
   FolderOpen,
   HardDrive,
   Loader2,
   LogOut,
   Save,
+  Star,
   Trash2,
   Upload,
 } from "lucide-react"
+import { BrowserOpenURL } from "../../wailsjs/runtime/runtime"
 import {
   ChooseBackupArchive,
   ExportBackup,
@@ -63,6 +66,15 @@ type SettingsSectionId = "account" | "system"
  * into Account. One control was never a page, and the theme belongs to the
  * person signed in rather than to the installation, which is what Account is.
  */
+/*
+  The project and the way to support it. Both taken from what the repository
+  already declares -- the remote, and .github/FUNDING.yml, which names
+  `github: rexionmars` -- rather than guessed: a sponsor button that leads
+  nowhere is worse than no button.
+*/
+const REPO_URL = "https://github.com/rexionmars/TERRA"
+const SPONSOR_URL = "https://github.com/sponsors/rexionmars"
+
 const SECTIONS: {
   id: SettingsSectionId
   label: string
@@ -908,6 +920,43 @@ export function ProfilePage({
               </div>
             </Section>
           )}
+
+          {/*
+            Outside the section switch, so it closes the page rather than one
+            of its tabs -- and last, because an ask placed above the settings
+            someone came here to change is an ask that interrupts them.
+
+            Both links open in the system browser through BrowserOpenURL: this
+            is a WKWebView with no createWebViewWith delegate, so an anchor
+            with target="_blank" is silently ignored.
+          */}
+          <div
+            className="mt-8 flex flex-wrap items-center gap-x-4 gap-y-2 border-t pt-4"
+            style={{ borderColor: "var(--border)" }}
+          >
+            <p className="min-w-0 flex-1 text-meta leading-relaxed text-muted-foreground">
+              TERRA is open source. If it is useful to you, a star helps other
+              people find it, and sponsoring pays for the time that goes into it.
+            </p>
+            <div className="flex shrink-0 items-center gap-2">
+              <button
+                type="button"
+                onClick={() => BrowserOpenURL(REPO_URL)}
+                className={btnGhost}
+              >
+                <Star className="h-3 w-3" />
+                Star on GitHub
+              </button>
+              <button
+                type="button"
+                onClick={() => BrowserOpenURL(SPONSOR_URL)}
+                className={btnGhost}
+              >
+                <Heart className="h-3 w-3" />
+                Sponsor
+              </button>
+            </div>
+          </div>
         </div>
       </PageBody>
 

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
+  ArrowLeft,
   Camera,
   ChartColumn,
   Download,
@@ -34,6 +35,7 @@ import {
   layoutModeFromPrefs,
   mergePreferenceExtras,
 } from "@/lib/preferenceExtras"
+import { NAV_GROUPS } from "@/lib/navigation"
 import { displayRunLabel } from "@/lib/aoiLabel"
 import { formatBytes } from "@/lib/formatBytes"
 import { runRowLine } from "@/lib/runSummary"
@@ -98,6 +100,8 @@ export function ProfilePage({
     goAnalysis,
     settingsPage,
     consumeSettingsPage,
+    settingsReturnTo,
+    leaveSettings,
   } = useAuth()
   const { setTheme: setNextTheme } = useTheme()
   const [name, setName] = useState("")
@@ -208,6 +212,14 @@ export function ProfilePage({
   )
 
   const layoutMode = layoutModeFromPrefs(prefs)
+
+  /*
+    Named from the navigation table so the button and the column agree on what
+    the destination is called. A screen with no entry there -- there is none
+    today -- would fall back to the neutral word rather than to a blank.
+  */
+  const returnLabel =
+    NAV_GROUPS.find((g) => g.id === settingsReturnTo)?.label ?? "the map"
 
   const schedulePrefsSave = useCallback(
     (patch: Partial<{ theme: string; layoutMode: LayoutMode }>) => {
@@ -424,6 +436,34 @@ export function ProfilePage({
         {/* Whose settings, which the removed header used to say twice. The
             display name rather than the literal "User": it is the one thing
             here the title bar does not already carry. */}
+        {/*
+          The way out, named after where it goes.
+          
+          Settings is the only screen with no work of its own to return to, and
+          leaving it meant picking a destination from the navigation column --
+          which required remembering what you had been doing, and landed you
+          beside it rather than back in it: from the solar tab, the nearest
+          column entry is Classification, which is a different product on a
+          different screen.
+          
+          The label comes from the navigation table, so it is the same word the
+          column uses for the place it returns to.
+        */}
+        <button
+          type="button"
+          onClick={leaveSettings}
+          className={cn(
+            "flex w-full items-center gap-2 border-b border-border px-3 py-2.5 text-left text-emphasis",
+            "text-muted-foreground transition-colors hover:bg-surface-raised/70 hover:text-foreground",
+            focusRing
+          )}
+        >
+          <ArrowLeft className="size-3.5 shrink-0" />
+          <span className="min-w-0 truncate">
+            Back to {returnLabel}
+          </span>
+        </button>
+
         <div className="border-b border-border px-3 py-3">
           <p className="telemetry text-meta text-accent-quiet">SETTINGS</p>
           <p className="mt-1 truncate text-emphasis font-medium text-foreground">

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -29,8 +29,11 @@ import { btnGhost, btnPrimary } from "@/components/ui/buttons"
 import { EnvironmentPanel } from "@/components/EnvironmentPanel"
 import { StorageModal } from "@/components/StorageModal"
 import { cn } from "@/lib/utils"
-import type { InferenceRun, Preferences } from "@/lib/types"
-import { mergePreferenceExtras } from "@/lib/preferenceExtras"
+import type { InferenceRun, LayoutMode, Preferences } from "@/lib/types"
+import {
+  layoutModeFromPrefs,
+  mergePreferenceExtras,
+} from "@/lib/preferenceExtras"
 import { displayRunLabel } from "@/lib/aoiLabel"
 import { formatBytes } from "@/lib/formatBytes"
 import { runRowLine } from "@/lib/runSummary"
@@ -173,14 +176,17 @@ export function ProfilePage({
     the stored value through keeps a theme change to being a theme change.
   */
   const persistPreferences = useCallback(
-    async (next: { theme: string }) => {
+    async (next: { theme: string; layoutMode?: LayoutMode }) => {
       if (!user) return
       const payload: Preferences = {
         user_id: user.id,
         default_model: prefs?.default_model || "spectral",
         overlay_opacity: prefs?.overlay_opacity ?? 0.75,
         theme: next.theme,
-        extras_json: mergePreferenceExtras(prefs?.extras_json, {}),
+        extras_json: mergePreferenceExtras(
+          prefs?.extras_json,
+          next.layoutMode ? { layout_mode: next.layoutMode } : {}
+        ),
       }
       await savePrefs(payload)
       if (
@@ -201,8 +207,10 @@ export function ProfilePage({
     ]
   )
 
+  const layoutMode = layoutModeFromPrefs(prefs)
+
   const schedulePrefsSave = useCallback(
-    (patch: Partial<{ theme: string }>) => {
+    (patch: Partial<{ theme: string; layoutMode: LayoutMode }>) => {
       if (!prefsReady.current) return
       prefsDraftRef.current = { ...prefsDraftRef.current, ...patch }
       if (savePrefsTimer.current) window.clearTimeout(savePrefsTimer.current)
@@ -797,6 +805,34 @@ export function ProfilePage({
                   <option value="light">Light</option>
                   <option value="system">System</option>
                 </select>
+              </SettingRow>
+
+              <SettingRow
+                id="account.layout"
+                title="Map layout"
+                description="How the map and energy screens are arranged. The title bar switches between them too; this is where the choice is explained and where it is restored from on start."
+                focused={focusedSetting === "account.layout"}
+                onFocus={() => setFocusedSetting("account.layout")}
+              >
+                <div className="flex max-w-md flex-col gap-2">
+                  <select
+                    className="field-input max-w-xs focus-visible:ring-1 focus-visible:ring-ring"
+                    value={layoutMode}
+                    onChange={(e) =>
+                      schedulePrefsSave({
+                        layoutMode: e.target.value as LayoutMode,
+                      })
+                    }
+                  >
+                    <option value="docked">Sidebar and column</option>
+                    <option value="workspace">Dock</option>
+                  </select>
+                  <p className="text-meta leading-relaxed text-muted-foreground">
+                    {layoutMode === "workspace"
+                      ? "Controls sit in a bar at the foot of the map, with parameters in a drawer. The map takes the full width."
+                      : "A navigation column on the left and the product's controls in a panel beside it."}
+                  </p>
+                </div>
               </SettingRow>
 
               {/* Sign out belongs to the account, not to the bottom of a


### PR DESCRIPTION
## Summary

A second layout, switchable, for the two screens that draw a map. The navigation column and the docked panel are a good answer for one AOI — which is what this application works on — and this is a second answer to the same question, not a replacement. The existing layout stays and is the default.

In the dock layout the column is withheld, returning 13.5rem to the map. Product selection and the run action move to an island at the foot, beside the period track rather than above it; parameters open in a right-edge drawer.

## How it was built

Six steps, each independently correct and revertable. The first carried all the regression risk and was verified inert: the three map panels' attachment to the left column was one line written three times, so it was extracted into a shared shell that takes a placement. The concatenated docked class string is byte-identical to the interpolated original, and an adversarial pass over the class strings, the motion config, the ref chain and the AnimatePresence boundary found no user-visible difference.

The bar and the shell were then generalised — the group is a prop, so the map passes its three tools and energy its two resources — and the energy screen followed.

## Things found while building it

- **The layout was a trap.** The bar named only the group it was on, so leaving the map for energy meant leaving the layout, switching in the column, and coming back. The menu now carries every destination, which is the column lying down.
- **Settings had no way out.** It is the one screen with no work of its own to return to; leaving meant picking a destination from the column, which required remembering what you had been doing and landed you beside it. It now returns to the screen it was opened from.
- **The tile credit's links did nothing.** Moving it to the title bar replaced Leaflet's control with anchors carrying `target="_blank"`, which this WKWebView ignores — Wails declares `WKUIDelegate` without implementing `createWebViewWith`. On links the ODbL requires to be reachable, that is the one outcome that cannot ship. They call `BrowserOpenURL` now.
- **The status panels cleared a column that was not there**, centring 9.8rem right of the window centre.
- **Leaflet never learned its container had resized.** It caches the dimensions and re-reads them only on a window resize, so returning 13.5rem to the stage left it drawing at the old width — tiles stopping at the former edge, and clicks projected against a viewport that no longer existed.

## Drift removed

Three tables now have one reader each where they had two: the navigation destinations (Solar and Wind were written in the column and again in the energy screen), the basemaps (the tile URL and the credit naming its source were separate strings, and the active basemap was recovered from its display name by regular expression), and the status panels' inset.

## Also here

The layout is chosen in Settings as well as from the title bar — the same preference, not a separate default that the toggle could contradict. And a block at the foot of Settings inviting a star or a sponsorship, with both destinations taken from the repository's own remote and `.github/FUNDING.yml`.

## Testing

208 sidecar tests, both Go packages, `tsc`, `vite build` and the contrast check pass. Exactly one route into settings exists in each of the ten screen-by-layout states, checked across the matrix.