### PR TITLE
chore(release): 0.4.0, named Amazon

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: "If you use TERRA, please cite it as below."
 type: software
 title: "TERRA: Desktop land-cover classification from Sentinel-2 time series"
-version: 0.2.0
-date-released: "2026-07-01"
+version: 0.4.0
+date-released: "2026-08-23"
 url: "https://github.com/rexionmars/TERRA"
 repository-code: "https://github.com/rexionmars/TERRA"
 license: GPL-3.0-only

--- a/frontend/src/lib/whatsNew.ts
+++ b/frontend/src/lib/whatsNew.ts
@@ -7,6 +7,18 @@ export type WhatsNewEntry = {
 /** Newest first. Keep in sync with AppVersion / Git tags when cutting a release. */
 export const WHATS_NEW: WhatsNewEntry[] = [
   {
+    version: "0.4.0",
+    title: "Amazon — the energy result in a column of its own",
+    items: [
+      "Energy results are read in a column rather than along the map's foot, with the figures worth quoting at the head of it",
+      "An analysis that stalls now stops and says so, instead of waiting without end on a subprocess that will not answer",
+      "A panel that fails leaves the rest of the board readable, where before it took the window with it",
+      "Work files no longer accumulate without bound: promoted rasters and abandoned work directories are swept once they are old enough that nothing can still be reading them",
+      "An export that cannot be finished reports the failure, rather than handing back the path of a file that was truncated on the way out",
+      "Analyses now run in the same import environment the Settings screen inspects. On a machine whose packages live only in the per-user site directory, a run will refuse where it previously imported -- which is what that screen was already reporting, and was the one place the two disagreed",
+    ],
+  },
+  {
     version: "0.3.0",
     title: "Ember — the studio, the crop in three dimensions, and energy",
     items: [

--- a/version.go
+++ b/version.go
@@ -3,8 +3,8 @@ package main
 import "strings"
 
 // AppVersion is the product SemVer without a "v" prefix.
-// Override at link time: go build -ldflags "-X main.AppVersion=0.3.0"
-var AppVersion = "0.3.0"
+// Override at link time: go build -ldflags "-X main.AppVersion=0.4.0"
+var AppVersion = "0.4.0"
 
 // GetAppVersion returns the embedded product version for the UI (What's New, About).
 func (a *App) GetAppVersion() string {


### PR DESCRIPTION
## The number

**MINOR**, by the table in [docs/RELEASING.md](docs/RELEASING.md).

Most of what landed since `v0.3.0` earns no bump at all under that document's
own rule — *"internal refactors, tests, and CI that do not change the above are
not release-worthy by themselves."* The five-package restructure, the lint
configuration, `-race`, the type-contract guard, the 242 frontend tests and the
Python lock change none of the workflows, install flavors, `TERRA_*` variables
or sidecar contracts it names as the public surface.

What does earn it:

- **A new capability.** The energy result is read in a column of its own —
  `EnergyStatusPanel` out, `EnergyReadingColumn`, `readingSections` and
  `headlineFigures` in. A new reading surface, not a repair.
- **A code name and a splash still**, under a scheme RELEASING.md now documents.
- **Fixes**: a panel crash no longer takes the window, a stalled analysis stops
  instead of hanging, temp files stop accumulating, an export no longer reports
  success over a truncated file, a data race on the store, and a run id no
  longer returned for a row that was never written.

Precedence: a release that mixes types takes the highest bump. MINOR.

**Not MAJOR.** The sidecar JSON contract is byte-identical — verified by feeding
six requests to the old and new dispatcher and comparing stdout, stderr and exit
status. No `TERRA_*` removed. Zip layout untouched.

## CITATION.cff was two releases behind

It said `0.2.0`. It missed the `0.3.0` bump entirely, so it has been stale since
July. That is the file Zenodo and JOSS read, which makes it the one place where
a wrong number costs something outside this repository. `date-released` moves
with it — adjust if the tag is cut on a different day.

## One item in What's New is a warning

Sidecar runs now set `PYTHONNOUSERSITE`, so a machine whose packages live only
in the per-user site directory will see a run refuse where it previously
imported. The Settings screen was already reporting that interpreter as not
ready; the run and the report simply disagreed until now. It is in the list
because it is the one change here that can turn a working install into a
failing one.

## After merging

```bash
git checkout main && git pull
git tag -a v0.4.0 -m "TERRA v0.4.0 Amazon — the energy result in a column of its own"
git push origin v0.4.0
```

The tag push is deliberately left to you: it triggers `release.yml`, which
builds six platform and flavor combinations and publishes the assets.