### PR TITLE
feat(ui): move the chassis from Mars sand to a blue accent

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,8 +1,13 @@
 # TERRA design system
 
-Mars sand: warm near-black surfaces where the neutrals carry the hue rather than
-leaving it to the accent, one terracotta accent, monospace telemetry, and a
-density chosen on purpose.
+Cool near-black surfaces where the neutrals carry the accent's hue rather than
+leaving it to the accent, one blue accent, monospace telemetry, and a density
+chosen on purpose.
+
+The family replaces the Mars sand it began as. The rotation was done at constant
+luminance -- WCAG contrast is a function of relative luminance alone, so every
+neutral kept the ratio it had been measured at while its hue moved to the
+accent's 214 degrees.
 
 The implementation is the source of truth. This file describes it; where the two
 disagree, the code is right and this file is stale.
@@ -44,32 +49,40 @@ from `--p-*` in a plain `:root` block, and `@theme inline` maps those to
 | Token | RGB | Hex | Role |
 | --- | --- | --- | --- |
 | `--p-ink` | `23 23 23` | `#171717` | App background |
-| `--p-surface` | `38 32 28` | `#26201C` | Panel |
-| `--p-surface-raised` | `54 45 39` | `#362D27` | Card, field |
-| `--p-line` | `86 73 63` | `#56493F` | Divider |
-| `--p-line-strong` | `138 117 100` | `#8A7564` | Component boundary |
-| `--p-text` | `226 220 212` | `#E2DCD4` | Text |
-| `--p-muted` | `172 159 144` | `#AC9F90` | Secondary text |
-| `--p-accent` | `242 86 35` | `#F25623` | Fill, focus, active state |
-| `--p-accent-quiet` | `255 138 92` | `#FF8A5C` | The accent **as text** |
+| `--p-surface` | `29 34 39` | `#1D2227` | Panel |
+| `--p-surface-raised` | `41 48 56` | `#293038` | Card, field |
+| `--p-line` | `66 76 90` | `#424C5A` | Divider |
+| `--p-line-strong` | `105 122 145` | `#697A91` | Component boundary |
+| `--p-text` | `216 221 229` | `#D8DDE5` | Text |
+| `--p-muted` | `150 162 177` | `#96A2B1` | Secondary text |
+| `--p-accent` | `53 120 207` | `#3578CF` | Fill, focus, active state |
+| `--p-accent-quiet` | `106 155 219` | `#6A9BDB` | The accent **as text** |
+| `--p-accent-dim` | `22 45 74` | `#162D4A` | The plate a chosen value lights on |
+
+The brand value is `#3376CE`. This theme lightens it by two levels per channel,
+because the exact value measures **2.96** against the raised surface where the
+boundary floor is 3.0, and darkening only lowers it further. The nudged value
+measures 3.01.
 
 ### Light
 
 The light theme derives on its own path and inherits nothing from the dark
-block, so every ratio is measured there too. The accent is darkened rather than
-reused: `#F25623` on a light surface reads as a highlight, not as a control.
+block, so every ratio is measured there too. Here the accent is the brand value
+unchanged: `#3376CE` measures 4.34 on the light surface and 3.52 on the raised
+one, so it needs no darkening for this ground.
 
 | Token | RGB | Hex |
 | --- | --- | --- |
-| `--p-ink` | `245 240 233` | `#F5F0E9` |
-| `--p-surface` | `252 249 243` | `#FCF9F3` |
-| `--p-surface-raised` | `234 226 214` | `#EAE2D6` |
-| `--p-line` | `190 175 156` | `#BEAF9C` |
-| `--p-line-strong` | `138 118 98` | `#8A7662` |
-| `--p-text` | `38 30 24` | `#261E18` |
-| `--p-muted` | `104 90 76` | `#685A4C` |
-| `--p-accent` | `186 58 18` | `#BA3A12` |
-| `--p-accent-quiet` | `158 48 14` | `#9E300E` |
+| `--p-ink` | `236 241 247` | `#ECF1F7` |
+| `--p-surface` | `247 250 253` | `#F7FAFD` |
+| `--p-surface-raised` | `220 227 237` | `#DCE3ED` |
+| `--p-line` | `165 179 196` | `#A5B3C4` |
+| `--p-line-strong` | `105 123 147` | `#697B93` |
+| `--p-text` | `26 32 40` | `#1A2028` |
+| `--p-muted` | `81 93 110` | `#515D6E` |
+| `--p-accent` | `51 118 206` | `#3376CE` |
+| `--p-accent-quiet` | `40 94 166` | `#285EA6` |
+| `--p-accent-dim` | `204 220 242` | `#CCDCF2` |
 
 ---
 
