### PR TITLE
fix(sidecar): explain why a run failed, and install the optional models from Settings

### DIFF
--- a/backend/envsetup.go
+++ b/backend/envsetup.go
@@ -275,6 +275,142 @@ func itoaAll(parts []int) []string {
 	return out
 }
 
+/*
+OptionalPackage is a dependency the application can run without.
+
+These are the ones deliberately outside requirements.txt: torch alone outweighs
+everything else the application ships, so making every install pay for it to
+serve the users who want the neural models would be the wrong default. They are
+installed on request instead.
+*/
+type OptionalPackage struct {
+	// What pip installs. May carry a version constraint.
+	Spec string `json:"spec"`
+	// The distribution name, for uninstalling and for matching the doctor's
+	// report -- "torch>=2.1" installs, but "torch" is what is removed.
+	Name string `json:"name"`
+	// What it unlocks, in the user's terms.
+	Enables string `json:"enables"`
+	// Roughly what the download costs, since these are large enough that the
+	// number changes whether someone starts it.
+	Size string `json:"size"`
+}
+
+// OptionalPackages are what Settings can add and remove.
+//
+// Kept here rather than read from requirements-prithvi.txt: that file exists
+// for a manual pip install and pulls requirements.txt with it, which is not
+// what adding one package to a working environment should do.
+var OptionalPackages = []OptionalPackage{
+	{
+		Spec:    "torch>=2.1",
+		Name:    "torch",
+		Enables: "Temporal Transformer and Prithvi-EO 2.0",
+		Size:    "about 2-3 GB",
+	},
+}
+
+/*
+InstallOptional adds one optional package to an existing environment.
+
+Reuses the build lock: pip writing into the same environment twice at once is
+how a half-installed package gets left behind, and the UI has one progress
+channel to report through either way.
+
+Refuses anything not on the list above. The name reaches this from the
+frontend, and an install command that accepts an arbitrary string is a way to
+run arbitrary pip.
+*/
+func (b *EnvBuilder) InstallOptional(
+	ctx context.Context,
+	python, name, sidecarDir string,
+	emit func(EnvSetupEvent),
+) error {
+	pkg, ok := findOptional(name)
+	if !ok {
+		return fmt.Errorf("%q is not an optional package this application manages", name)
+	}
+	return b.runPip(ctx, python, sidecarDir, emit,
+		fmt.Sprintf("installing %s (%s)", pkg.Name, pkg.Size),
+		"-m", "pip", "install", pkg.Spec)
+}
+
+// RemoveOptional uninstalls one optional package.
+//
+// Offered because these are large: someone who tried the neural models and went
+// back to the Random Forest should be able to reclaim the gigabytes without
+// rebuilding the environment from scratch.
+func (b *EnvBuilder) RemoveOptional(
+	ctx context.Context,
+	python, name, sidecarDir string,
+	emit func(EnvSetupEvent),
+) error {
+	pkg, ok := findOptional(name)
+	if !ok {
+		return fmt.Errorf("%q is not an optional package this application manages", name)
+	}
+	return b.runPip(ctx, python, sidecarDir, emit,
+		"removing "+pkg.Name,
+		"-m", "pip", "uninstall", "-y", pkg.Name)
+}
+
+func findOptional(name string) (OptionalPackage, bool) {
+	for _, p := range OptionalPackages {
+		if p.Name == name {
+			return p, true
+		}
+	}
+	return OptionalPackage{}, false
+}
+
+// runPip performs one pip operation under the build lock, reporting progress
+// and re-inspecting the environment afterwards so the screen reflects reality
+// rather than the assumption that pip did what it was asked.
+func (b *EnvBuilder) runPip(
+	ctx context.Context,
+	python, sidecarDir string,
+	emit func(EnvSetupEvent),
+	what string,
+	args ...string,
+) error {
+	b.mu.Lock()
+	if b.running {
+		b.mu.Unlock()
+		return fmt.Errorf("an environment operation is already running")
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	b.cancel = cancel
+	b.running = true
+	b.mu.Unlock()
+
+	defer func() {
+		cancel()
+		b.mu.Lock()
+		b.running = false
+		b.cancel = nil
+		b.mu.Unlock()
+	}()
+
+	emit(EnvSetupEvent{Step: StepInstalling, Line: what})
+	if err := runStreaming(ctx, emit, StepInstalling, python, args...); err != nil {
+		emit(EnvSetupEvent{Step: StepFailed, Error: err.Error()})
+		return err
+	}
+
+	// What the doctor says now, not what pip's exit status implies.
+	emit(EnvSetupEvent{Step: StepVerifying, Line: "checking the environment"})
+	report := InspectPython(ctx, python, sidecarDir)
+	if report.Unreachable != "" {
+		err := fmt.Errorf("the environment could not be inspected afterwards: %s",
+			report.Unreachable)
+		emit(EnvSetupEvent{Step: StepFailed, Error: err.Error()})
+		return err
+	}
+
+	emit(EnvSetupEvent{Step: StepDone, Line: "done"})
+	return nil
+}
+
 // runStreaming runs a command and reports every line it writes, on either
 // stream, as it appears.
 //

--- a/backend/sidecar.go
+++ b/backend/sidecar.go
@@ -387,6 +387,7 @@ func (r *Runner) Predict(ctx context.Context, req PredictRequest) (*PredictResul
 
 	var wg sync.WaitGroup
 	var lastError string
+	var tail stderrTail
 
 	// Stream stderr: one JSON object per line ({progress,msg} or {error}).
 	wg.Add(1)
@@ -405,7 +406,10 @@ func (r *Runner) Predict(ctx context.Context, req PredictRequest) (*PredictResul
 				Error    string `json:"error"`
 			}
 			if err := json.Unmarshal([]byte(line), &ev); err != nil {
-				// Non-JSON stderr (e.g. library warnings): forward as a message.
+				// Non-JSON stderr (e.g. library warnings, or a traceback when
+				// the process dies): forward it, and keep the last few so a
+				// crash can still say why.
+				tail.add(line)
 				emitProgress(ctx, "predict:progress", ProgressEvent{Progress: -1, Msg: line})
 				continue
 			}
@@ -437,10 +441,7 @@ func (r *Runner) Predict(ctx context.Context, req PredictRequest) (*PredictResul
 	waitErr := cmd.Wait()
 
 	if waitErr != nil {
-		if lastError != "" {
-			return nil, fmt.Errorf("%s", lastError)
-		}
-		return nil, fmt.Errorf("sidecar failed: %w", waitErr)
+		return nil, sidecarFailure(waitErr, lastError, &tail)
 	}
 
 	raw := strings.TrimSpace(out.String())
@@ -628,6 +629,7 @@ func (r *Runner) AnalyzeLULC(ctx context.Context, req LULCRequest) (*LULCAnalysi
 
 	var wg sync.WaitGroup
 	var lastError string
+	var tail stderrTail
 
 	wg.Add(1)
 	go func() {
@@ -645,6 +647,8 @@ func (r *Runner) AnalyzeLULC(ctx context.Context, req LULCRequest) (*LULCAnalysi
 				Error    string `json:"error"`
 			}
 			if err := json.Unmarshal([]byte(line), &ev); err != nil {
+				// Kept, so a crash without a structured error can still say why.
+				tail.add(line)
 				emitProgress(ctx, "predict:progress", ProgressEvent{Progress: -1, Msg: line})
 				continue
 			}
@@ -674,10 +678,7 @@ func (r *Runner) AnalyzeLULC(ctx context.Context, req LULCRequest) (*LULCAnalysi
 	wg.Wait()
 	waitErr := cmd.Wait()
 	if waitErr != nil {
-		if lastError != "" {
-			return nil, fmt.Errorf("%s", lastError)
-		}
-		return nil, fmt.Errorf("sidecar failed: %w", waitErr)
+		return nil, sidecarFailure(waitErr, lastError, &tail)
 	}
 
 	raw := strings.TrimSpace(out.String())
@@ -774,6 +775,7 @@ func (r *Runner) ListDataCube(ctx context.Context, req DataCubeRequest) (*DataCu
 
 	var wg sync.WaitGroup
 	var lastError string
+	var tail stderrTail
 
 	wg.Add(1)
 	go func() {
@@ -791,6 +793,8 @@ func (r *Runner) ListDataCube(ctx context.Context, req DataCubeRequest) (*DataCu
 				Error    string `json:"error"`
 			}
 			if err := json.Unmarshal([]byte(line), &ev); err != nil {
+				// Kept, so a crash without a structured error can still say why.
+				tail.add(line)
 				emitProgress(ctx, "predict:progress", ProgressEvent{Progress: -1, Msg: line})
 				continue
 			}
@@ -820,10 +824,7 @@ func (r *Runner) ListDataCube(ctx context.Context, req DataCubeRequest) (*DataCu
 	wg.Wait()
 	waitErr := cmd.Wait()
 	if waitErr != nil {
-		if lastError != "" {
-			return nil, fmt.Errorf("%s", lastError)
-		}
-		return nil, fmt.Errorf("sidecar failed: %w", waitErr)
+		return nil, sidecarFailure(waitErr, lastError, &tail)
 	}
 
 	raw := strings.TrimSpace(out.String())
@@ -934,6 +935,7 @@ func (r *Runner) RenderComposite(ctx context.Context, req CompositeRequest) (*Co
 
 	var wg sync.WaitGroup
 	var lastError string
+	var tail stderrTail
 
 	wg.Add(1)
 	go func() {
@@ -951,6 +953,8 @@ func (r *Runner) RenderComposite(ctx context.Context, req CompositeRequest) (*Co
 				Error    string `json:"error"`
 			}
 			if err := json.Unmarshal([]byte(line), &ev); err != nil {
+				// Kept, so a crash without a structured error can still say why.
+				tail.add(line)
 				emitProgress(ctx, "predict:progress", ProgressEvent{Progress: -1, Msg: line})
 				continue
 			}
@@ -980,10 +984,7 @@ func (r *Runner) RenderComposite(ctx context.Context, req CompositeRequest) (*Co
 	wg.Wait()
 	waitErr := cmd.Wait()
 	if waitErr != nil {
-		if lastError != "" {
-			return nil, fmt.Errorf("%s", lastError)
-		}
-		return nil, fmt.Errorf("sidecar failed: %w", waitErr)
+		return nil, sidecarFailure(waitErr, lastError, &tail)
 	}
 
 	raw := strings.TrimSpace(out.String())
@@ -1022,6 +1023,57 @@ func (r *Runner) RenderComposite(ctx context.Context, req CompositeRequest) (*Co
 		RasterTIF:  rasterTIF,
 		Meta:       wrapped.Meta,
 	}, nil
+}
+
+/*
+stderrTail keeps the last few non-JSON lines the sidecar wrote.
+
+The sidecar reports errors as {"error": ...} and the caller shows that. What it
+cannot report that way is a crash: an unguarded import or any other uncaught
+exception ends the process as a Python traceback on stderr, which parses as
+nothing and was forwarded as progress -- then replaced by "sidecar failed: exit
+status 1", a message that names neither the cause nor anywhere to look.
+
+The tail is what turns that back into a diagnosis. Bounded, because a traceback
+ends with the reason and the frames above it are noise.
+*/
+type stderrTail struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (t *stderrTail) add(line string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.lines = append(t.lines, line)
+	if len(t.lines) > 6 {
+		t.lines = t.lines[1:]
+	}
+}
+
+// reason renders the tail as one line, or empty when nothing was captured.
+func (t *stderrTail) reason() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.lines) == 0 {
+		return ""
+	}
+	return strings.Join(t.lines, " · ")
+}
+
+// sidecarFailure explains a non-zero exit as well as the evidence allows.
+//
+// The structured error first, since the sidecar says what it means when it can.
+// Then the tail, which is all that exists when the process died rather than
+// reported. The bare exit status only when there is neither.
+func sidecarFailure(waitErr error, lastError string, tail *stderrTail) error {
+	if lastError != "" {
+		return fmt.Errorf("%s", lastError)
+	}
+	if reason := tail.reason(); reason != "" {
+		return fmt.Errorf("the analysis process stopped: %s", reason)
+	}
+	return fmt.Errorf("sidecar failed: %w", waitErr)
 }
 
 // pngToDataURI reads a PNG file and returns a base64 data URI.
@@ -1188,6 +1240,7 @@ func (r *Runner) runSidecarJSON(ctx context.Context, reqBytes []byte) (string, e
 
 	var wg sync.WaitGroup
 	var lastError string
+	var tail stderrTail
 
 	wg.Add(1)
 	go func() {
@@ -1205,6 +1258,8 @@ func (r *Runner) runSidecarJSON(ctx context.Context, reqBytes []byte) (string, e
 				Error    string `json:"error"`
 			}
 			if err := json.Unmarshal([]byte(line), &ev); err != nil {
+				// Kept, so a crash without a structured error can still say why.
+				tail.add(line)
 				emitProgress(ctx, "predict:progress", ProgressEvent{Progress: -1, Msg: line})
 				continue
 			}
@@ -1233,10 +1288,7 @@ func (r *Runner) runSidecarJSON(ctx context.Context, reqBytes []byte) (string, e
 
 	wg.Wait()
 	if waitErr := cmd.Wait(); waitErr != nil {
-		if lastError != "" {
-			return "", fmt.Errorf("%s", lastError)
-		}
-		return "", fmt.Errorf("sidecar failed: %w", waitErr)
+		return "", sidecarFailure(waitErr, lastError, &tail)
 	}
 
 	raw := strings.TrimSpace(out.String())

--- a/environment_api.go
+++ b/environment_api.go
@@ -330,6 +330,58 @@ func (a *App) BuildManagedEnvironment(basePython string) error {
 	return nil
 }
 
+/*
+ManageOptionalPackage installs or removes one optional dependency.
+
+Runs in the background on the same "env:setup" channel as a build, because it
+is the same operation from the user's side: pip working in their environment
+with output worth watching. torch is a multi-gigabyte download, so a
+synchronous call would freeze the window for the whole of it.
+
+`install` false removes it. These are large enough that reclaiming the space
+is a real request, and rebuilding the whole environment to drop one package
+would be a poor answer to it.
+*/
+func (a *App) ManageOptionalPackage(name string, install bool) error {
+	data := a.dataDir()
+	if data == "" {
+		return fmt.Errorf("the local store is not open")
+	}
+	sidecar := a.sidecarDir()
+	if sidecar == "" {
+		return fmt.Errorf("the sidecar directory is not resolved")
+	}
+	runner := a.currentRunner()
+	if runner == nil {
+		return fmt.Errorf("no interpreter is resolved")
+	}
+	if a.envBuilder.Running() {
+		return fmt.Errorf("an environment operation is already running")
+	}
+	python := runner.PythonPath()
+
+	ctx := a.ctx
+	go func() {
+		emit := func(ev backend.EnvSetupEvent) {
+			if ctx != nil {
+				wruntime.EventsEmit(ctx, "env:setup", ev)
+			}
+		}
+		if install {
+			_ = a.envBuilder.InstallOptional(context.Background(), python, name, sidecar, emit)
+			return
+		}
+		_ = a.envBuilder.RemoveOptional(context.Background(), python, name, sidecar, emit)
+	}()
+	return nil
+}
+
+// ListOptionalPackages reports what can be added, so the screen names the cost
+// and what each one unlocks rather than listing bare package names.
+func (a *App) ListOptionalPackages() []backend.OptionalPackage {
+	return backend.OptionalPackages
+}
+
 // CancelEnvironmentBuild stops a build in progress.
 func (a *App) CancelEnvironmentBuild() {
 	a.envBuilder.Cancel()

--- a/frontend/src/components/EnvironmentPanel.tsx
+++ b/frontend/src/components/EnvironmentPanel.tsx
@@ -24,6 +24,8 @@ import {
   BuildManagedEnvironment,
   CancelEnvironmentBuild,
   InspectEnvironment,
+  ListOptionalPackages,
+  ManageOptionalPackage,
   UseInterpreter,
 } from "../../wailsjs/go/main/App"
 import type { backend, main } from "../../wailsjs/go/models"
@@ -66,6 +68,7 @@ export function EnvironmentPanel() {
   const [problem, setProblem] = useState<string | null>(null)
   const [log, setLog] = useState<SetupEvent[]>([])
   const [building, setBuilding] = useState(false)
+  const [optional, setOptional] = useState<backend.OptionalPackage[]>([])
   const logRef = useRef<HTMLDivElement | null>(null)
 
   const refresh = useCallback(async () => {
@@ -83,6 +86,13 @@ export function EnvironmentPanel() {
   useEffect(() => {
     void refresh()
   }, [refresh])
+
+  // Static for the life of the build, so fetched once rather than per refresh.
+  useEffect(() => {
+    ListOptionalPackages()
+      .then((list) => setOptional(list ?? []))
+      .catch(() => {})
+  }, [])
 
   // pip's own lines, as they arrive. An install takes minutes, and its output
   // is the only honest answer to "is this stuck".
@@ -115,6 +125,25 @@ export function EnvironmentPanel() {
     }
   }
 
+  /*
+    Install or remove one optional package.
+
+    Reports through the same "env:setup" events a build uses -- pip's output is
+    the honest answer to "is this stuck" for a multi-gigabyte download too, and
+    the listener above already refreshes the panel when it ends.
+  */
+  const manage = async (name: string, install: boolean) => {
+    setLog([])
+    setProblem(null)
+    setBuilding(true)
+    try {
+      await ManageOptionalPackage(name, install)
+    } catch (e) {
+      setBuilding(false)
+      setProblem(e instanceof Error ? e.message : String(e))
+    }
+  }
+
   const choose = async (path: string) => {
     setBusyPath(path)
     setProblem(null)
@@ -132,7 +161,9 @@ export function EnvironmentPanel() {
   const missing = (active?.packages ?? []).filter(
     (p) => !p.optional && (!p.present || p.version_problem)
   )
-  const degraded = (active?.packages ?? []).filter((p) => p.optional && !p.present)
+  // Optional packages are no longer listed as "degraded" here: the section
+  // below names them, says what they cost, and offers to install them, which
+  // is the whole of what a reader needed from that line.
 
   return (
     <div className="flex flex-col gap-3">
@@ -227,16 +258,62 @@ export function EnvironmentPanel() {
                 ))}
               </ul>
             )}
-            {degraded.length > 0 && (
-              <ul className="mt-3 flex flex-col gap-1.5">
-                {degraded.map((p) => (
-                  <PackageRow key={p.module} pkg={p} />
-                ))}
-              </ul>
-            )}
           </>
         )}
       </section>
+
+      {/*
+        The optional models, with a way to get them.
+
+        torch is outside requirements.txt on purpose -- it outweighs everything
+        else the application ships, so every install paying for it to serve the
+        people who want the neural models would be the wrong default. But the
+        panel only ever reported its absence: "without it: Temporal Transformer
+        and Prithvi" told the user what they were missing and left them to work
+        out where pip lived. Removal is offered for the same reason it is
+        optional: it is gigabytes, and someone who tried the neural models
+        should be able to reclaim them without rebuilding the environment.
+      */}
+      {optional.length > 0 && active && !active.unreachable && (
+        <section className="rounded-sm border border-border bg-secondary/50 p-4">
+          <p className="eyebrow mb-1">Optional models</p>
+          <p className="mb-3 text-body text-muted-foreground">
+            Large downloads TERRA does not install by default. Everything else
+            works without them.
+          </p>
+          <ul className="flex flex-col gap-2">
+            {optional.map((pkg) => {
+              const installed = (active.packages ?? []).some(
+                (p) => p.distribution === pkg.name && p.present
+              )
+              return (
+                <li
+                  key={pkg.name}
+                  className="flex flex-wrap items-center justify-between gap-2 rounded-sm border border-border bg-background px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <p className="text-body text-foreground">
+                      <span className="telemetry">{pkg.name}</span>
+                      {installed ? " · installed" : ` · ${pkg.size}`}
+                    </p>
+                    <p className="text-micro text-muted-foreground">
+                      enables {pkg.enables}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    disabled={building || busyPath !== null}
+                    onClick={() => void manage(pkg.name, !installed)}
+                    className={installed ? btnGhost : btnPrimaryCommit}
+                  >
+                    {installed ? "Remove" : "Install"}
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        </section>
+      )}
 
       {/* The recommended repair, and the interpreters it can be built on. */}
       <section className="rounded-sm border border-border bg-secondary/50 p-4">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -994,7 +994,9 @@
   align-items: flex-start;
   gap: 0.7rem;
   width: var(--width);
-  padding: 0.7rem 0.85rem;
+  /* Extra room on the right for the absolutely positioned close button, which
+     reserves none of its own and otherwise sits on top of the text. */
+  padding: 0.7rem 2rem 0.7rem 0.85rem;
   /* A floating container, so the container radius. It carried the control
      radius, which made it the one thing over the map with a different corner
      from every panel beside it. */
@@ -1054,19 +1056,40 @@
   color: var(--muted-foreground);
   word-break: break-word;
 }
+/*
+  The dismiss control.
+
+  It is absolutely positioned inside the toast but had no display mode, so the
+  glyph sat wherever the button's default layout put it rather than in the
+  middle of the box drawn around it -- an outline with an X near one edge.
+  Centring it is what the border implies.
+
+  The toast's right padding accounts for it below, since an absolute element
+  reserves no space: at 0.85rem the button overlapped the last few characters
+  of any description long enough to reach the edge.
+*/
 .terra-toast-close {
   position: absolute !important;
   top: 0.45rem !important;
   right: 0.45rem !important;
   left: auto !important;
   transform: none !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
   width: 1.25rem !important;
   height: 1.25rem !important;
+  padding: 0 !important;
   border-radius: var(--radius-sm)!important;
   border: 1px solid rgb(var(--p-line) / 0.35) !important;
   background: transparent !important;
   color: var(--muted-foreground) !important;
   opacity: 0.85;
+}
+/* The glyph, at a size that fits the 1.25rem box it sits in. */
+.terra-toast-close svg {
+  width: 0.7rem !important;
+  height: 0.7rem !important;
 }
 .terra-toast-close:hover {
   opacity: 1;

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -72,6 +72,8 @@ export function ListDataCube(arg1:backend.DataCubeRequest):Promise<backend.DataC
 
 export function ListEmbeddedAreas():Promise<Array<backend.Area>>;
 
+export function ListOptionalPackages():Promise<Array<backend.OptionalPackage>>;
+
 export function ListProjectOverlays(arg1:string):Promise<Array<store.ProjectOverlay>>;
 
 export function ListProjectRuns(arg1:string,arg2:number):Promise<Array<store.InferenceRun>>;
@@ -87,6 +89,8 @@ export function LoadAnalysis(arg1:string):Promise<backend.PredictResult>;
 export function Login(arg1:string,arg2:string):Promise<store.User>;
 
 export function Logout():Promise<void>;
+
+export function ManageOptionalPackage(arg1:string,arg2:boolean):Promise<void>;
 
 export function OpenExternal(arg1:string):Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -138,6 +138,10 @@ export function ListEmbeddedAreas() {
   return window['go']['main']['App']['ListEmbeddedAreas']();
 }
 
+export function ListOptionalPackages() {
+  return window['go']['main']['App']['ListOptionalPackages']();
+}
+
 export function ListProjectOverlays(arg1) {
   return window['go']['main']['App']['ListProjectOverlays'](arg1);
 }
@@ -168,6 +172,10 @@ export function Login(arg1, arg2) {
 
 export function Logout() {
   return window['go']['main']['App']['Logout']();
+}
+
+export function ManageOptionalPackage(arg1, arg2) {
+  return window['go']['main']['App']['ManageOptionalPackage'](arg1, arg2);
 }
 
 export function OpenExternal(arg1) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -2945,6 +2945,24 @@ export namespace backend {
 		    return a;
 		}
 	}
+	export class OptionalPackage {
+	    spec: string;
+	    name: string;
+	    enables: string;
+	    size: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new OptionalPackage(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.spec = source["spec"];
+	        this.name = source["name"];
+	        this.enables = source["enables"];
+	        this.size = source["size"];
+	    }
+	}
 	export class PhenologyMetrics {
 	    sos_doy?: number;
 	    pos_doy?: number;

--- a/sidecar/infer.py
+++ b/sidecar/infer.py
@@ -79,6 +79,29 @@ def fail(msg):
     sys.exit(1)
 
 
+def require_torch(product):
+    """
+    Fail with an explanation when PyTorch is absent.
+
+    torch is deliberately outside requirements.txt -- it outweighs everything
+    else the application ships -- so the models that need it are opt-in. A bare
+    `import torch` raises ModuleNotFoundError, which leaves the process as a
+    traceback and an exit status: the caller reported "sidecar failed: exit
+    status 1" and the user had no way to learn that one optional package was
+    the whole of the problem.
+
+    Named here rather than inlined because two products need it, and a check
+    that exists in one place is a check the other forgets.
+    """
+    try:
+        import torch  # noqa: F401
+    except ImportError:
+        fail(f'{product} needs PyTorch, which is not installed in this '
+             f'environment. Install it there, or choose the Random Forest '
+             f'model, which needs nothing further. '
+             f'Settings > System reports what each interpreter has.')
+
+
 # --- Request parameters ----------------------------------------------------
 #
 # ABSENCE SELECTS THE DEFAULT, NOT FALSINESS. `float(req.get(key) or default)`
@@ -675,6 +698,7 @@ def compute_aoi_vi_series(products, polygon, ref_prof):
 
 def classify_temporal_transformer(products, polygon, ref_profile, model_dir):
     """Classify with the mestrado Temporal Transformer (T×6 reflectance)."""
+    require_torch("The Temporal Transformer")
     import torch
     import temporal_transformer as tt
 
@@ -835,6 +859,9 @@ def classify_prithvi(products, polygon, ref_profile, model_dir, mode):
     and the matching Random Forest head. mode is 'pixel' or 'patch'.
     Returns a (H, W) map of MapBiomas class ids (-1 = invalid).
     """
+    # prithvi imports torch on the way in, so the same absence surfaces here as
+    # an unexplained traceback rather than as a missing package.
+    require_torch("Prithvi-EO 2.0")
     import prithvi as pv
 
     rf_path = model_dir / f'prithvi_rf_{mode}.joblib'


### PR DESCRIPTION
Selecting the Temporal Transformer on an environment without PyTorch produced
`sidecar failed: exit status 1`. Nothing named torch, named the model, or
pointed anywhere — and the one screen that already knew, Settings › System,
was never connected to the moment the user hit it. This branch closes that gap
from both ends: the failure explains itself, and the panel that knows the cause
can now act on it.

## What lands

**A failure that says why.** torch was imported unguarded, so the process died
before the sidecar's own error path could run, and the Go side had only an exit
status to report. The import is now guarded like every other failure in the
sidecar, and non-JSON stderr — a traceback included — is retained in a bounded
tail so a crash without a structured error can still name its cause.

**Optional packages installable from Settings › System.** torch sits outside
`requirements.txt` deliberately: it outweighs everything else the application
ships, so making every install pay for it would be the wrong default. But the
panel only ever reported its absence and left the user to find pip and guess
which interpreter to point it at. It now lists the optional packages, says what
each unlocks and roughly what it costs to download, and installs into the
interpreter already in use. Removal is offered for the same reason the package
is optional: it is gigabytes, and someone who tried the neural models and went
back to the Random Forest should be able to reclaim them.

Installation runs through the machinery a build already uses — the same lock,
so pip cannot write into one environment twice at once, and the same
`env:setup` events, so pip's output is visible while a multi-gigabyte download
runs. The environment is re-inspected afterwards rather than trusting pip's
exit status.

**The package name is checked against the declared list.** It arrives from the
frontend, and an install command that accepts an arbitrary string is a way to
run arbitrary pip.

**A toast close button that is centred.** The control had a border, a size and
a position but no display mode, so the glyph sat wherever the button's default
layout put it. The toast's padding also reserved no room for it, and long
descriptions ran underneath.

## Rebase note

The branch was 168 commits behind and has been rebased onto current `main`. One
conflict, in `backend/sidecar.go`: `main` introduced `emitProgress` as a
stubbable indirection over wails' `EventsEmit`, while this branch added the
stderr tail at the same five call sites. Both sides are kept — the tail
bookkeeping emits through the indirection.

## Verification

`go build`, `go vet`, `gofmt`, `go test ./...` (3 packages pass), `tsc
--noEmit`, `vite build`, and `pytest sidecar/tests` (223 passed, 8 skipped) —
all on the rebased tree.
