### PR TITLE
fix(studio): a retained run could be drawn but not read

### DIFF
--- a/frontend/src/components/whiteboard/BoardSurface.tsx
+++ b/frontend/src/components/whiteboard/BoardSurface.tsx
@@ -1359,6 +1359,25 @@ export function BoardSurface({
         return ring ? [[a.id, ring] as const] : []
       })
     ),
+    /*
+      A retained run's outline, from the run record where there is one.
+
+      Without it the area falls back to its raster's rectangle, so a run the
+      map has moved on from is outlined as a box while every other area shows
+      its real shape.
+    */
+    ...Object.fromEntries(
+      retainedRuns.flatMap(({ id }) => {
+        const rec = runs.find((r) => r.id === id)
+        if (!rec) return []
+        const geom = resolveProjectGeometry(
+          { polygon_geojson: rec.polygon_geojson },
+          []
+        )
+        const ring = geom ? polygonOuterRing(geom) : null
+        return ring ? [[id, ring] as const] : []
+      })
+    ),
     ...Object.fromEntries(
       extraRuns.flatMap(({ run }) => {
         // The run stores the polygon it was asked for; there is no area
@@ -1469,8 +1488,31 @@ export function BoardSurface({
     }
   })
 
+  /*
+    A retained run has to appear HERE too, not only in `assetRuns`.
+
+    `sideOf` asks this map for the result behind an area, and every reading
+    built on a pair goes through it -- the compare editor, the domain-shift
+    pair, the cohort. A run that was listed in the data tree and absent from
+    this map could be selected, drawn, and then refused by both editors with
+    "pick two prediction planes" while two were plainly picked.
+  */
   const legendByArea = new Map<string, LegendSources>([
     [live, legendSources ?? {}],
+    ...retainedRuns.map(
+      ({ id, result }) =>
+        [
+          id,
+          {
+            result,
+            water: result.water,
+            solarTerrain: result.solar_terrain,
+            solarSiting: result.solar_siting,
+          },
+        ] as [string, LegendSources]
+    ),
+    // After the retained ones, so a run the picker has since loaded wins: it
+    // carries the full record where a retained entry carries only the result.
     ...extraRuns.map(
       ({ run, result }) =>
         [

--- a/frontend/src/lib/runAssets.ts
+++ b/frontend/src/lib/runAssets.ts
@@ -35,7 +35,7 @@ import type {
   SolarTerrainAnalysis,
   WaterAnalysis,
 } from "@/lib/types"
-import { isZeroExtent } from "@/lib/mapLayers"
+import { isZeroExtent, predictionSource } from "@/lib/mapLayers"
 import { seasonLabel } from "@/lib/solarOptions"
 
 /**
@@ -202,6 +202,19 @@ export function compositionList(i: {
   return i.composition?.overlay_uri ? [i.composition] : []
 }
 
+/**
+ * What a run's prediction raster should be CALLED.
+ *
+ * Mirrors the naming in `rasterLayers` so the scene tree does not give one
+ * raster two names depending on which area holds it.
+ */
+function predictionTitle(r: PredictResult | null | undefined): string {
+  const src = predictionSource(r ?? undefined)?.source
+  if (src === "lulc") return `MapBiomas ${r?.lulc?.year ?? ""}`.trim()
+  if (src === "reference") return "Reference map"
+  return "Classification"
+}
+
 /** Everything this run produced, in the order it is worth reading. */
 export function runAssets(i: RunAssetInput): RunAsset[] {
   const out: RunAsset[] = []
@@ -211,7 +224,18 @@ export function runAssets(i: RunAssetInput): RunAsset[] {
     out.push({
       id: "prediction",
       sceneId: "prediction",
-      title: "Prediction",
+      /*
+        Named for what it IS, which is the rule `rasterLayers` already states
+        for the same raster on the live area: the three sources are three
+        different maps with three different class sets.
+
+        This said "Prediction" flatly -- the slot's name, which is what that
+        rule argues against -- so one board showed the same layer as
+        "Classification" under the area the map is on and as "Prediction"
+        under every other, and a reader had no way to tell whether they were
+        looking at two things or at one thing named twice.
+      */
+      title: predictionTitle(r),
       params: [
         i.areaLabel?.trim() || null,
         modelLabel(i.modelKind),


### PR DESCRIPTION
Two defects found by running the reported flow — draw an AOI, run it, draw a second, run it — against `main`.

**A retained run was half-wired.** Keeping a run the map had moved on from was added to `assetRuns` only. That feeds the data tree and the scene, so the run appeared, could be selected and could be put in the viewport — and then the compare editor and the domain-shift pair both refused it with "pick two prediction planes" while two were picked, badges and all. `sideOf` resolves an area to its result through `legendByArea`, which did not have it; drawing does not consult the map the reading does. `polygonsRef` was missing the same runs, so a retained area was outlined by its raster's rectangle rather than the shape the run was asked for.

**One raster had two names.** `rasterLayers` names the prediction for what it is — Classification, MapBiomas YYYY, Reference map — and its comment gives the reason. `runAssets` called it "Prediction" flatly, the slot's name, so the same layer read one way under the area the map is on and another way under every other. The rule now lives in one function both paths call.

## Verification

Everything CI runs, locally: `go vet`, `go test ./backend/...`, `pytest sidecar/tests -q` (231 passed), `npm run build`.

Confirmed in the running app by the reporter: the flow that produced the bug now opens both editors on the pair.