@@ -77,20 +90,25 @@ reused: `#F25623` on a light surface reads as a highlight, not as a control.
 
 These are not style preferences. Each one is a ratio that fails.
 
-**1. The accent is not a text colour.** Full accent measures **3.93** on the
+**1. The accent is not a text colour.** Full accent measures **3.01** on the
 raised surface, below the 4.5 WCAG 1.4.3 asks. It is a fill, a focus ring and an
 active state. Text that has to read as the accent uses `--p-accent-quiet`, which
-clears 4.5 on every surface (7.72 / 6.92 / 5.79 dark).
+clears 4.5 on every surface (6.25 / 5.59 / 4.65 dark).
 
-**2. A filled accent button takes near-black.** `--primary-foreground` is the
-ink: **5.23** dark, 5.00 light. White on the same fill is 3.43 and fails. For the
-same reason no filled button carries a whole-element hover fade —
-`hover:opacity-90` drops the label to 4.45 dark and 4.29 light.
+**2. A filled accent button takes white, and does not fully clear the floor.**
+`--primary-foreground` is white: **4.43** dark, 4.54 light. The near-black ink it
+replaced measures 4.05 and 4.00, so white is the better of the two and the dark
+theme still sits 0.07 under 4.5. That shortfall is a stated exception, not an
+oversight: no colour at this hue clears both floors at once, because a fill dark
+enough to carry white at 4.5 is too dark to clear 3.0 against the raised surface
+behind it. It is the one pair `contrast.ts` deliberately does not encode as a
+rule. For a separate reason no filled button carries a whole-element hover fade —
+`hover:opacity-90` drops the label further still.
 
-**3. Adjacent surfaces need a border.** Surface separation is 1.11 and 1.20, low
+**3. Adjacent surfaces need a border.** Surface separation is 1.12 and 1.20, low
 by construction because the family is dark. Two panels are told apart by their
 border, not by luminance, which is why `--p-line-strong` exists and why it has to
-clear 3.0 against *both* surfaces: 3.68 on surface, 3.08 on the raised one. An
+clear 3.0 against *both* surfaces: 3.66 on surface, 3.04 on the raised one. An
 earlier value cleared it against surface alone.
 
 ### Destructive splits the same way
@@ -109,13 +127,26 @@ The foreground being a different token per theme is why the contrast check
 resolves it rather than assuming one: a rule that assumed `--p-text` passed in
 dark and failed in light by 2.76.
 
+### Warning stopped following the accent
+
+`--warning` was `--p-accent-quiet`, which held while the accent was orange: the
+warning mark and the accent were the same hue by accident, and no other hue
+competed for the meaning. A blue accent would have drawn the warning toast in
+the colour the interface uses for the selected thing, so warning is now an amber
+of its own per theme — `#D9A441` dark, `#8A5A10` light — and it joins the check,
+because a literal that derives from nothing is unchecked by default.
+
+Three call sites ask for `var(--p-warning)`, which is not a declared token and
+resolves to nothing; they inherit their parent's colour and always have. Fixing
+them is a separate change, since it turns text amber that has never been amber.
+
 ### Focus
 
 `--ring` is the **full** accent, not a wash of it. At 0.55 alpha the composited
-ring measured 2.04 against a filled button and 2.44 against the surface behind
-it — under the 3.0 WCAG 1.4.11 asks of a focus indicator, and under the figure
-the check reported, because the check read the token and the token was not what
-got painted.
+ring fell under the 3.0 WCAG 1.4.11 asks of a focus indicator, and under the
+figure the check reported, because the check read the token and the token was
+not what got painted. At full strength the two agree: 4.05 on ink, 3.62 on a
+panel, 3.01 on a raised surface.
 
 Every control gets a ring from one rule in `@layer base` covering `button`,
 `summary` and the `button`, `slider` and `tab` roles. It uses `outline` rather
@@ -136,9 +167,11 @@ The same holds for the AOI outline colours in `frontend/src/lib/aoiStyle.ts`:
 they are drawn over satellite imagery and chosen to contrast with terrain, not
 with the interface.
 
-**The map area stays out of the warm drift.** The chassis is Mars sand; the
-viewport and any chrome touching a raster stay low-chroma, or the frame competes
-with the data for the reading.
+**The map area stays out of the chassis hue.** The viewport and any chrome
+touching a raster stay low-chroma and answer to the terrain, or the frame
+competes with the data for the reading. The rubber band leaflet-draw paints
+while a polygon is being drawn is part of that: it stays `#d8944a` over imagery
+rather than following the accent to blue.
 
 ---
 

--- a/frontend/scripts/check-contrast.ts
+++ b/frontend/scripts/check-contrast.ts
@@ -51,6 +51,7 @@ const CSS_HEX: Record<string, string> = {
   destructive: "--destructive",
   destructiveQuiet: "--destructive-quiet",
   success: "--success",
+  warning: "--warning",
 }
 
 function hexChannels(hex: string): Channels {

--- a/frontend/src/components/energy/controls.tsx
+++ b/frontend/src/components/energy/controls.tsx
@@ -146,8 +146,8 @@ export function RunButton({
       // The one filled button that cannot take a primitive verbatim: its label
       // states what the product returns and wraps to two lines, so min-h-9 with
       // its own leading is load-bearing and any fixed height truncates it. The
-      // rest of the primitive is here in full -- the fill, the near-black label,
-      // one disabled convention and the focus ring.
+      // rest of the primitive is here in full -- the fill, the white label, one
+      // disabled convention and the focus ring.
       className={cn(
         "flex min-h-9 w-full items-center justify-center gap-1.5 rounded-sm bg-primary px-3 py-2",
         "text-center text-emphasis font-semibold leading-snug text-primary-foreground",

--- a/frontend/src/components/leafletDrawPatch.ts
+++ b/frontend/src/components/leafletDrawPatch.ts
@@ -176,6 +176,10 @@ if (LDraw?.Polyline?.prototype) {
   const ensureRubberBand = (handler: RubberHandler) => {
     if (handler._rubberBand || !handler._map) return
     handler._rubberBand = L.polyline([], {
+      // Not the accent, and it does not follow the chassis: this line is drawn
+      // over imagery, so it answers to the terrain the way the AOI outlines in
+      // lib/aoiStyle.ts do. See docs/DESIGN.md, "Scientific ramps are out of
+      // scope".
       color: "#d8944a",
       weight: 2,
       opacity: 0.95,

--- a/frontend/src/components/ui/PageShell.tsx
+++ b/frontend/src/components/ui/PageShell.tsx
@@ -6,8 +6,7 @@
  * bordered surface with the system radius, entering on a spring. Everything
  * that fills the window instead -- settings, analysis, sign-in, projects and
  * the modals -- was `.terra-workspace`, a flat fill with hairlines ported from
- * an editor theme, and it inherited the sand palette without ever taking the
- * shape.
+ * an editor theme, and it inherited the palette without ever taking the shape.
  *
  * The difference was never a decision. A page has no raster underneath, so it
  * cannot borrow the reason the glass exists -- but the surface, the border, the

--- a/frontend/src/components/whiteboard/BoardSurface.tsx
+++ b/frontend/src/components/whiteboard/BoardSurface.tsx
@@ -2345,8 +2345,8 @@ export function BoardSurface({
         onCardsLoaded: (loaded, total) => setCards({ loaded, total }),
         groups,
         background: tokenColor("--p-ink", "#171717"),
-        line: tokenColor("--p-line", "#404040"),
-        accent: tokenColor("--p-accent", "#ed8744"),
+        line: tokenColor("--p-line", "#424C5A"),
+        accent: tokenColor("--p-accent", "#3578CF"),
         // The separation in force at the moment of the build, so a plane lands
         // at its true height rather than at the base for a frame.
         gap: gapRef.current,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -16,75 +16,92 @@
 :root,
 :root[data-theme="dark"] {
   /*
-    Mars sand. The neutrals carry the hue rather than leaving it to the accent,
-    so the chassis reads warm without the accent having to be everywhere.
+    A cool chassis. The neutrals carry the accent's hue rather than leaving it
+    to the accent, so the surfaces read cool without the accent having to be
+    everywhere.
 
     Every value below is measured, not chosen by eye. The ratios in the comments
     are WCAG 2.x against the surfaces each token actually lands on, and
     frontend/src/lib/contrast.ts re-derives them from these channels so a future
     edit that breaks one fails a check rather than shipping.
+
+    The family replaces the Mars sand it used to be, rotated to the accent's
+    hue at CONSTANT luminance: contrast is a function of relative luminance
+    alone, so each neutral keeps the ratio it was measured at while the hue
+    moves. Every separation below is the one the sand family already cleared,
+    which is why the numbers barely differ from the ones they replace.
   */
   --p-ink: 23 23 23;
-  --p-surface: 38 32 28;
-  --p-surface-raised: 54 45 39;
+  --p-surface: 29 34 39;
+  --p-surface-raised: 41 48 56;
   /*
-    Surface separation is 1.11 and 1.20 -- low by construction, because the
+    Surface separation is 1.12 and 1.20 -- low by construction, because the
     family is dark. Adjacent surfaces are told apart by their border, not by
     luminance, which is why --p-line-strong exists and why it clears WCAG
-    1.4.11 against BOTH surfaces: 3.68 on surface and 3.08 on the raised one.
+    1.4.11 against BOTH surfaces: 3.66 on surface and 3.04 on the raised one.
     An earlier value cleared it against surface alone, which is exactly the
     case the check exists to catch.
   */
-  --p-line: 86 73 63;
-  --p-line-strong: 138 117 100;
-  --p-text: 226 220 212;
+  --p-line: 66 76 90;
+  --p-line-strong: 105 122 145;
+  --p-text: 216 221 229;
   /*
     Muted text must clear WCAG 1.4.3 (4.5:1) on the darkest surface it lands on,
-    which is the raised one. This measures 5.20 there, 6.22 on surface and 6.93
+    which is the raised one. This measures 5.15 there, 6.18 on surface and 6.91
     on ink. Used only as a text colour, never as a background.
   */
-  --p-muted: 172 159 144;
+  --p-muted: 150 162 177;
   /*
     The accent is a fill, a focus ring and an active state.
 
-    Softened from 242 86 35, which read as a warning rather than as a control.
-    The lighter value measures BETTER against every surface -- 6.96 on ink,
-    6.24 on surface, 5.22 on the raised one, against 5.23/4.70/3.93 before --
-    so it now clears 4.5 as text too. --p-accent-quiet stays: it is what the
-    light theme's text uses, and one name for "the accent, readable" is worth
-    keeping on both.
+    #3376CE is the brand value. This theme lightens it by two levels per channel
+    to #3578CF, because the exact value measures 2.96 against the raised surface
+    where the boundary floor is 3.0. Darkening cannot recover it -- the raised
+    surface is darker still, so the ratio only falls further -- and the nudged
+    value measures 3.01. The two are not separable side by side.
 
-    What the change COSTS is the label on top of it. White on the old orange
-    measured 3.43, already under 4.5; on this one it is 2.58, under even 3.
-    --accent-foreground is the ink, at 6.96, and eight call sites that had
-    hardcoded `text-white` now use it.
+    A mid tone carries neither label cleanly: white measures 4.43 on this fill
+    and the near-black ink 4.05. No blue at this hue clears 4.5 in this theme,
+    because white would require a fill darker than the raised-surface boundary
+    allows. --accent-foreground is white, the better of the two, and the 0.07
+    shortfall against WCAG 1.4.3 is a stated exception rather than an oversight.
+    Text that has to READ as the accent uses --p-accent-quiet, which clears 4.5
+    on every surface: 6.25 on ink, 5.59 on surface, 4.65 on the raised one.
   */
-  --p-accent: 237 135 68;
-  --p-accent-quiet: 255 138 92;
-  --p-accent-dim: 74 38 22;
+  --p-accent: 53 120 207;
+  --p-accent-quiet: 106 155 219;
+  /*
+    The dim plate is one step darker than a constant-luminance rotation would
+    give. At the sand plate's own luminance the accent measured 3.00 on it,
+    which is the floor to the rounding and not past it; at this value it is
+    3.14, with the quiet variant at 4.86 and the boundary at 3.18.
+  */
+  --p-accent-dim: 22 45 74;
   --p-place: 120 138 148;
-  --p-haze: 196 128 84;
+  --p-haze: 104 146 203;
 }
 
 /*
   The light theme derives on its own path and inherits nothing from the block
-  above, so every ratio is measured here too. The accent is darkened rather than
-  reused: #F25623 on a light surface reads as a highlight, not as a control.
+  above, so every ratio is measured here too. Here the accent is the brand value
+  unchanged: #3376CE measures 4.34 on the light surface and 3.52 on the raised
+  one, so unlike the sand accent it needs no darkening for this ground, and the
+  white label on it clears 4.5 at 4.54.
 */
 :root[data-theme="light"] {
-  --p-ink: 245 240 233;
-  --p-surface: 252 249 243;
-  --p-surface-raised: 234 226 214;
-  --p-line: 190 175 156;
-  --p-line-strong: 138 118 98;
-  --p-text: 38 30 24;
-  --p-muted: 104 90 76;
-  /* Same rule as dark: a fill, not a text colour. 4.42 on the raised surface. */
-  --p-accent: 186 58 18;
-  --p-accent-quiet: 158 48 14;
-  --p-accent-dim: 240 214 198;
+  --p-ink: 236 241 247;
+  --p-surface: 247 250 253;
+  --p-surface-raised: 220 227 237;
+  --p-line: 165 179 196;
+  --p-line-strong: 105 123 147;
+  --p-text: 26 32 40;
+  --p-muted: 81 93 110;
+  /* Same rule as dark: a fill, not a text colour. 3.52 on the raised surface. */
+  --p-accent: 51 118 206;
+  --p-accent-quiet: 40 94 166;
+  --p-accent-dim: 204 220 242;
   --p-place: 90 110 122;
-  --p-haze: 196 150 118;
+  --p-haze: 131 161 202;
 }
 
 :root {
@@ -95,11 +112,17 @@
   --panel-solid: rgb(var(--p-ink));
   --card: rgb(var(--p-ink) / 0.45);
   --card-foreground: rgb(var(--p-text));
-  --popover: rgb(12 11 10);
+  --popover: rgb(10 11 13);
   --popover-foreground: rgb(var(--p-text));
 
   --primary: rgb(var(--p-accent));
-  --primary-foreground: rgb(var(--p-ink));
+  /*
+    White, in both themes, because the accent is now a mid tone. On the dark
+    theme's fill it measures 4.43 and on the light theme's 4.54; the near-black
+    ink it replaces measured 4.05 and 4.00. See --p-accent for why no value at
+    this hue clears 4.5 on both sides at once.
+  */
+  --primary-foreground: #ffffff;
 
   --secondary: rgb(var(--p-surface-raised) / 0.85);
   --secondary-foreground: rgb(var(--p-text));
@@ -107,7 +130,7 @@
   --muted-foreground: rgb(var(--p-muted));
 
   --accent: rgb(var(--p-accent));
-  --accent-foreground: rgb(var(--p-ink));
+  --accent-foreground: #ffffff;
   /* The accent where it has to be read rather than filled. See --p-accent. */
   --accent-quiet: rgb(var(--p-accent-quiet));
   --terra: rgb(var(--p-accent));
@@ -131,7 +154,18 @@
   --destructive: #a02c2c;
   --destructive-foreground: rgb(var(--p-text));
   --destructive-quiet: #e08a78;
-  --warning: rgb(var(--p-accent-quiet));
+  /*
+    An amber of its own, one value per theme, rather than the accent.
+
+    It used to be --p-accent-quiet, which worked while the accent was orange:
+    the warning mark and the informational one were the same hue by accident
+    and nobody could tell, because there was no other hue for them to be. With
+    a blue accent that inheritance would have drawn the warning toast in the
+    colour the interface uses for "this is the selected thing", which is the
+    one meaning it must not carry. Measured 7.97 / 7.13 / 5.93 dark and
+    5.21 / 5.65 / 4.58 light, so it clears the mark floor on every surface.
+  */
+  --warning: #d9a441;
   --success: #6f9c5a;
 
   /*
@@ -173,8 +207,8 @@
   /* Full accent, not a wash of it. At 0.55 the composited ring measured under
      the 3.0 WCAG 1.4.11 asks of a focus indicator, and under the figure the
      contrast check verifies, because the check reads the token and the token
-     was not what got painted. At full strength the two agree: 6.96 on ink,
-     6.24 on the panel, 5.22 on a raised surface. */
+     was not what got painted. At full strength the two agree: 4.05 on ink,
+     3.62 on the panel, 3.01 on a raised surface. */
   --ring: rgb(var(--p-accent));
 
   --font-display: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
@@ -196,6 +230,7 @@
   --destructive: #b33a1a;
   --destructive-foreground: rgb(var(--p-surface));
   --destructive-quiet: #9e2b25;
+  --warning: #8a5a10;
   --success: #3f6b2c;
   /* Darkened for the light ground; same four floors, same search. */
   --series-ndvi: #4b9b55;
@@ -311,7 +346,7 @@
     follows the border radius and does not fight the shadow utilities a floating
     panel needs.
 
-    --ring is the full accent: 5.23 on ink, 4.70 on a panel, 3.93 on a raised
+    --ring is the full accent: 4.05 on ink, 3.62 on a panel, 3.01 on a raised
     surface, all clearing the 3.0 WCAG 1.4.11 asks of a focus indicator.
   */
   button:focus-visible,
@@ -540,10 +575,10 @@
   The nav item, the one shared treatment left from the workspace chrome.
 
   Everything else in this block -- .terra-workspace and the eight .ar-* rules --
-  was a VS Code Dark Modern port, including a blue selection, and it made the
-  application run two unrelated palettes: the map panels were warm and
-  tokenised while every full screen was cold and hardcoded. Retiring it is why
-  a re-theme now moves every screen.
+  was a VS Code Dark Modern port with its own hardcoded selection, and it made
+  the application run two unrelated palettes: the map panels were tokenised
+  while every full screen was hardcoded. Retiring it is why a re-theme now
+  moves every screen.
 
   Kept unlayered like the other component classes, and named for what it is
   rather than for where it came from.
@@ -557,10 +592,10 @@
 }
 
 /*
-  The active row. Accent at 45 percent composites to rgb(119 73 43), on which
-  the label measures 5.56 -- but --p-muted measures 2.93 there, which is why the
-  count beside the label follows the label up on this row rather than staying
-  the one unreadable thing on it.
+  The active row. Accent at 45 percent composites to rgb(36 67 106), on which
+  the label measures 7.38 -- but --p-muted measures 3.88 there, still short of
+  the 4.5 a text colour asks, which is why the count beside the label follows
+  the label up on this row rather than staying the one unreadable thing on it.
 */
 .nav-item.is-active {
   background: color-mix(in srgb, rgb(var(--p-accent)) 45%, transparent);
@@ -607,7 +642,7 @@
   }
 }
 
-/* Title bar bottom edge — terra gradient (haze → ochre → dust → fade) */
+/* Title bar bottom edge — terra gradient (haze → accent → line → fade) */
 .titlebar-terra::after {
   content: "";
   position: absolute;

--- a/frontend/src/lib/contrast.ts
+++ b/frontend/src/lib/contrast.ts
@@ -39,34 +39,36 @@ export function contrast(a: Channels, b: Channels): number {
 export const TOKENS = {
   dark: {
     ink: [23, 23, 23],
-    surface: [38, 32, 28],
-    surfaceRaised: [54, 45, 39],
-    line: [86, 73, 63],
-    lineStrong: [138, 117, 100],
-    text: [226, 220, 212],
-    muted: [172, 159, 144],
-    accent: [237, 135, 68],
-    accentQuiet: [255, 138, 92],
-    accentDim: [74, 38, 22],
+    surface: [29, 34, 39],
+    surfaceRaised: [41, 48, 56],
+    line: [66, 76, 90],
+    lineStrong: [105, 122, 145],
+    text: [216, 221, 229],
+    muted: [150, 162, 177],
+    accent: [53, 120, 207],
+    accentQuiet: [106, 155, 219],
+    accentDim: [22, 45, 74],
     destructive: [160, 44, 44],
     success: [111, 156, 90],
-    destructiveForeground: [226, 220, 212],
+    warning: [217, 164, 65],
+    destructiveForeground: [216, 221, 229],
     destructiveQuiet: [224, 138, 120],
   },
   light: {
-    ink: [245, 240, 233],
-    surface: [252, 249, 243],
-    surfaceRaised: [234, 226, 214],
-    line: [190, 175, 156],
-    lineStrong: [138, 118, 98],
-    text: [38, 30, 24],
-    muted: [104, 90, 76],
-    accent: [186, 58, 18],
-    accentQuiet: [158, 48, 14],
-    accentDim: [240, 214, 198],
+    ink: [236, 241, 247],
+    surface: [247, 250, 253],
+    surfaceRaised: [220, 227, 237],
+    line: [165, 179, 196],
+    lineStrong: [105, 123, 147],
+    text: [26, 32, 40],
+    muted: [81, 93, 110],
+    accent: [51, 118, 206],
+    accentQuiet: [40, 94, 166],
+    accentDim: [204, 220, 242],
     destructive: [179, 58, 26],
     success: [63, 107, 44],
-    destructiveForeground: [252, 249, 243],
+    warning: [138, 90, 16],
+    destructiveForeground: [247, 250, 253],
     destructiveQuiet: [158, 43, 37],
   },
 } as const satisfies Record<string, Record<string, Channels>>
@@ -88,10 +90,18 @@ export interface ContrastRule {
  * Every pair the interface paints, and the floor each has to clear.
  *
  * `accent` is checked at 3.0, not 4.5, and only as a fill, a focus ring and an
- * active state. It measures 3.93 on the raised surface, so it is not a text
+ * active state. It measures 3.01 on the raised surface, so it is not a text
  * colour; text that has to read as the accent uses `accentQuiet`. Listing it
  * here at 4.5 would either fail honestly or push the palette away from the
- * brand orange, and neither is what the token is for.
+ * brand value, and neither is what the token is for.
+ *
+ * The label ON the accent fill is not listed either, and that one is a stated
+ * exception rather than a category difference: white measures 4.43 on the dark
+ * theme's fill and 4.54 on the light theme's, so the dark side sits 0.07 under
+ * WCAG 1.4.3. No colour at this hue clears both floors at once -- white would
+ * need a fill darker than the 3.0 boundary against the raised surface permits.
+ * A rule here would fail on a trade that was made deliberately; see the comment
+ * on --p-accent in index.css.
  */
 export const RULES: readonly ContrastRule[] = [
   {
@@ -155,15 +165,28 @@ export const RULES: readonly ContrastRule[] = [
    * fail, and nothing caught it, because nothing was looking.
    *
    * 3.0 rather than 4.5: these are meaningful graphics under WCAG 1.4.11, not
-   * text. Success stays green rather than joining the sand family, because
-   * green and orange are the only thing separating a success toast from a
-   * warning one once both are marks of the same shape.
+   * text. Success stays green rather than joining the accent family, because
+   * hue is the only thing separating a success toast from a warning one once
+   * both are marks of the same shape -- and --warning is the accent, so the
+   * green has to stay off it.
    */
   {
     fg: "success",
     on: ["ink", "surface", "surfaceRaised"],
     min: 3.0,
     why: "the success mark on a toast, which is a graphic rather than text",
+  },
+  /*
+   * Warning joins the list because it stopped deriving from a checked token.
+   * It used to be --p-accent-quiet and inherited that token's 4.5 floor for
+   * free; it is now an amber of its own, and an unchecked literal is exactly
+   * what the destructive pair was when it shipped failing.
+   */
+  {
+    fg: "warning",
+    on: ["ink", "surface", "surfaceRaised"],
+    min: 3.0,
+    why: "the warning mark on a toast, which no longer follows the accent because the accent is blue",
   },
 ]
 


### PR DESCRIPTION
## Summary

The accent becomes `#3376CE`, and the neutrals follow it rather than staying warm. Each one was rotated to the accent's 214 degrees at **constant luminance**, so every pair keeps the ratio it was measured at while the hue moves — surface separation is still 1.12 and 1.20, and `--p-line-strong` still clears WCAG 1.4.11 on both surfaces at 3.66 and 3.04.

## Changes

**Two values could not be taken verbatim.**

The dark theme lightens the accent by two levels per channel to `#3578CF`, because the exact value measures 2.96 against the raised surface where the boundary floor is 3.0. Darkening cannot recover it — that surface is darker still — so the ratio only falls further. The nudged value measures 3.01. The light theme takes `#3376CE` unchanged at 4.34 on surface and 3.52 on raised.

The label on a filled accent takes white instead of the near-black ink: 4.43 dark and 4.54 light, against 4.05 and 4.00 for the ink. The dark side sits **0.07 under 4.5** and no colour at this hue clears both floors at once, because a fill dark enough to carry white is too dark to clear 3.0 against the raised surface. It is recorded as a stated exception in `index.css` and `contrast.ts` rather than encoded as a rule that would fail on a deliberate trade.

**`--warning` stopped following the accent.** It was `--p-accent-quiet`, which held while the accent was orange; with blue it would have drawn the warning toast in the colour that means "selected". It is now an amber per theme, `#D9A441` and `#8A5A10`, and it joins the contrast check — a literal that derives from nothing is unchecked by default.

**Out of scope, per the rule the design doc already states:** the scientific ramps, the vegetation index series, and chrome drawn over rasters. The leaflet-draw rubber band stays `#d8944a` for that reason, with a comment saying so, since a blue line loses a dark scene.

| | dark | light |
|---|---|---|
| ink | `#171717` | `#ECF1F7` |
| surface | `#1D2227` | `#F7FAFD` |
| surface-raised | `#293038` | `#DCE3ED` |
| line / line-strong | `#424C5A` / `#697A91` | `#A5B3C4` / `#697B93` |
| text / muted | `#D8DDE5` / `#96A2B1` | `#1A2028` / `#515D6E` |
| accent / quiet / dim | `#3578CF` / `#6A9BDB` / `#162D4A` | `#3376CE` / `#285EA6` / `#CCDCF2` |

## Testing

- `npm run check:contrast` — 46 pairs across both themes, all clear their floor, and the channels in `contrast.ts` match `index.css`
- `npx tsc --noEmit` clean
- `npm run build` compiles
- Checked in `wails dev` against the running app

## Checklist

- [x] Contrast check extended to cover `--warning`, which previously derived from a checked token and now does not
- [x] `docs/DESIGN.md` palette tables and the three measured rules updated (they were already stale, listing `#F25623` while the CSS carried `237 135 68`)
- [x] No console errors