### PR TITLE
feat(design): the viewport gets a chassis of its own, and the accent lab returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ can be installed from Settings › System into the environment already in use.
 | [Troubleshooting](docs/TROUBLESHOOTING.md) | Python, STAC, models, macOS |
 | [Contributing](CONTRIBUTING.md) | Issues, PRs, tests |
 | [Design](docs/DESIGN.md) | Visual tokens |
+| [Performance](docs/PERFORMANCE.md) | Frame rate, memory, and what was measured |
 | [JOSS paper draft](paper/paper.md) | Manuscript and BibTeX |
 
 ## Architecture

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -47,21 +47,31 @@ from `--p-*` in a plain `:root` block, and `@theme inline` maps those to
 
 | Token | RGB | Hex | Role |
 | --- | --- | --- | --- |
-| `--p-ink` | `26 26 26` | `#1A1A1A` | App background |
-| `--p-surface` | `37 37 37` | `#252525` | Panel |
-| `--p-surface-raised` | `53 53 53` | `#353535` | Card, field |
+| `--p-ink` | `33 33 33` | `#212121` | App background |
+| `--p-surface` | `47 47 47` | `#2F2F2F` | Panel |
+| `--p-surface-raised` | `67 67 67` | `#434343` | Card, field |
 | `--p-line` | `75 75 75` | `#4B4B4B` | Divider |
-| `--p-line-strong` | `126 126 126` | `#7E7E7E` | Component boundary |
+| `--p-line-strong` | `142 142 142` | `#8E8E8E` | Component boundary |
 | `--p-text` | `221 221 221` | `#DDDDDD` | Text |
-| `--p-muted` | `161 161 161` | `#A1A1A1` | Secondary text |
+| `--p-muted` | `175 175 175` | `#AFAFAF` | Secondary text |
 | `--p-accent` | `237 135 68` | `#ED8744` | Fill, focus, active state |
-| `--p-accent-quiet` | `236 128 57` | `#EC8039` | The accent **as text** |
-| `--p-accent-dim` | `75 37 11` | `#4B250B` | The plate a chosen value lights on |
+| `--p-accent-quiet` | `240 155 99` | `#F09B63` | The accent **as text** |
+| `--p-accent-dim` | `83 40 12` | `#53280C` | The plate a chosen value lights on |
 
-`--p-line-strong` is 126 and not the 120 the surfaces suggest. At 120 it
-measured **2.78** against the raised surface, under the 3.0 floor: lifting a
-surface does not lift the boundary that separates it, and this is the case the
-check exists to catch.
+`--p-line-strong` is 142, and every digit of it is a measurement rather than a
+choice. The value has been re-derived four times, each time by the same check
+catching the same mistake: 120 gave **2.78** against the raised surface, 126 held
+**3.02** while that surface was 53 and fell to **2.98** at 54, and 127 gave
+**2.47** once it reached 67. Lifting a surface does not lift what has to be seen
+against it.
+
+The same lift moved three more tokens, and none of them was chosen either.
+`--p-muted` is 175 because 161 read **3.83** on the raised surface, under the 4.5
+floor for body-adjacent text. `--destructive-quiet` moved from `#E08A78` to
+`#E59E8F` because it read **3.80** there — a failure the accent lab cannot see,
+since status colours take no part in its rules and only `check:contrast` covers
+them. `--p-accent-quiet` and `--p-accent-dim` came out of the lab with the rest
+of the family.
 
 ### Light
 
@@ -90,7 +100,7 @@ at all.
 
 These are not style preferences. Each one is a ratio that fails.
 
-**1. The accent is not a text colour.** It happens to measure 4.76 on the raised
+**1. The accent is not a text colour.** It happens to measure 3.84 on the raised
 surface, which is a property of this accent being a light one rather than a rule
 the token holds — the blue before it measured 3.01 there. It is a fill, a focus
 ring and an active state, and text that has to read as the accent uses
@@ -98,16 +108,16 @@ ring and an active state, and text that has to read as the accent uses
 (6.39 / 5.63 / 4.51 dark).
 
 **2. A filled accent button takes the ink.** `--primary-foreground` is
-`--p-ink`, near-black in the dark theme and near-white in the light one: **6.75**
+`--p-ink`, near-black in the dark theme and near-white in the light one: **6.25**
 dark, 5.02 light. White on the dark fill is 2.58. The label is a consequence of
 the fill and not a constant — under the blue accent, which was a mid tone, it was
 white at 4.43 and that was a stated exception. There is no exception now.
 
-**3. Adjacent surfaces need a border.** Surface separation is 1.14 and 1.25, low
-by construction because the family is dark. Two panels are told apart by their
-border, not by luminance, which is why `--p-line-strong` exists and why it has to
-clear 3.0 against *both* surfaces: 3.78 on surface, 3.02 on the raised one. At
-120 the raised surface measured 2.78, which is what raised it to 126.
+**3. Adjacent surfaces need a border.** Surface separation is 1.20 and 1.35 —
+wider than any earlier reading of this family, because the surfaces were lifted
+apart rather than merely lifted. Two panels are still told apart by their border
+rather than by luminance, which is why `--p-line-strong` exists and why it has to
+clear 3.0 against *both* surfaces: 4.09 on surface, 3.02 on the raised one.
 
 ### Destructive splits the same way
 
@@ -142,8 +152,8 @@ separation is hardest to see and most worth keeping.
 `--ring` is the **full** accent, not a wash of it. At 0.55 alpha the composited
 ring fell under the 3.0 WCAG 1.4.11 asks of a focus indicator, and under the
 figure the check reported, because the check read the token and the token was
-not what got painted. At full strength the two agree: 6.75 on ink, 5.95 on a
-panel, 4.76 on a raised surface.
+not what got painted. At full strength the two agree: 6.25 on ink, 5.20 on a
+panel, 3.84 on a raised surface.
 
 Every control gets a ring from one rule in `@layer base` covering `button`,
 `summary` and the `button`, `slider` and `tab` roles. It uses `outline` rather
@@ -169,6 +179,47 @@ touching a raster stay low-chroma and answer to the terrain, or the frame
 competes with the data for the reading. The rubber band leaflet-draw paints
 while a polygon is being drawn is part of that: it stays `#d8944a` over imagery
 rather than following the accent to blue.
+
+---
+
+## The 3D viewport is chassis, and repaints live
+
+The studio's two WebGL surfaces are the interface, not the data, and they are
+painted from the palette: `--p-ink` is the background and the fog, `--p-line` is
+the ground grid and an empty area's footprint, `--p-accent` is the selected
+plane's outline, the links between corresponding rasters, and the path and
+arrowheads through a selection. `standScene.ts` takes the same two chassis
+tokens for its ground and its haze.
+
+**They re-read the tokens when the palette moves.** A CSS custom property
+re-resolves for free; a WebGL scene cannot, because it reads the tokens once at
+build into colours it then holds as its own numbers. So the studio kept whichever
+palette it opened in until something unrelated rebuilt it. Both scenes now
+subscribe through `frontend/src/lib/paletteWatch.ts` and repaint **in place** — a
+rebuild would decode every raster again, refetch the canopy mesh, and send
+dragged planes back to the layout's first answer, all for a colour.
+
+Two attributes are watched, because the palette moves in two ways: `data-theme`,
+which next-themes writes with the resolved theme, and `style`, which AccentLab
+writes the `--p-*` channels to inline while a candidate accent is being judged.
+
+**The scenes can be pinned off the tokens.** `setViewportPaletteOverride` gives
+them a palette of their own. Nothing sets it in normal use — one null check per
+repaint — and it exists because the stylesheet and the scenes read the same
+tokens by design, which is correct for shipping and makes the two impossible to
+judge apart: moving a token to see it in the viewport moves every panel around
+the viewport at the same time. AccentLab's scope row uses it to hold one still
+while the other moves.
+
+### What inside the viewport is not chassis
+
+Three groups stay literal, and each is data or an instrument rather than chrome:
+
+| What | Where | Why it does not follow the theme |
+| --- | --- | --- |
+| Rover lens and echo rings | `boardScene.ts` | Drawn **over a raster**, not over a surface. Their ground is the imagery, so `--p-text` would invert them to near-black on it in the light theme. White with the surroundings dimmed is the measure that works against any scene. |
+| `CLEAR_SKY`, `OVERCAST_SKY`, `SOIL_BOUNCE`, `CANOPY_BOUNCE` | `standScene.ts` | Radiances the light model reads. A sky that followed the accent would report the theme instead of the atmosphere. |
+| `ORGAN_COLOR` | `standScene.ts` | Says blade from stem. Botanical, and the whole job of that view. |
 
 ---
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,185 @@
+# Performance
+
+What has been measured about this application's frame rate and memory, what
+turned out to cause it, and what was cleared. Written after an investigation
+that spent most of its time in the wrong places, so the record of what is *not*
+the cause is as much of the point as the record of what is.
+
+---
+
+## The window, not the page
+
+**A frameless macOS window slowed every other window sharing its space.**
+
+Wails builds the NSWindow in `WailsContext.m`, and it adds
+`NSWindowStyleMaskTitled` only when the window is not frameless:
+
+```objc
+if( !frameless ) {
+    if (!hideTitleBar) styleMask |= NSWindowStyleMaskTitled;
+    styleMask |= NSWindowStyleMaskClosable;
+}
+```
+
+So `Frameless: true` produced a borderless window, and macOS composites a
+borderless window off the path it uses for titled ones. The cost did not land in
+this application at all — it landed in WindowServer, and it was paid by every
+window on the same space.
+
+**The measurement that proved it.** Safari running the WebGL aquarium
+benchmark, on the same machine at the same moment:
+
+| Space | Safari's own frame rate |
+| --- | --- |
+| Any space without this window | 60fps, constant |
+| The space this window occupied | 27–41fps |
+
+A different application, slowed by ours being present. Nothing measured inside
+our page could have shown this, which is why the investigation took as long as
+it did.
+
+**The fix is `Frameless: false`.** The look is kept by `TitleBar`:
+`mac.TitleBarHidden()` gives a titled window with a transparent, title-less bar
+and full-size content — the traffic lights over the application's own header,
+which is what frameless was being used for. Custom drag regions are unaffected:
+`--wails-draggable` is handled in the JavaScript runtime and does not depend on
+the style mask.
+
+`TitleBarHiddenInset()` is the same thing plus `UseToolbar`, and the toolbar
+pushes the traffic lights in from the corner — right and down, past the `4.5rem`
+the header reserves — into the wordmark. Hidden, not hidden-inset.
+
+### What this looked like from inside
+
+Every figure below was measured while the page was being delivered frames at
+11Hz. None of them points at the cause:
+
+| Figure | Reading |
+| --- | --- |
+| Frame work (controls, draw, helper, labels) | **0.0ms** |
+| Draw calls / triangles | **9 / 72** |
+| Pointer handler cost | **0.0ms**, events arriving at 120/s |
+| WebContent process CPU | **2.8%**, 97% of samples parked in `mach_msg2_trap` |
+| WebKit GPU process CPU | **0.1%** |
+| WindowServer CPU | 35.6% |
+
+Everything was waiting and nothing in the application was the reason.
+
+---
+
+## Tested and cleared
+
+Each of these was a hypothesis with a plausible mechanism, tested in a
+**production build**, and found not to be the cause. They are listed so the next
+person does not spend the time again.
+
+| Suspect | Mechanism proposed | Result |
+| --- | --- | --- |
+| `backdrop-filter` on `.panel` | 224 elements, each forcing a compositing layer, a backdrop buffer and an 18px blur per frame | No change. 65ms → 74ms gap, which is noise |
+| Multisampling (`antialias: true`) | MSAA resolve is a full extra pass over a retina-sized buffer before the compositor can take it | No change |
+| Canvas alpha channel (`alpha: true`) | An alpha canvas must be blended by the compositor every frame; an opaque one need not be | 24Hz → 26Hz, which is noise |
+| Drawing buffer size | WebKit resolves and copies the buffer into a window-server surface every frame; 2808×1592 at 2x is 4.5M pixels | 11Hz → 24Hz. Real, and a symptom of the window problem rather than a cause |
+| Rasters as base64 data URIs | Megabyte strings held per plane | Not supported by the numbers: a run's PNGs total 392KB, the largest 168KB |
+| Development mode | Vite serving modules one at a time, React's development build, HMR, and an fsevents watcher over the whole repository including `.venv` and `node_modules` | **Real and large.** Always measure a `wails build` binary |
+
+---
+
+## The 60fps ceiling on macOS
+
+WebKit paces page rendering updates near 60fps, so `requestAnimationFrame` is
+delivered at 60Hz on a display running at 120. This is WKWebView's, not the
+display's: `system_profiler` reports the built-in panel at 120.00Hz while the
+studio's own readout showed 59–60.
+
+The preference is `PreferPageRenderingUpdatesNear60FPSEnabled` and there is **no
+public API for it**. The only route is
+`[WKPreferences _setEnabled:NO forFeature:]`, which is private.
+
+**This was implemented, measured and then removed.** It works — the page rate
+went to 111–125Hz, the variation being the display's own adaptive refresh rather
+than instability. It was taken out anyway:
+
+- The problem worth solving was 11Hz, and it is solved. 60 against 120 is polish
+  on something that already works.
+- A private preference only pays while Apple leaves it in place, and the
+  implementation was guarded to fail silently — so a macOS update returns the
+  ceiling without warning. The feature is temporary by construction.
+
+Published reports say the restriction was lifted in macOS 26 and the preference
+ignored. That is not what this machine does: macOS 26.6.1, a 120Hz display, and
+WKWebView delivering 60. Test rather than trust the note.
+
+---
+
+## React: one component holds the application
+
+`App` carries 77 `useState` hooks across itself and `AppBody`, renders every
+screen inline, and there is no `React.memo` anywhere in the frontend. Any
+`setState` there reconciles the whole tree. Two paths did it far more often than
+the work justified, and both are fixed by holding the value outside React and
+letting the one component that wants it subscribe:
+
+| Value | Was | Now |
+| --- | --- | --- |
+| The map's centre and zoom | Written into `App` on every frame of a drag, so the whole tree reconciled 60 times a second to update one line of text in the title bar | `lib/mapPose.ts`; the settled value still reaches `App` on `moveend`, where persistence wants it |
+| Which tool panel is open | In `App` because two components read it and the map screen remounts on every return, which a `useState` inside the screen forgot | `lib/panelSelection.ts`; a module outlives the remount for free |
+
+`AnimatePresence` also carried `mode="wait"`, under which the leaving screen had
+to finish its 240ms exit before the arriving one was allowed to mount — and the
+mount is the expensive half, since a screen here builds Leaflet, its overlays
+and sometimes the studio.
+
+**Still open:** the screens unmount and remount on every change. That is the
+larger remaining cost in navigation and it is deliberate for now — keeping them
+mounted means their effects keep running and the studio holds a WebGL context,
+and WebKit caps how many of those may exist.
+
+---
+
+## Measuring
+
+### The studio's own readout
+
+Seven figures, each switched separately in **Profile → Telemetry**, all off by
+default. `lib/studioTelemetry.ts` says what each one is for. The order in the
+settings page is the order to reach for them in:
+
+1. **Page frame rate** — how fast the browser delivers frames, from a loop that
+   draws nothing. First, always: it is what says whether the studio is the cause
+   at all. **It is the one figure that costs something** — it keeps the page
+   animating for as long as the studio is open.
+2. **Board frame rate** — the board draws on demand, so a long interval on a
+   still scene is idling, not a fault.
+3. **Frame work** — the only figure that accuses the scene itself.
+4. **Pointer cost** — pointer handlers run outside the animation callback, so an
+   expensive one blocks frames without appearing in the frame timing.
+5. **Draw calls**, **GPU resources**, **Drawing buffer** — what is being
+   submitted, what is being held, and how much of the frame there is to move.
+
+### Traps in the tools
+
+**`ps %CPU` on macOS is a lifetime average, not an instantaneous reading.** A
+process that was busy an hour ago reports a high figure while idle. Use
+`top -l N -s S` and read a sample after the first, which is the only one that is
+instantaneous.
+
+**On a render-on-demand surface, the interval between frames is not the frame
+time.** The gap includes however long nothing asked for a frame. Measure the
+work inside the callback separately, or a still scene reads as a slow scene.
+
+**Sample the right process.** WebKit draws canvas and WebGL in a separate GPU
+process, so a stack sample of the web content process shows almost no WebGL
+work. `sample <pid>` both, and read the CPU of each.
+
+**Attribute memory with `vmmap -summary <pid>`.** The region table separates the
+JavaScript heap from `WebKit Malloc`, which is where WebCore's own strings and
+image buffers live — a distinction that rules out or in "some JavaScript is
+holding objects" in one command.
+
+### The control experiment
+
+The one that ended this investigation in thirty seconds, after hours inside the
+page: **run a different application's benchmark on the same space.** If it is
+also slow there and fast elsewhere, nothing inside this application's page is
+the cause. Ask for that control the moment a symptom includes anything outside
+the application's own window.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -68,6 +68,33 @@ Set `TERRA_APP_DIR` to the directory that contains `sidecar/`, `areas/`, and
 Runs live under the OS user config directory for `geosense-infer` (legacy name),
 not inside the `.app` bundle. Clearing Application Support removes history.
 
+## The interface feels slow
+
+### Everything is slow, including other applications
+
+Check whether it is this application at all: run a benchmark in another app —
+Safari on <https://webglsamples.org/aquarium/aquarium.html> shows its own frame
+rate — on the same macOS space, and then on a different one. If the other
+application is also slow beside TERRA and fast away from it, the cause is the
+window rather than anything on screen inside it. That symptom had one cause
+here, and it is fixed; see [Performance](PERFORMANCE.md).
+
+### The studio stutters while orbiting
+
+Switch on **Profile → Telemetry → Page frame rate** first. It measures how fast
+the browser is delivering frames at all, which is what says whether the studio
+is the cause. A low page rate with the frame work near zero means nothing being
+drawn in the studio is the reason.
+
+Leave it off afterwards: it is the one figure that costs something to have on.
+
+### It is slow when run from source but not from a build
+
+Expected, and worth measuring past. `wails dev` serves modules one at a time,
+runs React's development build, keeps a hot-reload socket open and watches the
+whole repository tree — `.venv` and `node_modules` included. Measure a
+`wails build` binary before concluding anything about performance.
+
 ## Still stuck?
 
 Open an issue at https://github.com/rexionmars/TERRA/issues with OS, TERRA

--- a/editmenu_darwin.go
+++ b/editmenu_darwin.go
@@ -1,0 +1,22 @@
+//go:build darwin
+
+package main
+
+/*
+#cgo CFLAGS: -x objective-c -fobjc-arc
+#cgo LDFLAGS: -framework Foundation
+void TerraDisableAutoEditMenuItems(void);
+*/
+import "C"
+
+/*
+trimEditMenu declines the two Edit-menu items AppKit adds on its own.
+
+Called before wails.Run, because the menu is built during it and a default
+registered afterwards is registered too late. See editmenu_darwin.m for which
+items these are, why the menu itself has to stay, and why the values are
+registered rather than written.
+*/
+func trimEditMenu() {
+	C.TerraDisableAutoEditMenuItems()
+}

--- a/editmenu_darwin.m
+++ b/editmenu_darwin.m
@@ -1,0 +1,33 @@
+#import <Foundation/Foundation.h>
+
+/*
+ Keeps AppKit from adding its own items to the Edit menu.
+
+ The Edit menu here is Wails': Undo, Redo, Cut, Copy, Paste, Paste and Match
+ Style, Delete, Select All. AppKit appends four more to any Edit menu it finds
+ -- Speech, AutoFill, Start Dictation and Emoji & Symbols -- and two of those
+ can be declined. Neither belongs in an application whose only text fields are
+ an area's name and a search box.
+
+ THE MENU IS NOT REMOVED, and cannot be. Command-C, Command-V and Command-A in a
+ WKWebView are delivered through the responder chain, which reaches the web view
+ only because menu items carrying those key equivalents exist. An application
+ with no Edit menu is an application where copy and paste stop working inside
+ its own inputs.
+
+ registerDefaults, not setObject:forKey:. Registering places the values in the
+ defaults' registration domain, which is consulted when nothing else answers and
+ is discarded when the process ends. Writing them would put two keys in the
+ reader's own preferences and leave them there after the application is gone,
+ for a choice that is this application's rather than theirs.
+
+ Both keys are documented AppKit behaviour and public.
+ */
+void TerraDisableAutoEditMenuItems(void) {
+    [[NSUserDefaults standardUserDefaults] registerDefaults:@{
+        // "Start Dictation…"
+        @"NSDisabledDictationMenuItem" : @YES,
+        // "Emoji & Symbols"
+        @"NSDisabledCharacterPaletteMenuItem" : @YES,
+    }];
+}

--- a/editmenu_other.go
+++ b/editmenu_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin
+
+package main
+
+/*
+trimEditMenu does nothing off macOS.
+
+The items it declines are AppKit's, added to any Edit menu it finds. No other
+platform's menu grows on its own, so there is nothing to decline -- and a build
+tag says that, where a runtime check would read as though the call might do
+something.
+*/
+func trimEditMenu() {}

--- a/frontend/scripts/check-contrast.ts
+++ b/frontend/scripts/check-contrast.ts
@@ -13,6 +13,7 @@ import { readFileSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 import { dirname, join } from "node:path"
 import {
+  ACCEPTED,
   checkContrast,
   TOKENS,
   type Channels,
@@ -127,19 +128,48 @@ for (const theme of Object.keys(TOKENS) as ThemeName[]) {
 
 const results = checkContrast()
 const width = Math.max(...results.map((r) => `${r.fg} on ${r.bg}`.length))
+const accepted: string[] = []
 
 for (const theme of ["dark", "light"] as const) {
   console.log(`\n${theme}`)
   for (const r of results.filter((x) => x.theme === theme)) {
+    const key = `${r.theme}.${r.fg}.${r.bg}`
     const label = `${r.fg} on ${r.bg}`.padEnd(width)
-    const verdict = r.passes ? "ok  " : "FAIL"
+    const excused = !r.passes && key in ACCEPTED
+    const verdict = r.passes ? "ok  " : excused ? "KNOWN" : "FAIL"
     console.log(`  ${verdict} ${label}  ${r.ratio.toFixed(2)}  (min ${r.min})`)
-    if (!r.passes) failed++
+    if (excused) {
+      accepted.push(`  ${key}  ${r.ratio.toFixed(2)} / ${r.min} -- ${ACCEPTED[key]}`)
+    } else if (!r.passes) {
+      failed++
+    }
   }
+}
+
+/*
+  An entry that no longer describes a failure is itself a failure. Otherwise the
+  list outlives the palette that needed it and quietly excuses a pair that has
+  since regressed for a different reason.
+*/
+const stale = Object.keys(ACCEPTED).filter(
+  (k) => !results.some((r) => `${r.theme}.${r.fg}.${r.bg}` === k && !r.passes)
+)
+for (const k of stale) {
+  console.error(`STALE  ${k} is accepted but now passes; remove it from ACCEPTED`)
+  failed++
+}
+
+if (accepted.length) {
+  console.log(`\n${accepted.length} pair(s) accepted below floor:`)
+  for (const line of accepted) console.log(line)
 }
 
 if (failed) {
   console.error(`\n${failed} problem(s).`)
   process.exit(1)
 }
-console.log("\nEvery token pair clears its floor, and the channels match index.css.")
+console.log(
+  accepted.length
+    ? "\nNo unaccepted failure, and the channels match index.css."
+    : "\nEvery token pair clears its floor, and the channels match index.css."
+)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import {
   restoreBoard,
   writeBoardMemory,
 } from "@/components/whiteboard/boardMemory"
+import { AccentLab } from "@/components/AccentLab"
 import { useTheme } from "next-themes"
 import {
   ListEmbeddedAreas,
@@ -3458,6 +3459,8 @@ function AppBody(props: {
           )}
         </div>
       </div>
+      {/* TEMPORARY: accent lab. Delete this line and AccentLab.tsx. */}
+      {import.meta.env.DEV && <AccentLab />}
     </div>
   )
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { Dispatch, SetStateAction } from "react"
 import { AnimatePresence, motion } from "motion/react"
+import { selectPanel } from "@/lib/panelSelection"
 import { notifyError, notifyInfo, notifySuccess } from "@/lib/notify"
 import type { Whiteboard } from "@/lib/whiteboards"
 import { listWhiteboards, openWhiteboard } from "@/lib/whiteboards"
@@ -886,7 +887,6 @@ function AppBody(props: {
    * every navigation away, so local state reset the dock to the classification
    * panel on every return.
    */
-  const [leftPanel, setLeftPanel] = useState<MapToolId | null>("classify")
   /**
    * Which map layout is drawn.
    *
@@ -2701,7 +2701,7 @@ function AppBody(props: {
         goEnergy()
         return
       }
-      setLeftPanel(product)
+      selectPanel(product)
       startNewClassification()
     },
     [goEnergy, startNewClassification]
@@ -3004,7 +3004,7 @@ function AppBody(props: {
       } else if (groupId === "analysis") {
         openProjectHub()
       } else {
-        if (itemId) setLeftPanel(itemId as MapToolId)
+        if (itemId) selectPanel(itemId as MapToolId)
         goMap()
       }
     },
@@ -3104,15 +3104,26 @@ function AppBody(props: {
               key="app-nav"
               hasAnalysis={!!props.result || runs.length > 0}
               onAnalysisClick={openProjectHub}
-              leftPanel={leftPanel}
-              onLeftPanelChange={setLeftPanel}
               energyTab={energyTab}
               onEnergyTabChange={setEnergyTab}
             />
           )}
         </AnimatePresence>
         <div className="relative min-h-0 min-w-0 flex-1">
-          <AnimatePresence mode="wait" initial={false}>
+          {/*
+            NOT mode="wait". Under it the leaving screen has to finish its exit
+            before the arriving one is allowed to mount, so every change of
+            screen was 240ms of an empty stage followed by the mount -- and the
+            mount is the expensive half, since a screen here builds leaflet, its
+            overlays and sometimes the studio. Serialised by construction, and
+            felt as the transition being slow rather than as the animation being
+            long.
+
+            Without it the two overlap. They are both `absolute inset-0`, so
+            overlapping is what the layout already expects, and the arriving
+            screen starts building at the moment it is asked for.
+          */}
+          <AnimatePresence initial={false}>
             {screen === "map" && (
               <motion.div
                 key="screen-map"
@@ -3156,11 +3167,9 @@ function AppBody(props: {
                   solarProgress={solar.run.progress}
                   solarProgressMsg={solar.run.message}
                   initialView={initialMapView}
-                  leftPanel={leftPanel}
                   layoutMode={layoutMode}
                   onLayoutModeChange={changeLayoutMode}
                   onNavigate={navigateTo}
-                  onLeftPanelChange={setLeftPanel}
                   areas={props.areas}
                   activeExample={props.activeExample}
                   customPolygon={props.customPolygon}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,10 @@ import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } fro
 import type { Dispatch, SetStateAction } from "react"
 import { AnimatePresence, motion } from "motion/react"
 import { selectPanel } from "@/lib/panelSelection"
+import {
+  TELEMETRY_DEFAULT,
+  setStudioTelemetry,
+} from "@/lib/studioTelemetry"
 import { notifyError, notifyInfo, notifySuccess } from "@/lib/notify"
 import type { Whiteboard } from "@/lib/whiteboards"
 import { listWhiteboards, openWhiteboard } from "@/lib/whiteboards"
@@ -344,6 +348,13 @@ function App() {
       const extras = parsePreferenceExtras(p.extras_json)
       setSavedAois(extras.saved_aois ?? [])
       setActiveAoiId(extras.active_aoi_id)
+      /*
+        Into a module rather than into state: the readers are the studio's
+        status bar and the scene, and the scene is not React. Seeded here
+        because this is where preferences arrive, and absent means none --
+        which is what a reader who has never opened the setting should get.
+      */
+      setStudioTelemetry(extras.studio_telemetry ?? TELEMETRY_DEFAULT)
     },
     [setTheme]
   )

--- a/frontend/src/components/AccentLab.test.ts
+++ b/frontend/src/components/AccentLab.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest"
+
+import { SHIPPED_HAZE, derive } from "@/components/AccentLab"
+import { TOKENS, type Channels, type ThemeName } from "@/lib/contrast"
+
+/*
+  The panel is a reference before it is an editor: it opens on the palette the
+  application is running in, and every judgement made in it is a comparison
+  against that. A panel that opens on something else is not a weaker tool, it is
+  a wrong one -- the reader believes they are looking at the difference their
+  change made.
+
+  It was wrong in four ways at once, and this is what each of them was.
+
+  - `atLuminance` bisects lightness and rounds to a channel, so it could not
+    reproduce a value it was handed. Every surface came back off by one or two.
+  - `accentQuiet` was searched over 201 lightness steps rather than kept, so it
+    landed near the shipped value and not on it.
+  - `accentDim` carried a hardcoded 0.86 in the dark theme, so it could never
+    equal the shipped plate.
+  - `haze` still held the Mars sand literals from the family that put the
+    accent's hue in the surfaces. That one was off by a whole hue, #c57f52
+    against the #909090 index.css serves, and it survived the move to a neutral
+    chassis because nothing measured it -- the haze clears no contrast floor, so
+    check-contrast has no opinion about it.
+*/
+
+const REST = { hue: null, chroma: 1, depth: 1 }
+const KEYS = [
+  "ink",
+  "surface",
+  "surfaceRaised",
+  "line",
+  "lineStrong",
+  "text",
+  "muted",
+  "accent",
+  "accentQuiet",
+  "accentDim",
+  "haze",
+] as const
+
+const hex = (c: Channels) =>
+  "#" + c.map((v) => Math.round(v).toString(16).padStart(2, "0")).join("")
+
+describe("the accent lab at rest", () => {
+  for (const theme of ["dark", "light"] as ThemeName[]) {
+    it(`emits the ${theme} palette index.css serves, token for token`, () => {
+      const base = TOKENS[theme]
+      const shipped: Record<string, Channels> = {
+        ...(base as unknown as Record<string, Channels>),
+        haze: SHIPPED_HAZE[theme],
+      }
+      const { tokens } = derive(base.accent, theme, REST)
+
+      for (const k of KEYS) {
+        expect(hex(tokens[k]), k).toBe(hex(shipped[k]))
+      }
+    })
+  }
+
+  it("moves the accent family once the accent itself moves", () => {
+    // The variants are kept only while the accent is the shipped one: they
+    // exist to read AS it, so a variant held over from the old hue would be
+    // the wrong colour rather than a conservative choice.
+    const { tokens } = derive([46, 158, 107], "dark", REST)
+    expect(hex(tokens.accentQuiet)).not.toBe(hex(TOKENS.dark.accentQuiet))
+    expect(hex(tokens.accentDim)).not.toBe(hex(TOKENS.dark.accentDim))
+  })
+
+  it("leaves the chassis alone at chroma 1, since the chassis is neutral", () => {
+    const { tokens } = derive([139, 92, 246], "dark", REST)
+    expect(hex(tokens.surface)).toBe(hex(TOKENS.dark.surface))
+    expect(hex(tokens.line)).toBe(hex(TOKENS.dark.line))
+  })
+})

--- a/frontend/src/components/AccentLab.tsx
+++ b/frontend/src/components/AccentLab.tsx
@@ -1,0 +1,907 @@
+/**
+ * A throwaway panel for choosing the accent, with the palette derived live.
+ *
+ * NOT PART OF THE PRODUCT. It exists because picking a brand colour by editing
+ * index.css, reloading, and squinting is a slow loop, and because a colour
+ * cannot be judged from a swatch -- it has to be judged on the surfaces it
+ * lands on, at the sizes it lands at.
+ *
+ * What it does is what was done by hand for the blue: takes one colour, rotates
+ * the neutral family onto its hue at CONSTANT luminance so every measured
+ * ratio survives the change, searches for the quiet and dim variants that clear
+ * their floors, writes the lot onto :root, and reports what each pair measures.
+ *
+ * Delete the file and the one line in App.tsx when the colour is chosen.
+ */
+import { useEffect, useMemo, useState } from "react"
+import { useTheme } from "next-themes"
+
+import { TOKENS, contrast, type Channels, type ThemeName } from "@/lib/contrast"
+import {
+  setViewportPaletteOverride,
+  type ViewportPalette,
+} from "@/lib/paletteWatch"
+
+/* ---------------------------------------------------------------- colour */
+
+function hexToRgb(hex: string): Channels | null {
+  const m = /^#?([0-9a-f]{6})$/i.exec(hex.trim())
+  if (!m) return null
+  const n = parseInt(m[1], 16)
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255]
+}
+
+const toHex = (c: Channels) =>
+  "#" + c.map((v) => Math.round(v).toString(16).padStart(2, "0")).join("")
+
+function rgbToHsl([r, g, b]: Channels): [number, number, number] {
+  const R = r / 255, G = g / 255, B = b / 255
+  const max = Math.max(R, G, B), min = Math.min(R, G, B)
+  const l = (max + min) / 2
+  if (max === min) return [0, 0, l]
+  const d = max - min
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
+  const h =
+    max === R ? ((G - B) / d + (G < B ? 6 : 0))
+    : max === G ? (B - R) / d + 2
+    : (R - G) / d + 4
+  return [h / 6, s, l]
+}
+
+function hslToRgb(h: number, s: number, l: number): Channels {
+  if (s === 0) { const v = Math.round(l * 255); return [v, v, v] }
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s
+  const p = 2 * l - q
+  const f = (t: number) => {
+    if (t < 0) t += 1
+    if (t > 1) t -= 1
+    if (t < 1 / 6) return p + (q - p) * 6 * t
+    if (t < 1 / 2) return q
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6
+    return p
+  }
+  return [f(h + 1 / 3), f(h), f(h - 1 / 3)].map((v) =>
+    Math.round(v * 255)
+  ) as unknown as Channels
+}
+
+const luminance = (c: Channels) => {
+  const f = (v: number) => {
+    const s = v / 255
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4
+  }
+  return 0.2126 * f(c[0]) + 0.7152 * f(c[1]) + 0.0722 * f(c[2])
+}
+
+/** The same hue and saturation, at a lightness giving this luminance. */
+function atLuminance(target: number, hue: number, sat: number): Channels {
+  let lo = 0, hi = 1
+  for (let i = 0; i < 40; i++) {
+    const mid = (lo + hi) / 2
+    if (luminance(hslToRgb(hue, sat, mid)) < target) lo = mid
+    else hi = mid
+  }
+  return hslToRgb(hue, sat, (lo + hi) / 2)
+}
+
+/** The lightest or darkest value on this hue that clears `floor` on `grounds`. */
+function searchVariant(
+  hue: number,
+  sat: number,
+  grounds: Channels[],
+  floor: number,
+  lighter: boolean
+): Channels {
+  const steps = Array.from({ length: 201 }, (_, i) => i / 200)
+  const order = lighter ? steps : steps.slice().reverse()
+  for (const l of order) {
+    const c = hslToRgb(hue, sat, l)
+    if (grounds.every((g) => contrast(c, g) >= floor)) return c
+  }
+  return hslToRgb(hue, sat, lighter ? 0.75 : 0.25)
+}
+
+/**
+ * The haze, per theme, as index.css serves it.
+ *
+ * It lives here and not in TOKENS because it takes part in no contrast rule,
+ * so the check has nothing to say about it. Keep it in step with index.css by
+ * hand -- there is no guard on this pair, which is how it came to be two
+ * retired Mars sand values long after the chassis went neutral.
+ */
+export const SHIPPED_HAZE: Record<ThemeName, Channels> = {
+  dark: [144, 144, 144],
+  light: [176, 176, 176],
+}
+
+const sameChannels = (a: Channels, b: Channels) =>
+  a[0] === b[0] && a[1] === b[1] && a[2] === b[2]
+
+export interface Derived {
+  tokens: Record<string, Channels>
+  checks: { label: string; ratio: number; floor: number; ok: boolean }[]
+}
+
+/**
+ * The neutral family's own three axes, independent of the accent.
+ *
+ * The first version locked all three: the neutrals took the accent's hue and
+ * kept the shipped luminance exactly, which is right for porting a palette to
+ * a new accent and useless for deciding how dark the dark theme should be.
+ *
+ * `hue` is which way the greys lean, `chroma` how far, and `depth` scales the
+ * luminance of the three SURFACES only -- ink, surface, raised. Text and lines
+ * keep theirs, because moving both ends at once moves no ratio and would feel
+ * like nothing is happening while every measurement changes underneath.
+ */
+export interface Neutrals {
+  hue: number | null
+  chroma: number
+  depth: number
+}
+
+/** The whole family for one theme, from one accent and the neutral axes. */
+export function derive(accent: Channels, theme: ThemeName, n: Neutrals): Derived {
+  const base = TOKENS[theme]
+  const [accentHue, sat] = rgbToHsl(accent)
+  const hue = n.hue === null ? accentHue : n.hue / 360
+  const dark = theme === "dark"
+
+  /**
+   * Hue and chroma applied, luminance held.
+   *
+   * THE IDENTITY IS EXACT, and is a correctness fix rather than a shortcut.
+   * `atLuminance` bisects lightness and rounds to a channel, so it cannot
+   * reproduce the value it was given: asking it for a token's own luminance at
+   * a token's own saturation returned #1a1a1a as #181818. Small, and it applied
+   * to every surface at once, so the panel at rest painted a chassis that was
+   * not the one the stylesheet serves.
+   *
+   * When nothing is being asked of a token -- the saturation it would be
+   * rebuilt at is the one it already has, and the luminance is its own -- the
+   * answer is the token.
+   */
+  function tint(target: Channels, original: Channels): Channels {
+    const [, s0] = rgbToHsl(original)
+    const sat = Math.min(1, s0 * n.chroma)
+    if (target === original && sat === s0) return original
+    return atLuminance(luminance(target), hue, sat)
+  }
+
+  /** The same, for a value that is its own original. */
+  const tintOf = (c: Channels) => tint(c, c)
+
+  /*
+    Depth moves a surface's luminance and the hue rotation preserves whatever
+    it is moved to, so the two axes compose without fighting. Clamped away from
+    zero: a surface at luminance zero is pure black, on which the separation
+    between surfaces cannot exist at all.
+  */
+  const deepen = (c: Channels) =>
+    n.depth === 1
+      ? tintOf(c)
+      : tint(atLuminance(Math.max(0.002, luminance(c) * n.depth), hue, 0), c)
+
+  const t: Record<string, Channels> = {
+    ink: deepen(base.ink),
+    surface: deepen(base.surface),
+    surfaceRaised: deepen(base.surfaceRaised),
+    line: tintOf(base.line),
+    lineStrong: tintOf(base.lineStrong),
+    text: tintOf(base.text),
+    muted: tintOf(base.muted),
+    accent,
+  }
+
+  const grounds = [t.ink, t.surface, t.surfaceRaised]
+
+  // The accent has to clear 3.0 as a boundary; nudge it toward the readable
+  // side if the chosen value does not.
+  if (!grounds.every((g) => contrast(t.accent, g) >= 3)) {
+    t.accent = searchVariant(hue, sat, grounds, 3, dark)
+  }
+  /*
+    KEPT WHILE THEY STILL PASS, rather than re-derived on every change.
+
+    Both were computed unconditionally, and neither computation can land on the
+    value the stylesheet serves: the quiet variant is the first of 201 lightness
+    steps to clear 4.5, and the dim plate carried a hardcoded 0.86 in the dark
+    theme. So the panel at rest reported #ec7d35 and #45220a where index.css
+    serves #ec8039 and #4b250b -- it disagreed with the running application
+    about a palette nobody had asked it to change.
+
+    Conditioned on the accent being untouched, because these two exist to read
+    AS the accent. Once it moves, a variant held over from the old hue is not a
+    conservative choice, it is the wrong colour.
+  */
+  const accentHeld = sameChannels(t.accent, base.accent)
+  const clears = (c: Channels, floor: number) =>
+    grounds.every((g) => contrast(c, g) >= floor)
+
+  t.accentQuiet =
+    accentHeld && clears(base.accentQuiet, 4.5)
+      ? base.accentQuiet
+      : searchVariant(hue, sat, grounds, 4.5, dark)
+
+  // The plate: dark enough (or light enough) for the accent to sit on it.
+  const shippedDimHolds =
+    accentHeld &&
+    n.depth === 1 &&
+    contrast(t.accent, base.accentDim) >= 3 &&
+    contrast(t.accentQuiet, base.accentDim) >= 4.5
+  t.accentDim = shippedDimHolds
+    ? base.accentDim
+    : atLuminance(
+        dark
+          ? luminance(base.accentDim) * 0.86 * n.depth
+          : luminance(base.accentDim),
+        hue,
+        Math.min(1, sat * 0.9)
+      )
+  /*
+    The haze takes part in no contrast rule, so TOKENS has no reason to carry
+    it and its channels live here. They are the ones index.css serves.
+
+    They used to be [196 128 84] and [196 150 118], which is the Mars sand haze
+    -- warm, from the family that put the accent's hue in the surfaces. The
+    chassis went neutral and this literal did not follow, so the panel emitted
+    #c57f52 where the stylesheet serves #909090: the one token where the lab
+    disagreed with the product by a whole hue rather than by rounding.
+  */
+  t.haze = tintOf(dark ? SHIPPED_HAZE.dark : SHIPPED_HAZE.light)
+
+  const rule = (label: string, fg: Channels, bg: Channels, floor: number) => {
+    const ratio = contrast(fg, bg)
+    return { label, ratio, floor, ok: ratio >= floor }
+  }
+  const checks = [
+    /*
+      The surface separations first, because the depth axis is what moves them
+      and they have no floor to clear -- 1.12 and 1.20 as shipped, low by
+      construction, which is why --p-line-strong exists to tell panels apart.
+      Listed at 1.0 so they read as measurements rather than as tests.
+    */
+    rule("ink → surface", t.surface, t.ink, 1),
+    rule("surface → raised", t.surfaceRaised, t.surface, 1),
+    rule("text on raised", t.text, t.surfaceRaised, 4.5),
+    rule("muted on raised", t.muted, t.surfaceRaised, 4.5),
+    rule("quiet on raised", t.accentQuiet, t.surfaceRaised, 4.5),
+    rule("quiet on dim", t.accentQuiet, t.accentDim, 4.5),
+    rule("accent on raised", t.accent, t.surfaceRaised, 3),
+    rule("accent on dim", t.accent, t.accentDim, 3),
+    rule("lineStrong on raised", t.lineStrong, t.surfaceRaised, 3),
+    rule("white label on accent", [255, 255, 255], t.accent, 4.5),
+    rule("ink label on accent", t.ink, t.accent, 4.5),
+  ]
+  return { tokens: t, checks }
+}
+
+const CSS_NAME: Record<string, string> = {
+  ink: "--p-ink",
+  surface: "--p-surface",
+  surfaceRaised: "--p-surface-raised",
+  line: "--p-line",
+  lineStrong: "--p-line-strong",
+  text: "--p-text",
+  muted: "--p-muted",
+  accent: "--p-accent",
+  accentQuiet: "--p-accent-quiet",
+  accentDim: "--p-accent-dim",
+  haze: "--p-haze",
+}
+
+/** The accent the stylesheet is currently serving, as hex. */
+function shippedAccent(): string {
+  if (typeof getComputedStyle !== "function") return "#ED8744"
+  const raw = getComputedStyle(document.documentElement)
+    .getPropertyValue("--p-accent")
+    .trim()
+  const parts = raw.split(/\s+/).map(Number)
+  return parts.length === 3 && parts.every((n) => Number.isFinite(n))
+    ? toHex(parts as unknown as Channels)
+    : "#ED8744"
+}
+
+/**
+ * The same colour at a multiple of its luminance.
+ *
+ * Its own hue and saturation are kept, so a neutral stays neutral and a tinted
+ * chassis keeps its lean. Clamped away from zero because a surface at luminance
+ * zero is pure black, on which no separation can exist.
+ */
+function scaleLuminance(c: Channels, k: number): Channels {
+  if (k === 1) return c
+  const [h, sat] = rgbToHsl(c)
+  return atLuminance(Math.max(0.002, luminance(c) * k), h, sat)
+}
+
+/**
+ * A colour re-placed so it keeps the contrast it had, against a ground that
+ * moved.
+ *
+ * The ground grid is the case. Its colour is `--p-line`, fixed, while the room
+ * behind it is being lifted -- so past a certain lift the background PASSES it
+ * and the grid inverts, going darker than what it is drawn on. Raising its
+ * alpha then only makes it more wrong: over a room at #5a5a5a the whole alpha
+ * range moved the composited channel by eight, downward.
+ *
+ * Holding the WCAG ratio instead keeps the grid the same distance from the room
+ * at every lift, in the one measure the rest of this file already argues in.
+ * The luminance is clamped: a ratio that would ask for more than white returns
+ * white, which is the honest end of the scale rather than an overflow.
+ */
+function atRatio(newGround: Channels, fg: Channels, ground: Channels): Channels {
+  const ratio = (luminance(fg) + 0.05) / (luminance(ground) + 0.05)
+  const wanted = ratio * (luminance(newGround) + 0.05) - 0.05
+  const [h, sat] = rgbToHsl(fg)
+  return atLuminance(Math.min(1, Math.max(0, wanted)), h, sat)
+}
+
+/**
+ * Where a candidate palette is allowed to land while it is being judged.
+ *
+ * "off" is in here rather than beside it. There used to be a separate live/off
+ * switch, which made two controls for one decision and disagreed with itself:
+ * off and the scope then called "tokens" were the same state -- nothing
+ * painted, the block and the measurements still on screen -- reached by two
+ * different controls. Worse, the scope row was disabled while off, so the
+ * control that says what the lab does read as broken until you found the other
+ * one.
+ */
+export type Scope = "off" | "both" | "interface" | "viewport"
+
+const SCOPES: { id: Scope; label: string; hint: string }[] = [
+  {
+    id: "off",
+    label: "off",
+    hint: "nothing is painted; the block and the measurements still read",
+  },
+  { id: "both", label: "both", hint: "tokens drive the CSS and the 3D scenes" },
+  {
+    id: "interface",
+    label: "interface",
+    hint: "CSS moves; the 3D scenes stay on what ships",
+  },
+  {
+    id: "viewport",
+    label: "viewport",
+    hint: "the 3D scenes move; the CSS stays on what ships",
+  },
+]
+
+/** The three chassis colours a scene takes, from a set of channels. */
+function viewportTriple(
+  ink: Channels,
+  line: Channels,
+  accent: Channels,
+  gridOpacity: number
+): ViewportPalette {
+  const css = (c: Channels) => `rgb(${c[0]},${c[1]},${c[2]})`
+  return {
+    background: css(ink),
+    line: css(line),
+    accent: css(accent),
+    gridOpacity,
+  }
+}
+
+/** The ground grid's alpha in both scenes, which the grid control scales. */
+const GRID_OPACITY = 0.14
+
+/** A readout that names the colour a slider produced, not the slider's input. */
+const hexOf = (c: Channels) => toHex(c).toUpperCase()
+
+/* ------------------------------------------------------------------ panel */
+
+/** One labelled slider with its value, since there are three of them. */
+function Axis({
+  label,
+  value,
+  min,
+  max,
+  step,
+  suffix = "",
+  display,
+  onChange,
+}: {
+  label: string
+  value: number
+  min: number
+  max: number
+  step: number
+  suffix?: string
+  /** What the readout says, where the stored value is not it. */
+  display?: (v: number) => string
+  onChange: (v: number) => void
+}) {
+  return (
+    <label className="flex items-center gap-2 text-meta">
+      <span className="w-14 shrink-0 text-muted-foreground">{label}</span>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="h-1 flex-1 cursor-pointer accent-[var(--accent)]"
+      />
+      <span className="telemetry w-10 shrink-0 text-right">
+        {display ? display(value) : `${step < 1 ? value.toFixed(2) : value}${suffix}`}
+      </span>
+    </label>
+  )
+}
+
+export function AccentLab() {
+  /*
+    Seeded from the palette that ships.
+
+    The first version opened on a hardcoded blue and painted it, so simply
+    having the lab mounted repainted the application in a colour nobody had
+    chosen. A tool for judging a palette must show the real one until it is told
+    otherwise -- see Scope for the other half of that, which is opening on
+    "off".
+
+    Every token follows from this one at rest, exactly: AccentLab.test.ts holds
+    the eleven of them against index.css in both themes.
+  */
+  const [hex, setHex] = useState(shippedAccent)
+  const [open, setOpen] = useState(true)
+  /*
+    WHERE the derived palette is allowed to land.
+
+    "both" is the product's own arrangement: the stylesheet and the studio's 3D
+    scenes read the same `--p-*`, so moving a token moves them together. That is
+    right for shipping and useless for judging, because there is no moment where
+    one is the candidate and the other is the reference.
+
+    The other three take them apart. "interface" writes the tokens and pins the
+    scenes to what ships; "viewport" leaves the tokens alone and pins the scenes
+    to the candidate; "tokens" paints nothing at all and leaves the block and
+    the measurements, for reading a palette without living in it.
+  */
+  const [scope, setScope] = useState<Scope>("off")
+  const [followAccent, setFollowAccent] = useState(true)
+  const [hueDeg, setHueDeg] = useState(214)
+  const [chroma, setChroma] = useState(1)
+  const [depth, setDepth] = useState(1)
+  /*
+    The viewport's own two, applied ON TOP of whatever palette the scope hands
+    the scenes.
+
+    The studio is a dark room with rasters in it; the panels around it are a
+    reading surface. They are painted from the same two tokens -- `--p-ink` is
+    both the application background and the 3D background, `--p-line` is both a
+    divider and the ground grid -- so the one thing that could not be said
+    before was "this room, deeper than the panels around it" or "this grid,
+    fainter". These say it, and nothing else in the application moves.
+
+    Multiples of luminance rather than colours of their own, so whichever hue
+    was decided above is kept and only the depth of the room changes.
+  */
+  const [roomStops, setRoomStops] = useState(0)
+  const [gridStops, setGridStops] = useState(0)
+  /*
+    The grid's own tone, from black up through grey.
+
+    Separate from its alpha because they are separate questions and only one of
+    them was answerable. The alpha decides how much of the grid arrives; the
+    tone decides what arrives -- and a grid darker than the room reads as
+    scored-in graph paper while a lighter one reads as drawn on top of it. With
+    the tone pinned to a derived value there was no way to ask for the first.
+
+    Stops away from the derived tone, so 0 is whatever keeps the grid at the
+    distance from the room that --p-line has from --p-ink. Down is toward black.
+  */
+  const [toneStops, setToneStops] = useState(0)
+  const { resolvedTheme } = useTheme()
+  const theme: ThemeName = resolvedTheme === "light" ? "light" : "dark"
+
+  const rgb = hexToRgb(hex)
+  const neutrals: Neutrals = {
+    hue: followAccent ? null : hueDeg,
+    chroma,
+    depth,
+  }
+  const derived = useMemo(
+    () => (rgb ? derive(rgb, theme, neutrals) : null),
+    [hex, theme, followAccent, hueDeg, chroma, depth]
+  )
+
+  // Written onto :root, where an inline custom property beats the stylesheet's
+  // without touching it. Removing them restores the shipped palette exactly.
+  const paintsCss = scope === "both" || scope === "interface"
+  const paintsViewport = scope === "both" || scope === "viewport"
+
+  useEffect(() => {
+    const root = document.documentElement
+    if (!derived || !paintsCss) {
+      for (const name of Object.values(CSS_NAME)) root.style.removeProperty(name)
+      return
+    }
+    for (const [key, name] of Object.entries(CSS_NAME)) {
+      const c = derived.tokens[key]
+      if (c) root.style.setProperty(name, c.join(" "))
+    }
+  }, [derived, paintsCss])
+
+  /*
+    The scenes are pinned in two of the four scopes, and for opposite reasons.
+
+    Under "viewport" they are pinned to the CANDIDATE, because the tokens are
+    deliberately not being written and reading them would give the scenes the
+    shipped palette. Under "interface" they are pinned to what SHIPS, because
+    the tokens ARE being written and reading them would drag the scenes along --
+    which is the thing that scope exists to prevent.
+
+    TOKENS is the source for "what ships" rather than the computed style: by the
+    time this runs the inline properties are already on the element, so the
+    computed style is the candidate, not the reference.
+  */
+  /*
+    STOPS, doubling per unit, because luminance is not linear near black.
+
+    On an ink of 19 a plain multiplier spends most of its travel in a range
+    nothing can be seen in: 2.5x reaches only #222222, and a room bright enough
+    to judge a raster against needs something like 12x to 20x. A slider with
+    that as its maximum would squeeze everything under 3x into the first eighth
+    of the track. One doubling per unit gives the same resolution at both ends,
+    which is what a control over luminance wants.
+  */
+  const roomDepth = 2 ** roomStops
+  // Alpha has a hard ceiling of 1: past a fully opaque grid there is nothing
+  // left to ask for, and the tone below is where the remaining range lives.
+  const gridOpacity = Math.min(1, GRID_OPACITY * 2 ** gridStops)
+  const roomIsOffset =
+    roomStops !== 0 || gridStops !== 0 || toneStops !== 0
+
+  /*
+    The room and the grid as colours, in the render rather than only in the
+    effect, so the two readouts can say what the sliders actually produced. A
+    control over luminance whose readout is its own input tells the reader
+    nothing they could not already see on the track.
+  */
+  const roomSource = paintsViewport
+    ? derived?.tokens
+    : (TOKENS[theme] as unknown as Record<string, Channels>)
+  const roomColour = roomSource
+    ? scaleLuminance(roomSource.ink, roomDepth)
+    : null
+  const gridColour =
+    roomSource && roomColour
+      ? atLuminance(
+          Math.min(
+            1,
+            luminance(atRatio(roomColour, roomSource.line, roomSource.ink)) *
+              2 ** toneStops
+          ),
+          ...(rgbToHsl(roomSource.line).slice(0, 2) as [number, number])
+        )
+      : null
+
+  useEffect(() => {
+    if (!derived) return
+    /*
+      Nothing to pin: the scope leaves the scenes to the tokens and the room has
+      no offset of its own, so releasing them is both correct and cheaper than
+      handing them a copy of what they would read anyway.
+    */
+    if (!paintsViewport && !paintsCss && !roomIsOffset) {
+      setViewportPaletteOverride(null)
+      return
+    }
+    /*
+      Which palette the room is an offset FROM. Under "viewport" and "both" it
+      is the candidate. Under "interface" and "off" it is what ships, so a room
+      offset can be judged against the shipped chassis without the panels moving
+      with it -- and, under "interface", so the scenes are held still while the
+      panels move, which is what that scope is for.
+
+      TOKENS is the source for "what ships" rather than the computed style: by
+      the time this runs the inline properties are already on the element, so
+      the computed style is the candidate, not the reference.
+    */
+    if (!roomColour || !gridColour || !roomSource) return
+    setViewportPaletteOverride(
+      viewportTriple(roomColour, gridColour, roomSource.accent, gridOpacity)
+    )
+    return () => setViewportPaletteOverride(null)
+    // roomColour and gridColour are arrays rebuilt on every render, so they
+    // cannot be dependencies without re-running this every time; the numbers
+    // they are computed from can.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    derived,
+    paintsCss,
+    paintsViewport,
+    roomIsOffset,
+    roomDepth,
+    gridOpacity,
+    toneStops,
+    theme,
+  ])
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="fixed bottom-3 right-3 z-[9999] rounded-sm bg-accent px-2 py-1 text-meta text-accent-foreground shadow-lg"
+      >
+        accent lab
+      </button>
+    )
+  }
+
+  const block = derived
+    ? Object.entries(CSS_NAME)
+        .map(([k, name]) =>
+          derived.tokens[k] ? `  ${name}: ${derived.tokens[k].join(" ")};` : ""
+        )
+        .filter(Boolean)
+        .join("\n")
+    : ""
+
+  return (
+    <div
+      className="panel-scroll fixed bottom-3 right-3 z-[9999] flex max-h-[80vh] w-[21rem] flex-col gap-2 overflow-auto rounded-sm border p-2 shadow-xl"
+      style={{
+        borderColor: "rgb(var(--p-line) / 0.4)",
+        background: "rgb(var(--p-surface))",
+      }}
+    >
+      <div className="flex items-center gap-2">
+        <p className="eyebrow flex-1">Accent lab · {theme}</p>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="rounded-sm px-1.5 py-0.5 text-meta text-muted-foreground"
+        >
+          hide
+        </button>
+      </div>
+
+      {/*
+        The whole of the lab's effect on the application, in one row, always
+        clickable. It opens on "off": having the panel mounted must not repaint
+        anything, since inline custom properties beat the stylesheet and that is
+        both what makes the lab work and what would make it lie.
+      */}
+      <div
+        className="flex gap-1"
+        role="group"
+        aria-label="Where the candidate palette is painted"
+      >
+        {SCOPES.map((sc) => {
+          const active = sc.id === scope
+          return (
+            <button
+              key={sc.id}
+              type="button"
+              title={sc.hint}
+              aria-pressed={active}
+              onClick={() => setScope(sc.id)}
+              className="flex-1 cursor-pointer rounded-sm px-1 py-0.5 text-meta"
+              style={{
+                background: active ? "var(--accent-dim)" : "transparent",
+                color: active ? "var(--accent-quiet)" : "rgb(var(--p-muted))",
+              }}
+            >
+              {sc.label}
+            </button>
+          )
+        })}
+      </div>
+      <p className="text-[9px] leading-snug text-muted-foreground">
+        {SCOPES.find((sc) => sc.id === scope)?.hint}
+      </p>
+
+      <div className="flex items-center gap-2">
+        <input
+          type="color"
+          value={rgb ? hex : "#3376CE"}
+          onChange={(e) => setHex(e.target.value)}
+          className="h-8 w-12 cursor-pointer rounded-sm border-0 bg-transparent p-0"
+        />
+        <input
+          value={hex}
+          onChange={(e) => setHex(e.target.value)}
+          spellCheck={false}
+          className="field-input telemetry h-8 flex-1 px-1.5 text-meta"
+        />
+      </div>
+
+      {/* A few starting points, including the two this project has worn. */}
+      <div className="flex flex-wrap gap-1">
+        {["#3376CE", "#ED8744", "#2E9E6B", "#8B5CF6", "#D64545", "#0EA5A5"].map(
+          (p) => (
+            <button
+              key={p}
+              type="button"
+              onClick={() => setHex(p)}
+              title={p}
+              className="size-5 rounded-sm border"
+              style={{ background: p, borderColor: "rgb(var(--p-line) / 0.5)" }}
+            />
+          )
+        )}
+      </div>
+
+      {/*
+        The neutral family's own axes. Separate from the accent because
+        deciding how dark the dark theme is, and how far it leans, is a
+        different question from which colour the brand is -- and locking the
+        first to the second is what made the palette only portable and not
+        adjustable.
+      */}
+      <div className="flex flex-col gap-1.5 border-t pt-2" style={{ borderColor: "rgb(var(--p-line) / 0.25)" }}>
+        <label className="flex items-center gap-2 text-meta text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={followAccent}
+            onChange={(e) => setFollowAccent(e.target.checked)}
+          />
+          neutrals follow the accent's hue
+        </label>
+        {!followAccent && (
+          <Axis
+            label="hue"
+            value={hueDeg}
+            min={0}
+            max={359}
+            step={1}
+            suffix="°"
+            onChange={setHueDeg}
+          />
+        )}
+        {/* Zero is a pure grey chassis; one is what ships. */}
+        <Axis
+          label="chroma"
+          value={chroma}
+          min={0}
+          max={2.5}
+          step={0.05}
+          onChange={setChroma}
+        />
+        {/* Below one the surfaces deepen, above one they lift. */}
+        <Axis
+          label="depth"
+          value={depth}
+          min={0.25}
+          max={2.5}
+          step={0.05}
+          onChange={setDepth}
+        />
+        <button
+          type="button"
+          onClick={() => {
+            setFollowAccent(true)
+            setChroma(1)
+            setDepth(1)
+            setRoomStops(0)
+            setGridStops(0)
+            setToneStops(0)
+            setHex(shippedAccent())
+          }}
+          className="self-start rounded-sm px-1.5 py-0.5 text-meta text-muted-foreground"
+        >
+          back to what ships
+        </button>
+      </div>
+
+      {/*
+        The studio's own two, which move the 3D surfaces AND NOTHING ELSE.
+
+        Separate from the neutral axes above because they answer a separate
+        question. Those decide what the palette is; these decide how far the
+        room the rasters sit in departs from it -- and they apply whatever the
+        scope is, including "off", which is what makes them the only controls
+        here that can move the viewport while the interface stays exactly as it
+        ships.
+      */}
+      <div
+        className="flex flex-col gap-1.5 border-t pt-2"
+        style={{ borderColor: "rgb(var(--p-line) / 0.25)" }}
+      >
+        <p className="eyebrow">viewport only · 3D</p>
+        {/*
+          The room: the luminance of what the scenes read for --p-ink, which is
+          the background and the fog. Up to five doublings, because on an ink
+          this deep it takes about four to reach a grey a raster can be judged
+          against.
+        */}
+        <Axis
+          label="room"
+          value={roomStops}
+          min={-3}
+          max={5}
+          step={0.1}
+          display={() => (roomColour ? hexOf(roomColour) : "--")}
+          onChange={setRoomStops}
+        />
+        {/*
+          The grid: its ALPHA, not its colour. At 0.14 the grid is a seventh of
+          the pixel, so a colour control over it arrives divided by seven.
+        */}
+        <Axis
+          label="grid"
+          value={gridStops}
+          min={-4}
+          max={2.85}
+          step={0.05}
+          display={(v) => Math.min(1, GRID_OPACITY * 2 ** v).toFixed(3)}
+          onChange={setGridStops}
+        />
+        {/*
+          The grid's tone. Down is toward black, up toward a light grey; 0 is
+          the tone that keeps the grid the distance from the room that --p-line
+          has from --p-ink.
+        */}
+        <Axis
+          label="tone"
+          value={toneStops}
+          min={-7}
+          max={3}
+          step={0.1}
+          display={() => (gridColour ? hexOf(gridColour) : "--")}
+          onChange={setToneStops}
+        />
+        <p className="text-[9px] leading-snug text-muted-foreground">
+          Doublings per unit. Room is the luminance the scenes read for
+          `--p-ink`, and its readout is the colour that comes out; grid is the
+          ground's alpha, whose own value is 0.14 and whose ceiling is 1; tone is
+          the ground's own colour, black through grey. No CSS surface moves with
+          any of them, at any scope.
+        </p>
+      </div>
+
+      {derived && (
+        <>
+          <div className="flex flex-col gap-0.5">
+            {derived.checks.map((c) => (
+              <div
+                key={c.label}
+                className="flex items-baseline gap-2 text-meta"
+                style={{ color: c.ok ? undefined : "var(--destructive-quiet)" }}
+              >
+                <span className="flex-1 truncate text-muted-foreground">
+                  {c.label}
+                </span>
+                <span className="telemetry">{c.ratio.toFixed(2)}</span>
+                <span className="telemetry text-muted-foreground">
+                  /{c.floor}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          {/*
+            The two label rows are the trade this project already hit: a mid
+            tone carries neither black nor white at 4.5, so one of them failing
+            is information rather than an error.
+          */}
+          <p className="text-[9px] leading-snug text-muted-foreground">
+            A mid tone fails both label rows; a light one fails white and a dark
+            one fails ink. Pick which label you want, not a colour that passes
+            both.
+          </p>
+
+          <pre
+            className="telemetry overflow-auto rounded-sm p-1.5 text-[9px] leading-relaxed"
+            style={{ background: "rgb(var(--p-ink))" }}
+          >
+            {block}
+          </pre>
+          <button
+            type="button"
+            onClick={() => navigator.clipboard.writeText(block)}
+            className="rounded-sm bg-accent px-2 py-1 text-meta text-accent-foreground"
+          >
+            Copy the {theme} block
+          </button>
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/AppNav.tsx
+++ b/frontend/src/components/AppNav.tsx
@@ -27,7 +27,12 @@ import {
   Zap,
 } from "lucide-react"
 import { motion } from "motion/react"
-import { useState, type ReactNode } from "react"
+import { useState, type ReactNode, useSyncExternalStore } from "react"
+import {
+  panelSelection,
+  selectPanel,
+  subscribePanelSelection,
+} from "@/lib/panelSelection"
 import { useAuth, type AppScreen } from "@/lib/auth"
 import { cn } from "@/lib/utils"
 import { AvatarCircle } from "@/components/AvatarCircle"
@@ -40,8 +45,6 @@ export interface AppNavProps {
   /** Used instead of goAnalysis when the analysis screen is already open. */
   onAnalysisClick?: () => void
   /** The map's open tool panel, so its children can show which is current. */
-  leftPanel: MapToolId | null
-  onLeftPanelChange: (id: MapToolId | null) => void
   /** The energy screen's open tab, for the same reason. */
   energyTab: EnergyTab
   onEnergyTabChange: (tab: EnergyTab) => void
@@ -59,12 +62,20 @@ interface NavChild {
 export function AppNav({
   hasAnalysis = false,
   onAnalysisClick,
-  leftPanel,
-  onLeftPanelChange,
   energyTab,
   onEnergyTabChange,
   projectSwitcher,
 }: AppNavProps) {
+  /*
+    Subscribed rather than received. Both this column and the map screen read
+    which panel is open, and holding it in App meant a collapse reconciled every
+    screen in order to change which of three panels was drawn. See
+    lib/panelSelection.ts.
+  */
+  const leftPanel = useSyncExternalStore(
+    subscribePanelSelection,
+    panelSelection
+  )
   const {
     user,
     loading,
@@ -106,7 +117,7 @@ export function AppNav({
     label: t.label,
     active: onMap && leftPanel === t.id,
     onSelect: () => {
-      onLeftPanelChange(t.id)
+      selectPanel(t.id)
       goMap()
     },
   }))

--- a/frontend/src/components/DataTableView.tsx
+++ b/frontend/src/components/DataTableView.tsx
@@ -108,7 +108,7 @@ export function DataTableView({
 
       {/* Wide tables scroll inside the section rather than widening the page. */}
       <div className="rounded-sm border border-border bg-background max-h-[22rem] overflow-auto">
-        <table className="w-full min-w-max text-left text-[11px]">
+        <table className="selectable w-full min-w-max text-left text-[11px]">
           <thead className="sticky top-0 z-10">
             <tr
               className="border-b"

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -125,7 +125,7 @@ function CrashDetail({
         {error.message || "The thrown value carried no message."}
       </p>
       {componentStack ? (
-        <pre className="mt-1.5 max-h-40 overflow-auto whitespace-pre-wrap text-micro text-muted-foreground">
+        <pre className="selectable mt-1.5 max-h-40 overflow-auto whitespace-pre-wrap text-micro text-muted-foreground">
           {componentStack.trim()}
         </pre>
       ) : null}

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -18,6 +18,7 @@ import "./leafletDrawPatch"
 import type { LatLngBoundsExpression } from "leaflet"
 import type { Area, PredictResult, GeoJSONGeometry, CompositionOverlay } from "@/lib/types"
 import { BASEMAPS, basemapByName, type BasemapKind } from "@/lib/basemaps"
+import { publishMapPose } from "@/lib/mapPose"
 import { boundsToLatLng, isZeroExtent } from "@/lib/mapLayers"
 import { majoritySmoothOverlay } from "@/lib/smoothOverlay"
 import {
@@ -110,27 +111,40 @@ interface MapViewProps {
   onCreditChange?: (c: { kind: BasemapKind; date: string | null }) => void
 }
 
-// Report map center/zoom to the telemetry readout.
+/**
+ * Reports map centre and zoom, on two paths that run at two rates.
+ *
+ * PER FRAME, to the pose store, which the title bar's readout subscribes to.
+ * `move` fires on every frame of a drag, and this used to call onViewChange
+ * there -- a setState on App, whose subtree is every screen the application
+ * has, sixty times a second. See lib/mapPose.ts.
+ *
+ * ONCE PER GESTURE, to onViewChange, which is where the value is persisted to
+ * preferences and remembered for the return to this screen. Both wanted the
+ * settled value; neither wanted the intermediate ones.
+ */
 function ViewReporter({
   onViewChange,
 }: {
   onViewChange: (v: { lat: number; lon: number; zoom: number }) => void
 }) {
   const map = useMapEvents({
-    move: () => {
-      const c = map.getCenter()
-      onViewChange({ lat: c.lat, lon: c.lng, zoom: map.getZoom() })
-    },
-    zoom: () => {
-      const c = map.getCenter()
-      onViewChange({ lat: c.lat, lon: c.lng, zoom: map.getZoom() })
-    },
+    move: () => publishMapPose(readPose(map)),
+    zoom: () => publishMapPose(readPose(map)),
+    moveend: () => onViewChange(readPose(map)),
+    zoomend: () => onViewChange(readPose(map)),
   })
   useEffect(() => {
-    const c = map.getCenter()
-    onViewChange({ lat: c.lat, lon: c.lng, zoom: map.getZoom() })
+    const pose = readPose(map)
+    publishMapPose(pose)
+    onViewChange(pose)
   }, [map, onViewChange])
   return null
+}
+
+function readPose(map: L.Map): { lat: number; lon: number; zoom: number } {
+  const c = map.getCenter()
+  return { lat: c.lat, lon: c.lng, zoom: map.getZoom() }
 }
 
 

--- a/frontend/src/components/ProjectSwitcher.tsx
+++ b/frontend/src/components/ProjectSwitcher.tsx
@@ -354,14 +354,57 @@ export function ProjectSwitcher({
             return !o
           })
         }
-        className="panel flex max-w-[14rem] items-center gap-1.5 rounded-sm px-2 py-1 text-left text-[11px] text-foreground hover:bg-secondary/40"
+        /*
+          NO BOX AT REST, and no accent on the glyph.
+
+          It wore `panel` -- a bordered, translucent surface -- inside the title
+          bar, which is itself a panel. A panel drawn on a panel reads as a
+          control competing with the wordmark beside it rather than as one more
+          thing on the same row, and the row already separates its parts with a
+          hairline where it means to.
+
+          The accent went with it. DESIGN.md gives that colour three jobs -- a
+          fill, a focus ring, an active state -- and a permanent tint on a
+          folder glyph is none of them. It spent the one colour on screen that
+          is not data on a decoration, beside the project's name, which is what
+          a reader is actually here to read.
+
+          Both come back when the menu is open, because that IS an active state
+          and is exactly what the accent is for.
+        */
+        className={cn(
+          "flex max-w-[14rem] items-center gap-1.5 rounded-sm px-2 py-1 text-left text-[11px] transition-colors",
+          open
+            ? "bg-secondary/60 text-foreground"
+            : "text-foreground hover:bg-secondary/40"
+        )}
         title="Active project"
       >
-        <FolderKanban className="size-3.5 shrink-0 text-primary" />
-        <span className="min-w-0 flex-1 truncate">
+        <FolderKanban
+          className={cn(
+            "size-3.5 shrink-0 transition-colors",
+            open ? "text-primary" : "text-muted-foreground"
+          )}
+        />
+        {/*
+          The name at full strength and the fallback muted, because they are
+          different kinds of thing: one is a value, the other is the absence of
+          one. Drawn alike, "No project" read as a project called that.
+        */}
+        <span
+          className={cn(
+            "min-w-0 flex-1 truncate",
+            !active && "text-muted-foreground"
+          )}
+        >
           {active ? active.name : "No project"}
         </span>
-        <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
+        <ChevronDown
+          className={cn(
+            "size-3 shrink-0 transition-transform",
+            open ? "rotate-180 text-foreground" : "text-muted-foreground"
+          )}
+        />
       </button>
       {menu}
     </div>

--- a/frontend/src/components/TitleBar.tsx
+++ b/frontend/src/components/TitleBar.tsx
@@ -9,13 +9,20 @@ import {
 } from "lucide-react"
 import { BRAND_TAGLINE } from "@/lib/brand"
 import { AvatarCircle } from "@/components/AvatarCircle"
-import type { ReactNode } from "react"
+import {
+  useEffect,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react"
 import {
   BrowserOpenURL,
+  Environment,
   WindowMinimise,
   WindowToggleMaximise,
   Quit,
 } from "../../wailsjs/runtime/runtime"
+import { mapPose, subscribeMapPose } from "@/lib/mapPose"
 import type { LayoutMode, PredictResult } from "@/lib/types"
 import {
   LEAFLET_CREDIT,
@@ -127,6 +134,42 @@ export function TitleBar({
   boardOpen = false,
 }: TitleBarProps) {
   const { screen, user, loading, goProfile, goAuth } = useAuth()
+  /*
+    The live pose, subscribed to rather than received.
+
+    `view` is still the prop and still what App holds, but App only hears about
+    the settled value now, once per gesture -- the reporter used to write every
+    frame of a drag into the root component, and the root's subtree is every
+    screen the application has. This readout is the only thing that wants those
+    intermediate values, so it is the only thing that re-renders for them. The
+    prop stands in until the map has reported: on a screen with no map, and on
+    the first paint of one, the store is empty.
+  */
+  const live = useSyncExternalStore(subscribeMapPose, mapPose)
+  const shown = live ?? view
+  /*
+    Whether the platform draws the window controls, asked once.
+
+    Not a user-agent string: Wails reports the platform it was built for, which
+    is the thing being asked about. Starts false, so the buttons are absent for
+    the frame before the answer arrives -- appearing late reads as the bar
+    settling, where disappearing late reads as a glitch.
+  */
+  const [onMac, setOnMac] = useState(false)
+  useEffect(() => {
+    let cancelled = false
+    void Environment()
+      .then((env) => {
+        if (!cancelled) setOnMac(env.platform === "darwin")
+      })
+      .catch(() => {
+        /* No runtime to ask: leave the buttons drawn, which is the safe way
+           to be wrong -- a window with no controls cannot be closed. */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
   const onMap = screen === "map"
   const hasMap = onMap || screen === "energy"
   // The map's own readings, which need the map to be on screen to mean
@@ -221,13 +264,13 @@ export function TitleBar({
         {showMapTelemetry && (
           <div className="telemetry hidden items-center gap-4 text-[11px] text-muted-foreground lg:flex">
             <span>
-              LAT <span className="text-foreground">{fmtCoord(view.lat, "N", "S")}</span>
+              LAT <span className="text-foreground">{fmtCoord(shown.lat, "N", "S")}</span>
             </span>
             <span>
-              LON <span className="text-foreground">{fmtCoord(view.lon, "E", "W")}</span>
+              LON <span className="text-foreground">{fmtCoord(shown.lon, "E", "W")}</span>
             </span>
             <span>
-              Z <span className="text-foreground">{view.zoom.toFixed(0)}</span>
+              Z <span className="text-foreground">{shown.zoom.toFixed(0)}</span>
             </span>
             {credit && (
               <>
@@ -335,17 +378,32 @@ export function TitleBar({
           </button>
         )}
 
-        <div className="app-no-drag flex items-center gap-1">
-          <WindowButton onClick={WindowMinimise} title="Minimize">
-            <Minus className="h-3.5 w-3.5" />
-          </WindowButton>
-          <WindowButton onClick={WindowToggleMaximise} title="Maximize">
-            <Square className="h-3 w-3" />
-          </WindowButton>
-          <WindowButton onClick={Quit} danger title="Close">
-            <X className="h-3.5 w-3.5" />
-          </WindowButton>
-        </div>
+        {/*
+          NOT ON macOS, where the platform draws them itself.
+
+          These were written for a frameless window, which has no controls of
+          its own. The window is titled now -- frameless made macOS composite it
+          off the path it uses for titled windows, and that slowed every other
+          window sharing its space -- so the traffic lights sit at the other end
+          of this same bar, and drawing a second minimise, maximise and close
+          beside the avatar put two sets of window controls on one window.
+
+          Kept everywhere else: on Windows and Linux this bar is still the only
+          place they exist.
+        */}
+        {!onMac && (
+          <div className="app-no-drag flex items-center gap-1">
+            <WindowButton onClick={WindowMinimise} title="Minimize">
+              <Minus className="h-3.5 w-3.5" />
+            </WindowButton>
+            <WindowButton onClick={WindowToggleMaximise} title="Maximize">
+              <Square className="h-3 w-3" />
+            </WindowButton>
+            <WindowButton onClick={Quit} danger title="Close">
+              <X className="h-3.5 w-3.5" />
+            </WindowButton>
+          </div>
+        )}
       </div>
     </header>
   )

--- a/frontend/src/components/whiteboard/BoardSurface.tsx
+++ b/frontend/src/components/whiteboard/BoardSurface.tsx
@@ -2445,9 +2445,11 @@ export function BoardSurface({
         },
         onCardsLoaded: (loaded, total) => setCards({ loaded, total }),
         groups,
-        background: tokenColor("--p-ink", "#171717"),
-        line: tokenColor("--p-line", "#424C5A"),
-        accent: tokenColor("--p-accent", "#3578CF"),
+        // --v-*, not --p-*: the studio is a room the rasters hang in and the
+        // panels around it are a reading surface. See index.css.
+        background: tokenColor("--v-ink", "#333333"),
+        line: tokenColor("--v-line", "#F6F6F6"),
+        accent: tokenColor("--p-accent", "#ED8744"),
         // The separation in force at the moment of the build, so a plane lands
         // at its true height rather than at the base for a frame.
         gap: gapRef.current,

--- a/frontend/src/components/whiteboard/BoardSurface.tsx
+++ b/frontend/src/components/whiteboard/BoardSurface.tsx
@@ -101,7 +101,11 @@ import type {
   PredictResult,
 } from "@/lib/types"
 import type { BoardHandle, PlaneState } from "@/components/whiteboard/boardScene"
-import { createBoard, tokenColor } from "@/components/whiteboard/boardScene"
+import {
+  createBoard,
+  tokenColor,
+  type BoardStats,
+} from "@/components/whiteboard/boardScene"
 import { cn } from "@/lib/utils"
 import { remToPx } from "@/lib/boardPartition"
 import {
@@ -474,6 +478,24 @@ export function BoardSurface({
 }) {
   const hostRef = useRef<HTMLDivElement>(null)
   const boardRef = useRef<BoardHandle | null>(null)
+  /*
+    What the board costs, polled rather than pushed.
+
+    Twice a second, which is as fast as a figure is worth reading and slow
+    enough that displaying it is not itself the load. Pushing from the scene
+    would ask React to re-render at the frame rate in order to show the frame
+    rate, and the stall being looked for would be partly this.
+
+    Null until the scene reports: on a board with nothing on it there is no
+    frame to have taken any time.
+  */
+  const [boardStats, setBoardStats] = useState<BoardStats | null>(null)
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setBoardStats(boardRef.current?.stats() ?? null)
+    }, 500)
+    return () => window.clearInterval(id)
+  }, [])
 
   /**
    * What the column is listing, and which asset it is describing.
@@ -3943,6 +3965,7 @@ export function BoardSurface({
         legend of anything. Twenty-two pixels at the foot buys that back.
       */}
       <StudioStatusBar
+        stats={boardStats}
         running={!!runRunning}
         progress={runProgress}
         runLog={runLog ?? []}

--- a/frontend/src/components/whiteboard/MethodPanel.tsx
+++ b/frontend/src/components/whiteboard/MethodPanel.tsx
@@ -103,7 +103,7 @@ function Trace({
       <p className="eyebrow !text-[9px] pb-1">
         {running ? "Running" : "Last run"}
       </p>
-      <ul className="panel-scroll flex max-h-40 flex-col gap-0.5 overflow-y-auto">
+      <ul className="selectable panel-scroll flex max-h-40 flex-col gap-0.5 overflow-y-auto">
         {entries.map((e, i) => {
           const last = i === entries.length - 1
           return (

--- a/frontend/src/components/whiteboard/StudioStatusBar.tsx
+++ b/frontend/src/components/whiteboard/StudioStatusBar.tsx
@@ -20,12 +20,14 @@
  */
 import { Loader2 } from "lucide-react"
 import type { RunLogEntry } from "@/lib/runLog"
+import type { BoardStats } from "@/components/whiteboard/boardScene"
 import { cn } from "@/lib/utils"
 
 /** The strip's height, which the area tree subtracts from its rectangle. */
 export const STATUS_BAR_PX = 22
 
 export function StudioStatusBar({
+  stats,
   running,
   progress,
   runLog,
@@ -34,6 +36,8 @@ export function StudioStatusBar({
   areas,
   onOpenLog,
 }: {
+  /** What the surface is costing, or null before it has drawn a frame. */
+  stats: BoardStats | null
   running: boolean
   /** 0 to 100, from the sidecar's own stages. */
   progress: number
@@ -73,6 +77,75 @@ export function StudioStatusBar({
         <Binding keys="Shift Middle" what="Pan" />
         <Binding keys="Ctrl Middle" what="Zoom" />
       </span>
+
+      {/*
+        What the surface costs, beside what the pointer does, because both
+        answer questions about THIS viewport and a reader checking whether a
+        drag is smooth is already looking here.
+
+        EVERY FIGURE IS MEASURED. The frame time is the median interval between
+        the frames that actually happened -- the board renders on demand, so a
+        mean since the scene opened would hide the stall being looked for. The
+        counters are three's own renderer.info, which is what was submitted
+        rather than an estimate of it.
+
+        There is no CPU or process-memory figure here, and it is not an
+        oversight. A WKWebView exposes neither: `performance.memory` is not
+        implemented in WebKit, and the process doing the work is a WebContent
+        XPC service whose only link back to this application is a handful of
+        transient cache files. A number invented for those columns would be
+        worse than their absence.
+      */}
+      {stats && stats.fps > 0 && (
+        <span className="telemetry hidden shrink-0 items-center gap-2 text-[9px] text-muted-foreground xl:flex">
+          {/*
+            The browser's own rate first, because it is the figure that decides
+            whether anything below it is the studio's fault. It comes from a
+            loop that submits no drawing, so it measures the page rather than
+            the scene.
+          */}
+          <Figure
+            label="page"
+            value={`${stats.displayHz.toFixed(0)}hz`}
+            warn={stats.displayHz < 45}
+          />
+          <Figure
+            label="fps"
+            value={stats.fps.toFixed(0)}
+            /* Under 30 a drag reads as stepping rather than moving. */
+            warn={stats.fps < 30}
+          />
+          {/*
+            Two times, because they answer different questions and only one of
+            them accuses the surface. `work` is what a frame cost; `gap` is how
+            long the board waited before being asked for one, which on a
+            render-on-demand surface is mostly idleness and not a fault.
+          */}
+          <Figure label="work" value={`${stats.workMs.toFixed(1)}ms`} warn={stats.workMs > 16} />
+          <Figure label="gap" value={`${stats.frameMs.toFixed(0)}ms`} />
+          {/*
+            What a pointer event costs and how many arrive. The frame timing
+            cannot see these -- pointer handlers run outside the animation
+            callback -- and they are the one path that could block the main
+            thread between frames while every frame itself measured fast.
+          */}
+          <Figure label="move" value={`${stats.moveMs.toFixed(1)}ms`} warn={stats.moveMs > 4} />
+          <Figure label="ev" value={`${stats.moveHz.toFixed(0)}/s`} />
+          <Figure label="calls" value={String(stats.calls)} />
+          <Figure label="tris" value={formatCount(stats.triangles)} />
+          <Figure label="tex" value={String(stats.textures)} />
+          <Figure label="geo" value={String(stats.geometries)} />
+          {/*
+            The drawing buffer, because the cost of a frame that draws almost
+            nothing is the cost of moving it: WebKit resolves and copies this
+            many pixels into a window-server surface every frame.
+          */}
+          <Figure
+            label={`buf @${stats.pixelRatio}x`}
+            value={`${stats.bufferW}x${stats.bufferH}`}
+          />
+        </span>
+      )}
 
       <span className="flex-1" />
 
@@ -128,6 +201,36 @@ export function StudioStatusBar({
       </span>
     </div>
   )
+}
+
+/** One measured figure: the number in the foreground, its unit beside it. */
+function Figure({
+  label,
+  value,
+  warn = false,
+}: {
+  label: string
+  value: string
+  warn?: boolean
+}) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span
+        className="tabular-nums"
+        style={{ color: warn ? "var(--destructive-quiet)" : "rgb(var(--p-text))" }}
+      >
+        {value}
+      </span>
+      {label}
+    </span>
+  )
+}
+
+/** Thousands as k, because a triangle count is read for its order of size. */
+function formatCount(n: number): string {
+  if (n < 1000) return String(n)
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`
+  return `${(n / 1_000_000).toFixed(1)}M`
 }
 
 /** One binding: the key in the foreground, what it does beside it. */

--- a/frontend/src/components/whiteboard/StudioStatusBar.tsx
+++ b/frontend/src/components/whiteboard/StudioStatusBar.tsx
@@ -21,6 +21,12 @@
 import { Loader2 } from "lucide-react"
 import type { RunLogEntry } from "@/lib/runLog"
 import type { BoardStats } from "@/components/whiteboard/boardScene"
+import { useSyncExternalStore } from "react"
+import {
+  TELEMETRY_FIGURES,
+  studioTelemetry,
+  subscribeStudioTelemetry,
+} from "@/lib/studioTelemetry"
 import { cn } from "@/lib/utils"
 
 /** The strip's height, which the area tree subtracts from its rectangle. */
@@ -49,6 +55,20 @@ export function StudioStatusBar({
   onOpenLog?: () => void
 }) {
   const stage = runLog.length ? runLog[runLog.length - 1] : null
+  /*
+    Which figures to draw, subscribed rather than received.
+
+    Off by default and each switched separately in Settings, because a status
+    bar reporting its own performance to a reader who did not ask is chrome
+    spent on a question they are not holding. One of them is not free -- see
+    lib/studioTelemetry.ts -- and the scene watches the same store, so switching
+    that one off stops the work as well as the display.
+  */
+  const shows = useSyncExternalStore(
+    subscribeStudioTelemetry,
+    studioTelemetry
+  )
+  const anyShown = TELEMETRY_FIGURES.some((f) => shows[f.key])
 
   return (
     <div
@@ -96,54 +116,49 @@ export function StudioStatusBar({
         transient cache files. A number invented for those columns would be
         worse than their absence.
       */}
-      {stats && stats.fps > 0 && (
+      {stats && anyShown && (
         <span className="telemetry hidden shrink-0 items-center gap-2 text-[9px] text-muted-foreground xl:flex">
-          {/*
-            The browser's own rate first, because it is the figure that decides
-            whether anything below it is the studio's fault. It comes from a
-            loop that submits no drawing, so it measures the page rather than
-            the scene.
-          */}
-          <Figure
-            label="page"
-            value={`${stats.displayHz.toFixed(0)}hz`}
-            warn={stats.displayHz < 45}
-          />
-          <Figure
-            label="fps"
-            value={stats.fps.toFixed(0)}
-            /* Under 30 a drag reads as stepping rather than moving. */
-            warn={stats.fps < 30}
-          />
-          {/*
-            Two times, because they answer different questions and only one of
-            them accuses the surface. `work` is what a frame cost; `gap` is how
-            long the board waited before being asked for one, which on a
-            render-on-demand surface is mostly idleness and not a fault.
-          */}
-          <Figure label="work" value={`${stats.workMs.toFixed(1)}ms`} warn={stats.workMs > 16} />
-          <Figure label="gap" value={`${stats.frameMs.toFixed(0)}ms`} />
-          {/*
-            What a pointer event costs and how many arrive. The frame timing
-            cannot see these -- pointer handlers run outside the animation
-            callback -- and they are the one path that could block the main
-            thread between frames while every frame itself measured fast.
-          */}
-          <Figure label="move" value={`${stats.moveMs.toFixed(1)}ms`} warn={stats.moveMs > 4} />
-          <Figure label="ev" value={`${stats.moveHz.toFixed(0)}/s`} />
-          <Figure label="calls" value={String(stats.calls)} />
-          <Figure label="tris" value={formatCount(stats.triangles)} />
-          <Figure label="tex" value={String(stats.textures)} />
-          <Figure label="geo" value={String(stats.geometries)} />
-          {/*
-            The drawing buffer, because the cost of a frame that draws almost
-            nothing is the cost of moving it: WebKit resolves and copies this
-            many pixels into a window-server surface every frame.
-          */}
-          <Figure
-            label={`buf @${stats.pixelRatio}x`}
-            value={`${stats.bufferW}x${stats.bufferH}`}
-          />
+          {shows.page && (
+            <Figure
+              label="page"
+              value={`${stats.displayHz.toFixed(0)}hz`}
+              warn={stats.displayHz > 0 && stats.displayHz < 45}
+            />
+          )}
+          {shows.fps && (
+            <>
+              {/* Under 30 a drag reads as stepping rather than moving. */}
+              <Figure label="fps" value={stats.fps.toFixed(0)} warn={stats.fps > 0 && stats.fps < 30} />
+              <Figure label="gap" value={`${stats.frameMs.toFixed(0)}ms`} />
+            </>
+          )}
+          {shows.work && (
+            <Figure label="work" value={`${stats.workMs.toFixed(1)}ms`} warn={stats.workMs > 16} />
+          )}
+          {shows.pointer && (
+            <>
+              <Figure label="move" value={`${stats.moveMs.toFixed(1)}ms`} warn={stats.moveMs > 4} />
+              <Figure label="ev" value={`${stats.moveHz.toFixed(0)}/s`} />
+            </>
+          )}
+          {shows.draws && (
+            <>
+              <Figure label="calls" value={String(stats.calls)} />
+              <Figure label="tris" value={formatCount(stats.triangles)} />
+            </>
+          )}
+          {shows.resources && (
+            <>
+              <Figure label="tex" value={String(stats.textures)} />
+              <Figure label="geo" value={String(stats.geometries)} />
+            </>
+          )}
+          {shows.buffer && (
+            <Figure
+              label={`buf @${stats.pixelRatio}x`}
+              value={`${stats.bufferW}x${stats.bufferH}`}
+            />
+          )}
         </span>
       )}
 

--- a/frontend/src/components/whiteboard/boardScene.ts
+++ b/frontend/src/components/whiteboard/boardScene.ts
@@ -70,6 +70,10 @@ import {
   onPaletteChange,
   viewportPaletteOverride,
 } from "@/lib/paletteWatch"
+import {
+  subscribeStudioTelemetry,
+  telemetryShows,
+} from "@/lib/studioTelemetry"
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js"
 import { ViewHelper } from "three/examples/jsm/helpers/ViewHelper.js"
 
@@ -1607,7 +1611,12 @@ export function createBoard(
   let tickAt = 0
   let tickRaf = 0
   const tick = (t: number) => {
-    if (disposed) return
+    if (disposed || !telemetryShows("page")) {
+      tickRaf = 0
+      tickAt = 0
+      displayMs.length = 0
+      return
+    }
     if (tickAt) {
       displayMs.push(t - tickAt)
       if (displayMs.length > 60) displayMs.shift()
@@ -1615,7 +1624,25 @@ export function createBoard(
     tickAt = t
     tickRaf = requestAnimationFrame(tick)
   }
-  tickRaf = requestAnimationFrame(tick)
+  /*
+    Started only when the figure is switched on, and stopped when it is off.
+
+    This is the one measurement that is not free, so it does not run for a
+    reader who is not reading it. Subscribing rather than reading once means the
+    setting takes effect on the open studio instead of on the next one.
+  */
+  const syncTicker = () => {
+    if (telemetryShows("page")) {
+      if (!tickRaf && !disposed) tickRaf = requestAnimationFrame(tick)
+    } else if (tickRaf) {
+      cancelAnimationFrame(tickRaf)
+      tickRaf = 0
+      tickAt = 0
+      displayMs.length = 0
+    }
+  }
+  const stopTelemetryWatch = subscribeStudioTelemetry(syncTicker)
+  syncTicker()
 
   const render = () => {
     if (disposed || raf) return
@@ -2557,6 +2584,7 @@ export function createBoard(
       echoPool.length = 0
       if (raf) cancelAnimationFrame(raf)
       if (tickRaf) cancelAnimationFrame(tickRaf)
+      stopTelemetryWatch()
       stopPaletteWatch()
       observer.disconnect()
       controls.removeEventListener("change", render)

--- a/frontend/src/components/whiteboard/boardScene.ts
+++ b/frontend/src/components/whiteboard/boardScene.ts
@@ -154,6 +154,45 @@ export interface PlaneState {
  * Only the two units this variable is ever written in. Anything else returns 0,
  * which is the same fallback the caller had and is honest about not knowing.
  */
+/** What one board is costing to draw. Every figure is measured, none derived. */
+export interface BoardStats {
+  /**
+   * Frames per second the BROWSER delivers, from a loop that draws nothing.
+   *
+   * Near the display's own rate means the page's frame loop is healthy and a
+   * large `frameMs` is the board idling. Far below it means the browser cannot
+   * finish a frame, and nothing in this scene is the reason.
+   */
+  displayHz: number
+  /** Median time inside one pointermove handler, in milliseconds. */
+  moveMs: number
+  /** Pointer events arriving per second, over the last full second. */
+  moveHz: number
+  /** The drawing buffer, in device pixels, and the ratio it was built at. */
+  bufferW: number
+  bufferH: number
+  pixelRatio: number
+  /**
+   * Median time spent INSIDE a frame: controls, draw, helper, labels.
+   *
+   * This is the figure that says whether the surface is slow. It is not the
+   * interval -- see workMs in createBoard for why the two differ here.
+   */
+  workMs: number
+  /** Median interval between frames, which on an idle board is mostly waiting. */
+  frameMs: number
+  /** The interval as a rate, or 0 before two frames have been drawn. */
+  fps: number
+  /** three's renderer.info.render.calls for the last frame. */
+  calls: number
+  triangles: number
+  /** Live GPU resources: renderer.info.memory. */
+  textures: number
+  geometries: number
+  /** Compiled shader programs held by the renderer. */
+  programs: number
+}
+
 export interface BoardHandle {
   /** Redraw once. The board renders on demand, not in a permanent loop. */
   render: () => void
@@ -277,6 +316,14 @@ export interface BoardHandle {
    */
   focusPlane: (groupId: string, layerId: string) => boolean
   /** Release the GL context and every resource attached to it. */
+  /**
+   * What the surface is costing, for the studio's status bar.
+   *
+   * Read on demand rather than pushed: the caller polls at a rate a person can
+   * read, and a scene that reported every frame would be asking React to
+   * re-render at the frame rate to display the frame rate.
+   */
+  stats: () => BoardStats
   dispose: () => void
 }
 
@@ -1216,6 +1263,23 @@ export function createBoard(
   }
 
   const onPointerMove = (e: PointerEvent) => {
+    const began = performance.now()
+    moveCount++
+    if (!moveWindowAt) moveWindowAt = began
+    else if (began - moveWindowAt >= 1000) {
+      moveHz = (moveCount * 1000) / (began - moveWindowAt)
+      moveCount = 0
+      moveWindowAt = began
+    }
+    try {
+      onPointerMoveInner(e)
+    } finally {
+      moveMs.push(performance.now() - began)
+      if (moveMs.length > 60) moveMs.shift()
+    }
+  }
+
+  const onPointerMoveInner = (e: PointerEvent) => {
     if (!dragging) {
       sampleProbe(e)
       return
@@ -1478,10 +1542,91 @@ export function createBoard(
     opts.onLabels(spots)
   }
 
+  /*
+    What the last frames cost, and what they drew.
+
+    The board renders on demand, so a frame rate here is not "how fast the loop
+    runs" -- it is how long the frames that DID happen took, which is the number
+    that says whether a drag is smooth. Kept as a small ring rather than an
+    average since the scene opened: a mean over a session hides the stall that
+    is being looked for.
+
+    The counters come from three's own renderer.info, so they are what was
+    submitted rather than an estimate of it.
+  */
+  const frameMs: number[] = []
+  /*
+    And what the frame COST, which is a different number from what it waited.
+
+    The board renders on demand, so the gap between two frames includes however
+    long nothing asked for one. A readout of that gap alone reports a scene
+    sitting still as a slow scene -- the interval is honest about the rate and
+    says nothing about the work, and the two are only the same thing in a loop
+    that never idles. This one idles by design.
+
+    Measured around the whole callback rather than around renderer.render: what
+    a dropped frame costs includes the controls' update and the label
+    projection, and blaming only the draw would point at the wrong half.
+  */
+  const workMs: number[] = []
+  let lastFrameAt = 0
+
+  /*
+    How fast the BROWSER is handing out frames, measured by a loop that draws
+    nothing.
+
+    `frameMs` cannot answer this on its own. The board renders on demand, so a
+    gap of 70ms is either the browser delivering frames at 14Hz or the board
+    only being asked for one that often -- opposite diagnoses with opposite
+    fixes, and the same number.
+
+    This ticker asks for a frame, records when it arrives, and asks again. It
+    submits no drawing, so what it measures is the page's own frame loop:
+    whatever style, layout, paint and compositing the browser does between
+    handing out one frame and the next.
+
+    A DIAGNOSTIC, and not free: a self-scheduling rAF keeps the page animating,
+    which is the state being measured but not one the studio would otherwise
+    sit in.
+  */
+  /*
+    What a pointer event costs, measured because the frame timing cannot see it.
+
+    `workMs` covers the requestAnimationFrame callback. Pointer handlers run
+    OUTSIDE it: if a move handler were expensive, the main thread would be busy
+    between frames, the browser would deliver them late, and the readout would
+    show a fast frame and a slow page -- which is exactly what it does show. So
+    this closes the one gap in that reasoning rather than assuming it shut.
+  */
+  const moveMs: number[] = []
+  let moveCount = 0
+  let moveWindowAt = 0
+  let moveHz = 0
+
+  const displayMs: number[] = []
+  let tickAt = 0
+  let tickRaf = 0
+  const tick = (t: number) => {
+    if (disposed) return
+    if (tickAt) {
+      displayMs.push(t - tickAt)
+      if (displayMs.length > 60) displayMs.shift()
+    }
+    tickAt = t
+    tickRaf = requestAnimationFrame(tick)
+  }
+  tickRaf = requestAnimationFrame(tick)
+
   const render = () => {
     if (disposed || raf) return
     raf = requestAnimationFrame(() => {
       raf = 0
+      const began = performance.now()
+      if (lastFrameAt) {
+        frameMs.push(began - lastFrameAt)
+        if (frameMs.length > 60) frameMs.shift()
+      }
+      lastFrameAt = began
       controls.update()
       updateFog()
       renderer.clear()
@@ -1491,6 +1636,8 @@ export function createBoard(
       // behind the raster.
       viewHelper.render(renderer)
       reportLabels()
+      workMs.push(performance.now() - began)
+      if (workMs.length > 60) workMs.shift()
     })
   }
   controls.addEventListener("change", render)
@@ -2371,6 +2518,31 @@ export function createBoard(
         render()
       }
     },
+    stats() {
+      const mid = (xs: number[]) => {
+        if (!xs.length) return 0
+        const sorted = [...xs].sort((x, y) => x - y)
+        return sorted[Math.floor(sorted.length / 2)]
+      }
+      const median = mid(frameMs)
+      const display = mid(displayMs)
+      return {
+        displayHz: display > 0 ? 1000 / display : 0,
+        moveMs: mid(moveMs),
+        moveHz,
+        bufferW: renderer.domElement.width,
+        bufferH: renderer.domElement.height,
+        pixelRatio: renderer.getPixelRatio(),
+        workMs: mid(workMs),
+        frameMs: median,
+        fps: median > 0 ? 1000 / median : 0,
+        calls: renderer.info.render.calls,
+        triangles: renderer.info.render.triangles,
+        textures: renderer.info.memory.textures,
+        geometries: renderer.info.memory.geometries,
+        programs: renderer.info.programs?.length ?? 0,
+      }
+    },
     dispose() {
       disposed = true
       // Returns every echo to the pool first, so the loop below sees them all.
@@ -2384,6 +2556,7 @@ export function createBoard(
       for (const echo of echoPool) echo.material.dispose()
       echoPool.length = 0
       if (raf) cancelAnimationFrame(raf)
+      if (tickRaf) cancelAnimationFrame(tickRaf)
       stopPaletteWatch()
       observer.disconnect()
       controls.removeEventListener("change", render)

--- a/frontend/src/components/whiteboard/boardScene.ts
+++ b/frontend/src/components/whiteboard/boardScene.ts
@@ -66,6 +66,10 @@ import {
   file consult the partition without the chrome it must not pull.
 */
 import type { CardGroup, CardPlane } from "@/lib/boardLayout"
+import {
+  onPaletteChange,
+  viewportPaletteOverride,
+} from "@/lib/paletteWatch"
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js"
 import { ViewHelper } from "three/examples/jsm/helpers/ViewHelper.js"
 
@@ -82,6 +86,24 @@ import { ViewHelper } from "three/examples/jsm/helpers/ViewHelper.js"
  * Measured against three 0.185: `rgb(23 23 23)` parses to ffffff,
  * `rgb(23,23,23)` to 171717.
  */
+/**
+ * The ground grid's alpha.
+ *
+ * Sparse and dim on purpose -- see addGround. Named because the palette
+ * override can replace it, and a literal in two places would let the override
+ * and the default disagree about what "the grid's own alpha" means.
+ */
+const GRID_OPACITY = 0.14
+
+/** --v-grid-alpha, or the constant above where the token is missing. */
+function gridAlpha(): number {
+  const raw = getComputedStyle(document.documentElement)
+    .getPropertyValue("--v-grid-alpha")
+    .trim()
+  const n = Number(raw)
+  return Number.isFinite(n) && n > 0 && n <= 1 ? n : GRID_OPACITY
+}
+
 /** Arrowhead size, in board units where the largest area's side is 1. */
 const ARROW_RADIUS = 0.018
 const ARROW_LENGTH = 0.055
@@ -408,7 +430,25 @@ export function createBoard(
   host.appendChild(renderer.domElement)
 
   const scene = new Scene()
-  scene.background = new Color(opts.background)
+  /*
+    The chassis colours the board is painted in RIGHT NOW, rather than the ones
+    it was built with.
+
+    Held together and mutable because the theme can move under a scene that is
+    already open, and everything below reads from here instead of from `opts`
+    -- including the ground, which is built later than this and would otherwise
+    be the one object still wearing the palette that was current at the build.
+
+    `opts` stays the source of the first values: BoardSurface reads the tokens
+    off the computed style before calling, and repainting immediately to
+    re-read what it just passed would be a second answer to a settled question.
+  */
+  const palette = {
+    background: opts.background,
+    line: opts.line,
+    accent: opts.accent,
+  }
+  scene.background = new Color(palette.background)
 
   const FOV = 45
   /*
@@ -421,7 +461,7 @@ export function createBoard(
     Near and far are set once the cards are laid out, since both depend on how
     large the stack turned out to be.
   */
-  scene.fog = new Fog(new Color(opts.background).getHex(), 1, 10)
+  scene.fog = new Fog(new Color(palette.background).getHex(), 1, 10)
 
   const camera = new PerspectiveCamera(FOV, 1, 0.01, 1000)
 
@@ -1294,6 +1334,16 @@ export function createBoard(
   }
 
   /**
+   * The ground's material, once there is one.
+   *
+   * Kept because the ground is the only theme-painted thing here that is built
+   * on demand rather than with the scene, so a repaint cannot assume it exists
+   * and cannot find it by walking the graph without knowing what it is looking
+   * at.
+   */
+  let gridMaterial: LineBasicMaterial | null = null
+
+  /**
    * The ground the stack sits over: a sparse grid, fading out.
    *
    * Sparse and dim on purpose. A dense bright grid is what makes a surface
@@ -1307,15 +1357,16 @@ export function createBoard(
     // Ten cells across the object, out to four times its radius: fine enough
     // to read motion against, coarse enough not to draw attention.
     const span = radius * 8
-    const grid = new GridHelper(span, 20, opts.line, opts.line)
+    const grid = new GridHelper(span, 20, palette.line, palette.line)
     const material = grid.material as LineBasicMaterial
     material.transparent = true
-    material.opacity = 0.14
+    material.opacity = viewportPaletteOverride()?.gridOpacity ?? gridAlpha()
     material.depthWrite = false
     // Below the lowest plane, so it never fights the rasters for the surface.
     grid.position.y = -radius * 0.35
     scene.add(grid)
     disposables.push(grid.geometry, material)
+    gridMaterial = material
 
     gridSpan = span
   }
@@ -1564,7 +1615,7 @@ export function createBoard(
     boundary to reconcile with the first.
   */
   const footprintMaterial = new LineBasicMaterial({
-    color: new Color(opts.line),
+    color: new Color(palette.line),
     transparent: true,
     opacity: 0.55,
     depthWrite: false,
@@ -1578,7 +1629,7 @@ export function createBoard(
     for a property with two values.
   */
   const footprintSelected = new LineBasicMaterial({
-    color: new Color(opts.accent),
+    color: new Color(palette.accent),
     transparent: true,
     opacity: 0.95,
     depthWrite: false,
@@ -1617,7 +1668,7 @@ export function createBoard(
     geometry was disposed -- three only drops a replaced attribute then.
   */
   const linkMaterial = new LineBasicMaterial({
-    color: new Color(opts.accent),
+    color: new Color(palette.accent),
     transparent: true,
     opacity: 0.45,
     depthWrite: false,
@@ -1667,13 +1718,13 @@ export function createBoard(
     already is when it follows a line.
   */
   const pathMaterial = new LineBasicMaterial({
-    color: new Color(opts.accent),
+    color: new Color(palette.accent),
     transparent: true,
     opacity: 0.85,
     depthWrite: false,
   })
   const arrowMaterial = new MeshBasicMaterial({
-    color: new Color(opts.accent),
+    color: new Color(palette.accent),
     transparent: true,
     opacity: 0.9,
     depthWrite: false,
@@ -1870,12 +1921,64 @@ export function createBoard(
     are per plane and disposed individually.
   */
   const outlineMaterial = new LineBasicMaterial({
-    color: new Color(opts.accent),
+    color: new Color(palette.accent),
     transparent: true,
     opacity: 0.9,
     depthWrite: false,
   })
   disposables.push(outlineMaterial)
+
+  /*
+    Re-reads the chassis tokens and repaints everything drawn in them.
+
+    IN PLACE, not by rebuilding. A rebuilt scene decodes every raster again and
+    starts from the layout's first answer, so changing the theme would undo an
+    arrangement -- the planes someone dragged apart would spring back, and the
+    textures would go for a second trip through the decoder to arrive
+    identical. Nothing here is geometry: it is a colour per material, plus the
+    two on the scene itself.
+
+    Named for what it does rather than exposed on the handle, because no caller
+    asks for it. What asks is the attribute the theme is written to, and this
+    subscribes to that itself -- see onPaletteChange for why a WebGL surface is
+    the one place in the application that has to.
+  */
+  const repaint = () => {
+    /*
+      The override wins where there is one. It is how the studio can be held on
+      one palette while the panels around it move to another, which is the only
+      way to judge the two against each other -- they read the same tokens
+      otherwise, by design.
+    */
+    const pinned = viewportPaletteOverride()
+    palette.background = pinned
+      ? pinned.background
+      : tokenColor("--v-ink", palette.background)
+    palette.line = pinned ? pinned.line : tokenColor("--v-line", palette.line)
+    palette.accent = pinned
+      ? pinned.accent
+      : tokenColor("--p-accent", palette.accent)
+    ;(scene.background as Color).set(palette.background)
+    // The fog is the background, so the ground still dissolves into the edge
+    // of the viewport rather than into the colour the viewport used to be.
+    if (scene.fog) scene.fog.color.set(palette.background)
+    if (gridMaterial) {
+      gridMaterial.color.set(palette.line)
+      gridMaterial.opacity = pinned?.gridOpacity ?? gridAlpha()
+    }
+    footprintMaterial.color.set(palette.line)
+    for (const m of [
+      footprintSelected,
+      linkMaterial,
+      pathMaterial,
+      arrowMaterial,
+      outlineMaterial,
+    ]) {
+      m.color.set(palette.accent)
+    }
+    render()
+  }
+  const stopPaletteWatch = onPaletteChange(repaint)
 
   /*
     Every plane on the board, drawn in a single order.
@@ -2281,6 +2384,7 @@ export function createBoard(
       for (const echo of echoPool) echo.material.dispose()
       echoPool.length = 0
       if (raf) cancelAnimationFrame(raf)
+      stopPaletteWatch()
       observer.disconnect()
       controls.removeEventListener("change", render)
       controls.dispose()

--- a/frontend/src/components/whiteboard/standScene.ts
+++ b/frontend/src/components/whiteboard/standScene.ts
@@ -54,6 +54,10 @@ import {
 } from "three"
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js"
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js"
+import {
+  onPaletteChange,
+  viewportPaletteOverride,
+} from "@/lib/paletteWatch"
 
 /**
  * The sky the stand stands under, as the AOI's own record measured it.
@@ -109,6 +113,15 @@ const RAYLEIGH_TAU: [number, number, number] = [0.0733, 0.1052, 0.242]
   is a desaturated green, because light that has been through a leaf twice is
   much duller than the leaf.
 */
+/** The ground grid's alpha, matching boardScene's. See ViewportPalette. */
+const GRID_OPACITY = 0.14
+
+/** --v-grid-alpha off the host, or the constant above where it is missing. */
+function gridAlpha(host: HTMLElement): number {
+  const n = Number(getComputedStyle(host).getPropertyValue("--v-grid-alpha").trim())
+  return Number.isFinite(n) && n > 0 && n <= 1 ? n : GRID_OPACITY
+}
+
 const CLEAR_SKY = new Color(0xbcd6ff)
 const OVERCAST_SKY = new Color(0xd8d5cf)
 const SOIL_BOUNCE = new Color(0x6b5a3e)
@@ -319,13 +332,13 @@ export function createStandScene(
     set per frame, because fog is measured from the CAMERA: a fixed near plane
     is correct at exactly one zoom and eats the stand at every other.
   */
-  const groundColour = tokenColor(host, "--p-line")
+  const groundColour = tokenColor(host, "--v-line")
   // `--p-ink` is the studio viewport's own background, which is what
   // BoardSurface paints behind the board scene. A token this file invented
   // ("--p-surface-sunken") does not exist, and tokenColor answers a missing
   // one with near-black -- close enough to the panel to look deliberate and
   // wrong enough that the haze would never quite dissolve into it.
-  const hazeColour = tokenColor(host, "--p-ink")
+  const hazeColour = tokenColor(host, "--v-ink")
   scene.fog = new Fog(hazeColour.getHex(), 1, 10)
 
   let grid: GridHelper | null = null
@@ -370,7 +383,7 @@ export function createStandScene(
     const g = new GridHelper(span, 20, groundColour, groundColour)
     const material = g.material as LineBasicMaterial
     material.transparent = true
-    material.opacity = 0.14
+    material.opacity = viewportPaletteOverride()?.gridOpacity ?? gridAlpha(host)
     // Never writes depth, so it cannot fight the plants for a surface.
     material.depthWrite = false
     // At the base of the stems rather than at y=0: Helios grows from a ground
@@ -479,6 +492,39 @@ export function createStandScene(
       renderer.render(scene, camera)
     })
   }
+
+  /*
+    Re-reads the two chassis tokens this scene is painted in, and repaints.
+
+    The stand's own colours do not take part. The sky, the soil bounce and the
+    canopy bounce are radiances the light model reads, and the organ colours
+    say blade from stem -- none of them is chrome, and a leaf that turned with
+    the interface would be reporting the theme instead of the plant. What
+    follows the chassis here is what the chassis owns: the ground the stand
+    sits on, and the haze it stands in.
+
+    In place rather than by rebuilding, for the reason boardScene repaints the
+    same way: the mesh behind this view is fetched over HTTP and parsed, and a
+    colour is not a reason to do that twice.
+  */
+  const repaint = () => {
+    // The override wins where there is one -- see boardScene's repaint.
+    const pinned = viewportPaletteOverride()
+    groundColour.copy(
+      pinned ? new Color(pinned.line) : tokenColor(host, "--v-line")
+    )
+    hazeColour.copy(
+      pinned ? new Color(pinned.background) : tokenColor(host, "--v-ink")
+    )
+    if (scene.fog) scene.fog.color.copy(hazeColour)
+    if (grid) {
+      const m = grid.material as LineBasicMaterial
+      m.color.copy(groundColour)
+      m.opacity = pinned?.gridOpacity ?? gridAlpha(host)
+    }
+    render()
+  }
+  const stopPaletteWatch = onPaletteChange(repaint)
 
   // Whether the reader has moved the camera since the stand was framed. A
   // resize should re-fit a view nobody has touched -- the first one arrives
@@ -839,6 +885,7 @@ export function createStandScene(
     dispose() {
       disposed = true
       if (raf) cancelAnimationFrame(raf)
+      stopPaletteWatch()
       observer.disconnect()
       // Removed explicitly rather than left to controls.dispose(): both
       // closures hold the renderer and the scene, and a listener that outlives

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -29,29 +29,39 @@
     frontend/src/lib/contrast.ts re-derives them from these channels so a future
     edit that breaks one fails a check rather than shipping.
 
-    The surfaces sit higher than either predecessor -- ink 26 against 23, the
-    raised surface 53 against 41 -- which is what moved --p-line-strong. Lifting
-    a surface does not lift the boundary that separates it.
+    The surfaces sit well above either predecessor -- ink 33 against 23, the
+    raised surface 67 against 41 -- and lifting a surface does not lift what
+    lands on it. Every token measured against these had to follow, which is the
+    Three tokens did not follow, and that is a decision rather than an
+    oversight: --p-line-strong, --p-muted and --destructive-quiet each read below
+    their floor on the raised surface. The values that would clear were measured
+    -- 142, 175 and #E59E8F -- and were not taken. They are listed by name in
+    scripts/check-contrast.ts, which prints them every run and still fails for
+    anything not on that list.
   */
-  --p-ink: 26 26 26;
-  --p-surface: 37 37 37;
-  --p-surface-raised: 53 53 53;
+  --p-ink: 33 33 33;
+  --p-surface: 47 47 47;
+  --p-surface-raised: 67 67 67;
   /*
-    Surface separation is 1.14 and 1.25, and --p-line-strong is what actually
-    tells two panels apart, which is why it clears WCAG 1.4.11 against BOTH
-    surfaces: 3.78 on surface and 3.02 on the raised one.
+    Surface separation is 1.20 and 1.35 -- wider than any earlier reading of
+    this family, because the surfaces were lifted apart rather than merely
+    lifted. --p-line-strong is what tells two panels apart, and it clears WCAG
+    1.4.11 on surface at 3.34 but NOT on the raised one, where it reads 2.47.
+    That shortfall is accepted rather than corrected: see the note above and the
+    ACCEPTED list in scripts/check-contrast.ts.
 
-    126, not the 120 the picker proposed. At 120 the raised surface measured
-    2.78 -- the exact case this check exists to catch, and reachable because
-    lifting the surfaces moves the boundary's job without moving the boundary.
+    127 is where the measurement left it against a raised surface of 54. The
+    surface has since reached 67 and the boundary has not followed.
   */
   --p-line: 75 75 75;
-  --p-line-strong: 126 126 126;
+  --p-line-strong: 127 127 127;
   --p-text: 221 221 221;
   /*
     Muted text must clear WCAG 1.4.3 (4.5:1) on the darkest surface it lands on,
-    which is the raised one. This measures 4.75 there, 5.93 on surface and 6.74
-    on ink. Used only as a text colour, never as a background.
+    which is the raised one. This measures 3.83 there, under the floor, and
+    5.18 on surface and 6.23 on ink. 175 is the first value that clears and was
+    not taken -- the pair is accepted by name in scripts/check-contrast.ts.
+    Used only as a text colour, never as a background.
   */
   --p-muted: 161 161 161;
   /*
@@ -62,16 +72,38 @@
     on screen that is not data, which is a stronger position than it had when
     every surface leaned the same way.
 
-    A LIGHT FILL TAKES THE NEAR-BLACK LABEL. Ink measures 6.75 on it and white
+    A LIGHT FILL TAKES THE NEAR-BLACK LABEL. Ink measures 6.25 on it and white
     2.58, which is the reverse of the blue that preceded it -- that one was a
     mid tone and took white at 4.43. --accent-foreground follows the accent
     rather than staying where the blue left it.
   */
   --p-accent: 237 135 68;
-  --p-accent-quiet: 236 128 57;
-  --p-accent-dim: 75 37 11;
+  --p-accent-quiet: 240 155 99;
+  --p-accent-dim: 83 40 12;
   --p-place: 120 138 148;
   --p-haze: 144 144 144;
+  /*
+    THE STUDIO'S OWN THREE, and the reason they exist.
+
+    The 3D scenes used to read --p-ink and --p-line, the same tokens the panels
+    around them read. So the room the rasters sit in could never be set apart
+    from the interface: every attempt to deepen the studio deepened every panel
+    with it, and every attempt to hold the panels held the studio too. That is
+    one palette doing two jobs, and the jobs disagree -- the panels are a
+    reading surface, the studio is a room with photographs in it.
+
+    Lifted well clear of the chassis, and the grid is opaque and near-white
+    rather than a seventh of a mid grey. A raster is judged against the room it
+    hangs in, so the room is a deliberate grey rather than the darkest thing
+    available, and the grid is a rule to measure against rather than a texture.
+
+    No contrast rule covers these: nothing reads text on them, and what lands
+    on them is imagery. check-contrast has no opinion, which is the same
+    position --p-haze is in.
+  */
+  --v-ink: 51 51 51;
+  --v-line: 246 246 246;
+  --v-grid-alpha: 1;
 }
 
 /*
@@ -98,6 +130,15 @@
   --p-accent-dim: 240 214 198;
   --p-place: 90 110 122;
   --p-haze: 176 176 176;
+  /*
+    The light theme's studio is unchanged: the chassis tokens, at the alpha the
+    scenes have always drawn the grid with. The dark room above was set by eye
+    against real rasters and the light one has not been, so it stays where it
+    was rather than being guessed at from the dark values.
+  */
+  --v-ink: var(--p-ink);
+  --v-line: var(--p-line);
+  --v-grid-alpha: 0.14;
 }
 
 :root {
@@ -118,7 +159,7 @@
 
     It was white for a while, because the blue accent was a mid tone and white
     was the better of two failing options at 4.43. This accent is light: ink
-    measures 6.75 on it and white 2.58. A fill's label is a consequence of the
+    measures 6.25 on it and white 2.58. A fill's label is a consequence of the
     fill, not a constant.
   */
   --primary-foreground: rgb(var(--p-ink));
@@ -206,8 +247,8 @@
   /* Full accent, not a wash of it. At 0.55 the composited ring measured under
      the 3.0 WCAG 1.4.11 asks of a focus indicator, and under the figure the
      contrast check verifies, because the check reads the token and the token
-     was not what got painted. At full strength the two agree: 6.75 on ink,
-     5.95 on the panel, 4.76 on a raised surface. */
+     was not what got painted. At full strength the two agree: 6.25 on ink,
+     5.20 on the panel, 3.84 on a raised surface. */
   --ring: rgb(var(--p-accent));
 
   --font-display: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
@@ -345,7 +386,7 @@
     follows the border radius and does not fight the shadow utilities a floating
     panel needs.
 
-    --ring is the full accent: 6.75 on ink, 5.95 on a panel, 4.76 on a raised
+    --ring is the full accent: 6.25 on ink, 5.20 on a panel, 3.84 on a raised
     surface, all clearing the 3.0 WCAG 1.4.11 asks of a focus indicator.
   */
   button:focus-visible,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -911,6 +911,51 @@
   border-top-color: rgb(var(--p-line) / 0.28) !important;
 }
 
+/*
+  THE CHROME IS NOT SELECTABLE, and the content is.
+
+  A web view selects everything by default, so dragging across this application
+  highlighted its own labels, its navigation and the words on its buttons -- a
+  gesture that means nothing here and that no application with a native shell
+  answers to. The default is the wrong way round for a program whose text is
+  overwhelmingly chrome.
+
+  So the shell says no and the places that hold something worth taking say yes.
+  What earns `.selectable` is anything a reader might carry somewhere else: a
+  measured value, a coordinate, a file path, an error, a table cell, the text of
+  a run's log. Anything they might quote back into an issue.
+
+  FORM CONTROLS ARE EXEMPT UNCONDITIONALLY. Editing text without being able to
+  select it is not a restriction, it is a broken field, and this rule sits above
+  the class so no container can take it away from an input inside it.
+*/
+body {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+input,
+textarea,
+select,
+[contenteditable="true"],
+.selectable,
+.selectable * {
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+/*
+  Code and preformatted text, wherever they appear. Both exist here to be read
+  literally -- a token block, a path, a stack -- and being read literally is the
+  same reason they would be copied.
+*/
+code,
+pre,
+.telemetry {
+  user-select: text;
+  -webkit-user-select: text;
+}
+
 /* Map swipe (imagery ↔ prediction) — handle sits above leaflet panes */
 .map-swipe-handle {
   touch-action: none;

--- a/frontend/src/lib/contrast.test.ts
+++ b/frontend/src/lib/contrast.test.ts
@@ -15,6 +15,7 @@
  */
 import { describe, expect, it } from "vitest"
 import {
+  ACCEPTED,
   checkContrast,
   contrast,
   luminance,
@@ -93,7 +94,7 @@ describe("contrast", () => {
     )
     // Two tokens the interface actually paints, one per theme.
     expect(contrast(TOKENS.dark.text, TOKENS.dark.ink)).toBeCloseTo(
-      12.813813966308757,
+      11.85512560381741,
       10
     )
     expect(contrast(TOKENS.light.text, TOKENS.light.ink)).toBeCloseTo(
@@ -137,10 +138,10 @@ describe("checkContrast", () => {
     // a token's channels shows up here as a named number rather than only as a
     // pass/fail somewhere else.
     const expected: Record<string, number> = {
-      "dark.text.surfaceRaised": 9.03,
-      "dark.muted.surfaceRaised": 4.75,
-      "dark.accentQuiet.accentDim": 4.92,
-      "dark.lineStrong.surfaceRaised": 3.02,
+      "dark.text.surfaceRaised": 7.28,
+      "dark.muted.surfaceRaised": 3.83,
+      "dark.accentQuiet.accentDim": 5.71,
+      "dark.lineStrong.surfaceRaised": 2.47,
       "dark.destructiveForeground.destructive": 5.35,
       "light.text.surface": 15.66,
       "light.accent.accentDim": 4.09,
@@ -170,10 +171,17 @@ describe("checkContrast", () => {
     }
   })
 
-  it("finds every pair in the shipped palette clearing its floor", () => {
+  it("finds no failing pair in the shipped palette that is not accepted", () => {
+    /*
+      Not "nothing fails". Three pairs do, by a decision recorded in ACCEPTED,
+      and asserting an empty list here would have meant either deleting this
+      test or editing the palette to suit it. Asserting the SET keeps the guard:
+      a fourth failure breaks this, and so does an accepted pair that has since
+      been fixed and left on the list.
+    */
     const failing = results
       .filter((r) => !r.passes)
-      .map((r) => `${r.theme}: ${r.fg} on ${r.bg} is ${r.ratio}, min ${r.min}`)
-    expect(failing).toEqual([])
+      .map((r) => `${r.theme}.${r.fg}.${r.bg}`)
+    expect(failing.sort()).toEqual(Object.keys(ACCEPTED).sort())
   })
 })

--- a/frontend/src/lib/contrast.ts
+++ b/frontend/src/lib/contrast.ts
@@ -38,16 +38,16 @@ export function contrast(a: Channels, b: Channels): number {
 /** The channel values in index.css, per theme. Edited together with it. */
 export const TOKENS = {
   dark: {
-    ink: [26, 26, 26],
-    surface: [37, 37, 37],
-    surfaceRaised: [53, 53, 53],
+    ink: [33, 33, 33],
+    surface: [47, 47, 47],
+    surfaceRaised: [67, 67, 67],
     line: [75, 75, 75],
-    lineStrong: [126, 126, 126],
+    lineStrong: [127, 127, 127],
     text: [221, 221, 221],
     muted: [161, 161, 161],
     accent: [237, 135, 68],
-    accentQuiet: [236, 128, 57],
-    accentDim: [75, 37, 11],
+    accentQuiet: [240, 155, 99],
+    accentDim: [83, 40, 12],
     destructive: [160, 44, 44],
     success: [111, 156, 90],
     warning: [217, 164, 65],
@@ -74,6 +74,37 @@ export const TOKENS = {
 } as const satisfies Record<string, Record<string, Channels>>
 
 export type ThemeName = keyof typeof TOKENS
+
+/**
+ * Pairs the palette's owner has accepted below their floor.
+ *
+ * NOT a way to quiet the check. check-contrast prints each one on its own every
+ * run, with its measured ratio and its floor, so the cost stays visible and
+ * countable rather than becoming a red build everyone learns to scroll past.
+ * What the list buys is that anything NOT on it still fails.
+ *
+ * All three came in together, from a chassis whose surfaces were lifted: ink 33,
+ * surface 47, raised 67. Lifting a surface does not lift what has to be seen
+ * against it, and these are the three tokens that did not follow. The values
+ * that would clear were measured -- lineStrong 142, muted 175, destructiveQuiet
+ * #E59E8F -- and were not taken.
+ *
+ * It lives here rather than in the script because it is part of the palette's
+ * contract: the script and the test both read it, and two copies would let them
+ * disagree about which failures are known.
+ *
+ * Removing an entry is how one gets fixed -- drop the line, and the check tells
+ * you whether it still needed to be there. An entry that no longer describes a
+ * failure is itself reported as a failure.
+ */
+export const ACCEPTED: Record<string, string> = {
+  "dark.muted.surfaceRaised":
+    "secondary text on a card; 175 would clear 4.5 and was not taken",
+  "dark.lineStrong.surfaceRaised":
+    "the border between a card and its panel; 142 would clear 3.0",
+  "dark.destructiveQuiet.surfaceRaised":
+    "error text on a card; #E59E8F would clear 4.5",
+}
 export type TokenName = keyof (typeof TOKENS)["dark"]
 
 export interface ContrastRule {
@@ -90,7 +121,7 @@ export interface ContrastRule {
  * Every pair the interface paints, and the floor each has to clear.
  *
  * `accent` is checked at 3.0, not 4.5, and only as a fill, a focus ring and an
- * active state. The present accent happens to measure 4.76 on the raised
+ * active state. The present accent happens to measure 3.84 on the raised
  * surface, which is a property of this accent being a light one and not a rule
  * the token holds -- the blue before it measured 3.01 there. The floor stays at
  * 3.0 because the next accent may be a mid tone again, and text that has to
@@ -102,7 +133,7 @@ export interface ContrastRule {
  * the omission survived a change that removed its original reason. Under the
  * blue it was a stated exception: that accent was a mid tone, white measured
  * 4.43 on it and nothing at that hue cleared both floors. Under this one the
- * ink measures 6.75 and there is no exception left. The pair stays unlisted
+ * ink measures 6.25 and there is no exception left. The pair stays unlisted
  * because --accent-foreground resolves to --p-ink and the rule would restate
  * `text on ink`, not because the trade is still open.
  */
@@ -142,7 +173,7 @@ export const RULES: readonly ContrastRule[] = [
     fg: "lineStrong",
     on: ["ink", "surface", "surfaceRaised", "accentDim"],
     min: 3.0,
-    why: "component boundary, WCAG 1.4.11; the surfaces are 1.14 and 1.25 apart, so the border is what separates them",
+    why: "component boundary, WCAG 1.4.11; the surfaces are 1.20 and 1.35 apart, so the border is what separates them",
   },
   /*
    * Destructive splits the same way the accent does, and was checked neither

--- a/frontend/src/lib/mapPose.ts
+++ b/frontend/src/lib/mapPose.ts
@@ -1,0 +1,53 @@
+/**
+ * Where the map is looking, published outside React.
+ *
+ * WHY THIS IS NOT STATE. The map reports its centre and zoom on every frame of
+ * a pan -- that is what leaflet's `move` event is -- and the only thing in the
+ * application that reads the live value is the coordinate readout in the title
+ * bar. Routing it through `useState` in App put a new object on the ROOT
+ * component sixty times a second, and App's subtree is every screen the
+ * application has. React has no way to skip that: the object is new each frame,
+ * nothing on the path is memoised, and so a drag on the map reconciled the
+ * whole tree once per frame.
+ *
+ * That is measurable as the map being heavy to pan, and it is not only the
+ * map's problem -- the same render is what a screen transition and the studio
+ * switch land in the middle of.
+ *
+ * A store instead, so the one component that wants the live value subscribes to
+ * it and nothing else hears. The committed value still goes through App on
+ * `moveend`, where it is wanted for persistence and for restoring the position
+ * across screens, and where it happens once per gesture rather than per frame.
+ */
+export interface MapPose {
+  lat: number
+  lon: number
+  zoom: number
+}
+
+let pose: MapPose | null = null
+const listeners = new Set<() => void>()
+
+/** Called from leaflet's move handler. Replaces the pose and wakes readers. */
+export function publishMapPose(next: MapPose): void {
+  pose = next
+  for (const fn of listeners) fn()
+}
+
+export function subscribeMapPose(onChange: () => void): () => void {
+  listeners.add(onChange)
+  return () => {
+    listeners.delete(onChange)
+  }
+}
+
+/**
+ * The current pose, or null before the map has reported one.
+ *
+ * The reference is stable between publishes, which is what useSyncExternalStore
+ * requires: a getSnapshot that built a new object each call would re-render its
+ * subscriber on every check.
+ */
+export function mapPose(): MapPose | null {
+  return pose
+}

--- a/frontend/src/lib/paletteWatch.ts
+++ b/frontend/src/lib/paletteWatch.ts
@@ -1,0 +1,90 @@
+/**
+ * Where the 3D surfaces get their chassis colours, and when they re-read them.
+ *
+ * Everything painted in CSS re-resolves `var(--p-accent)` on its own when the
+ * palette moves -- that is what a custom property is for. A WebGL scene cannot:
+ * it reads the tokens once, at build, into colours it then holds as its own
+ * numbers, and no part of the cascade reaches those numbers afterwards. So the
+ * studio kept whatever palette it opened in until something unrelated rebuilt
+ * the scene. That is what `onPaletteChange` is for.
+ *
+ * The override is the second half. The scenes and the stylesheet read the SAME
+ * `--p-*` tokens, which is correct for the product -- one palette, one place --
+ * and is exactly what makes them impossible to judge apart: moving a token to
+ * see it in the viewport moves every panel around the viewport at the same
+ * time. An override pins the scenes to a palette of their own, so the two can
+ * be held against each other.
+ *
+ * Nothing sets it in normal use, and while nothing does this module costs one
+ * null check per repaint.
+ */
+
+/** The three chassis colours a scene is painted in, as three parses. */
+export interface ViewportPalette {
+  /** --p-ink: the background and the fog. */
+  background: string
+  /** --p-line: the ground grid, and an empty area's footprint. */
+  line: string
+  /** --p-accent: selection, links, and the path through an ordering. */
+  accent: string
+  /**
+   * The ground grid's alpha, where the scene's own default is not wanted.
+   *
+   * A colour alone cannot say how much of the grid shows. The material draws at
+   * 0.14, so the grid contributes at most a seventh of the pixel and any change
+   * to its colour arrives divided by seven -- over a lifted background the
+   * whole range of a colour control moved the composited channel by eleven of
+   * 255, which reads as a control that does nothing. The alpha is the lever
+   * that governs it, so the alpha is what is exposed.
+   *
+   * Absolute, not a multiplier: the scenes each carry their own default and a
+   * multiplier would mean two different results from one number.
+   */
+  gridOpacity?: number
+}
+
+let override: ViewportPalette | null = null
+const listeners = new Set<() => void>()
+
+/**
+ * Pins every open 3D scene to `next`, or releases them back to the tokens.
+ *
+ * Applies immediately: the subscribers are the scenes' own repaints, so this
+ * behaves like a token change without one having happened.
+ */
+export function setViewportPaletteOverride(next: ViewportPalette | null): void {
+  override = next
+  for (const fn of listeners) fn()
+}
+
+/** What a scene should paint itself in, or null to read the tokens. */
+export function viewportPaletteOverride(): ViewportPalette | null {
+  return override
+}
+
+/**
+ * Runs `onChange` whenever the palette actually being painted changes.
+ *
+ * TWO ATTRIBUTES, because the palette moves in two ways. `data-theme` is the
+ * one next-themes writes, and it carries the RESOLVED theme -- "dark" or
+ * "light", never "system" -- so it covers a reader left on the system setting
+ * whose machine flips at dusk. `style` is the one AccentLab writes: it sets the
+ * `--p-*` channels inline on the same element, where an inline custom property
+ * outranks the stylesheet's without touching it.
+ *
+ * Mutations are delivered in batches, so the eleven properties AccentLab writes
+ * per change arrive as one callback rather than eleven.
+ *
+ * Returns the unsubscribe, for the caller's own teardown.
+ */
+export function onPaletteChange(onChange: () => void): () => void {
+  const observer = new MutationObserver(onChange)
+  observer.observe(document.documentElement, {
+    attributeFilter: ["data-theme", "style"],
+  })
+  listeners.add(onChange)
+  return () => {
+    observer.disconnect()
+    listeners.delete(onChange)
+  }
+}

--- a/frontend/src/lib/panelSelection.ts
+++ b/frontend/src/lib/panelSelection.ts
@@ -1,0 +1,44 @@
+/**
+ * Which map tool has its panel open, held outside React.
+ *
+ * WHY IT IS NOT STATE IN App. Two things wanted it there and neither wanted it
+ * to be state: the navigation column and the map screen both read it, so it had
+ * to live above both, and the map screen remounts on every return to it, so a
+ * useState inside the screen forgot the choice each time.
+ *
+ * Lifting it to App answered both and charged for it every time: App holds the
+ * whole application's tree, nothing on the path is memoised, and so collapsing a
+ * panel reconciled every screen the application has in order to change which of
+ * three panels was drawn.
+ *
+ * A module holds it instead. It outlives the screen's remount for the same
+ * reason a module always does, and the two components that read it subscribe
+ * for themselves -- so a collapse re-renders the navigation column and the map
+ * screen, which are the two things a collapse changes.
+ *
+ * Shaped like lib/mapPose.ts and deliberately not shared with it. They hold
+ * different things for different reasons, and a `createStore` covering both
+ * would be an abstraction over two call sites.
+ */
+import type { MapToolId } from "@/lib/mapTools"
+
+let selected: MapToolId | null = "classify"
+const listeners = new Set<() => void>()
+
+export function selectPanel(next: MapToolId | null): void {
+  if (next === selected) return
+  selected = next
+  for (const fn of listeners) fn()
+}
+
+export function subscribePanelSelection(onChange: () => void): () => void {
+  listeners.add(onChange)
+  return () => {
+    listeners.delete(onChange)
+  }
+}
+
+/** The open panel, or null where the column is collapsed. */
+export function panelSelection(): MapToolId | null {
+  return selected
+}

--- a/frontend/src/lib/preferenceExtras.ts
+++ b/frontend/src/lib/preferenceExtras.ts
@@ -67,6 +67,15 @@ export interface PreferenceExtras {
    * boardMemory, which states why they should not outlive a restart.
    */
   studio_layout?: import("@/lib/studioLayout").StudioLayout
+  /**
+   * Which figures the studio's status bar reports.
+   *
+   * A preference rather than a build flag because one of the figures costs
+   * something to have on -- it keeps the page animating -- and the reader who
+   * accepts that cost is the one diagnosing a stall. Absent means none, which
+   * is what a reader who has never opened the setting should get.
+   */
+  studio_telemetry?: import("@/lib/studioTelemetry").StudioTelemetry
 }
 
 export function parsePreferenceExtras(

--- a/frontend/src/lib/studioTelemetry.ts
+++ b/frontend/src/lib/studioTelemetry.ts
@@ -1,0 +1,131 @@
+/**
+ * Which figures the studio's status bar reports, and where that choice lives.
+ *
+ * A store rather than props, for the reason lib/panelSelection.ts is one: the
+ * readers are the status bar, deep inside the studio, and the scene, which is
+ * not React at all. Routing a preference to both through App would put it in
+ * the component whose every state change reconciles the application.
+ *
+ * Seeded from preferences on sign-in and written back on change, so the choice
+ * outlives a restart the way the other settings on that page do.
+ */
+
+/** One switchable figure, and what it costs to have on. */
+export interface TelemetryFigure {
+  key: TelemetryKey
+  label: string
+  /** What the figure means, in the words the settings row uses. */
+  what: string
+  /**
+   * When it is worth having on. Not a rating: each says the question it
+   * answers, because a reader turning these on is diagnosing something and the
+   * useful thing to know is which figure speaks to which symptom.
+   */
+  when: string
+  /**
+   * What having it on costs, or null where it is free.
+   *
+   * Only one of these is not free, and it is the most useful of them, so the
+   * cost is stated rather than the figure being left out or left on quietly.
+   */
+  cost: string | null
+}
+
+export type TelemetryKey =
+  | "page"
+  | "fps"
+  | "work"
+  | "pointer"
+  | "draws"
+  | "resources"
+  | "buffer"
+
+export const TELEMETRY_FIGURES: readonly TelemetryFigure[] = [
+  {
+    key: "page",
+    label: "Page frame rate",
+    what: "How fast the browser delivers frames, measured by a loop that draws nothing.",
+    when: "First, when anything feels slow. It is the figure that says whether the studio is the cause at all — if it is low while the frame work below is near zero, nothing being drawn here is the reason.",
+    cost: "Keeps the page animating for as long as the studio is open, which is the state it measures and not one the studio would otherwise sit in. On battery, leave it off until something needs diagnosing.",
+  },
+  {
+    key: "fps",
+    label: "Board frame rate",
+    what: "Frames the board actually drew, and the interval between them.",
+    when: "Beside the page rate. The board draws on demand, so a long interval on a still scene is the board idling rather than a fault.",
+    cost: null,
+  },
+  {
+    key: "work",
+    label: "Frame work",
+    what: "Time spent inside one frame: controls, draw, orientation helper, labels.",
+    when: "When the board is the suspect. This is the only figure that accuses the scene itself; a high page rate with high work here means the drawing is what costs.",
+    cost: null,
+  },
+  {
+    key: "pointer",
+    label: "Pointer cost",
+    what: "Time inside one pointer event, and how many arrive per second.",
+    when: "When a drag is worse than an idle scene. Pointer handlers run outside the animation callback, so an expensive one blocks frames without appearing in the frame timing.",
+    cost: null,
+  },
+  {
+    key: "draws",
+    label: "Draw calls",
+    what: "Draw calls and triangles submitted for the last frame.",
+    when: "When a board has grown. Both should stay small here — a raster is two triangles — so a large count means something is being drawn per plane that should not be.",
+    cost: null,
+  },
+  {
+    key: "resources",
+    label: "GPU resources",
+    what: "Textures and geometries the renderer is holding.",
+    when: "When opening and closing boards. These should return to where they were; a count that only climbs is something not being released.",
+    cost: null,
+  },
+  {
+    key: "buffer",
+    label: "Drawing buffer",
+    what: "The buffer's size in device pixels, and the ratio it was built at.",
+    when: "When the cost seems to track the window rather than the scene. A frame that draws almost nothing still has to be moved, and this is how much of it there is to move.",
+    cost: null,
+  },
+] as const
+
+export type StudioTelemetry = Partial<Record<TelemetryKey, boolean>>
+
+/**
+ * Off by default, all of it.
+ *
+ * A status bar that reports its own performance to a reader who did not ask is
+ * chrome spent on a question they are not holding. These are switched on to
+ * diagnose something and switched off after -- and the one with a cost must not
+ * be on for anyone who has not read what it costs.
+ */
+export const TELEMETRY_DEFAULT: StudioTelemetry = {}
+
+let shown: StudioTelemetry = TELEMETRY_DEFAULT
+const listeners = new Set<() => void>()
+
+/** Replaces the whole set. Called when preferences load and when one changes. */
+export function setStudioTelemetry(next: StudioTelemetry): void {
+  shown = next
+  for (const fn of listeners) fn()
+}
+
+export function subscribeStudioTelemetry(onChange: () => void): () => void {
+  listeners.add(onChange)
+  return () => {
+    listeners.delete(onChange)
+  }
+}
+
+/** The reference is stable between writes, which useSyncExternalStore needs. */
+export function studioTelemetry(): StudioTelemetry {
+  return shown
+}
+
+/** Whether one figure is on, which is the only question most callers have. */
+export function telemetryShows(key: TelemetryKey): boolean {
+  return shown[key] === true
+}

--- a/frontend/src/pages/MapScreen.tsx
+++ b/frontend/src/pages/MapScreen.tsx
@@ -6,7 +6,7 @@ import {
   Map as MapGlyph,
   type LucideIcon,
 } from "lucide-react"
-import { Suspense, lazy, useEffect, useRef, useState } from "react"
+import { Suspense, lazy, useEffect, useRef, useState, useSyncExternalStore } from "react"
 import { createPortal } from "react-dom"
 import { AnimatePresence } from "motion/react"
 import type {
@@ -24,6 +24,11 @@ import type {
   WaterAnalysis,
   WaterIndex,
 } from "@/lib/types"
+import {
+  panelSelection,
+  selectPanel,
+  subscribePanelSelection,
+} from "@/lib/panelSelection"
 import type { AoiContourSchemeId } from "@/lib/aoiStyle"
 import { MapView } from "@/components/MapView"
 import { SearchBar } from "@/components/SearchBar"
@@ -106,8 +111,6 @@ export interface MapScreenProps {
   /** Where the map was left last session; null starts at the default view. */
   initialView?: { lat: number; lon: number; zoom: number } | null
   /** Open tool tab, owned by the caller so it survives this screen unmounting. */
-  leftPanel: MapToolId | null
-  onLeftPanelChange: (id: MapToolId | null) => void
   /** Which layout draws this screen. See lib/types LayoutMode. */
   layoutMode?: LayoutMode
   /**
@@ -313,7 +316,17 @@ export function MapScreen(props: MapScreenProps) {
   // goes to another one, so local state put the dock back on "classify" on
   // every return -- including a return from a water run, which left a water
   // raster on the map with the classification panel open beside it.
-  const { leftPanel, onLeftPanelChange } = props
+  /*
+    Subscribed rather than received. It was a prop because this screen remounts
+    on every return to it and a useState here forgot the choice -- a module
+    outlives the remount for free, and App stops re-rendering for a collapse.
+    See lib/panelSelection.ts.
+  */
+  const leftPanel = useSyncExternalStore(
+    subscribePanelSelection,
+    panelSelection
+  )
+  const onLeftPanelChange = selectPanel
   /**
    * Which right-edge drawer is open, at most one.
    *

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react"
 import {
   ArrowLeft,
   Camera,
@@ -32,6 +32,14 @@ import { PageAside, PageBody, PageShell } from "@/components/ui/PageShell"
 import { btnGhost, btnPrimary } from "@/components/ui/buttons"
 import { EnvironmentPanel } from "@/components/EnvironmentPanel"
 import { StorageModal } from "@/components/StorageModal"
+import {
+  TELEMETRY_FIGURES,
+  setStudioTelemetry,
+  studioTelemetry,
+  subscribeStudioTelemetry,
+  type StudioTelemetry,
+  type TelemetryKey,
+} from "@/lib/studioTelemetry"
 import { cn } from "@/lib/utils"
 import type {
   InferenceRun,
@@ -52,7 +60,7 @@ import { runRowLine } from "@/lib/runSummary"
 
 const MAX_AVATAR_BYTES = 2_000_000
 
-type SettingsSectionId = "account" | "system"
+type SettingsSectionId = "account" | "telemetry" | "system"
 
 /**
  * The pages of settings, grouped by subject.
@@ -92,6 +100,11 @@ const SECTIONS: {
   // No count. The other page is a list of controls, and the number says how
   // long the list is. This one reports the state of an environment and offers
   // what to do about it, so "(1)" would be counting the wrong thing.
+  /*
+    Counted, unlike System: this page IS a list of controls, and the number says
+    how long the list is.
+  */
+  { id: "telemetry", label: "Telemetry", count: TELEMETRY_FIGURES.length },
   { id: "system", label: "System" },
 ]
 
@@ -168,6 +181,18 @@ export function ProfilePage({
     consumeSettingsPage()
   }, [settingsPage, consumeSettingsPage])
   const [focusedSetting, setFocusedSetting] = useState<string | null>(null)
+  /*
+    Read from the module the studio reads, not from a copy held here.
+
+    The scene and the status bar subscribe to the same store, so a switch flipped
+    here takes effect on an open studio rather than on the next one -- including
+    the one figure whose cost is the work it does, which stops when it is
+    switched off.
+  */
+  const telemetry = useSyncExternalStore(
+    subscribeStudioTelemetry,
+    studioTelemetry
+  )
   const fileRef = useRef<HTMLInputElement>(null)
   const prefsReady = useRef(false)
   const savePrefsTimer = useRef<number | null>(null)
@@ -198,6 +223,32 @@ export function ProfilePage({
     write a zero opacity and an empty model over whatever is stored. Passing
     the stored value through keeps a theme change to being a theme change.
   */
+  /*
+    The store first and the preferences after, deliberately.
+
+    Writing preferences means a round trip through the bridge and the database,
+    and a switch that waited for it would feel like it had not registered. The
+    store is what the studio reads, so flipping it first makes the change
+    immediate; the save is how it survives a restart.
+  */
+  const persistTelemetry = useCallback(
+    async (key: TelemetryKey, on: boolean) => {
+      const next: StudioTelemetry = { ...studioTelemetry(), [key]: on }
+      setStudioTelemetry(next)
+      if (!user) return
+      await savePrefs({
+        user_id: user.id,
+        default_model: prefs?.default_model || "spectral",
+        overlay_opacity: prefs?.overlay_opacity ?? 0.75,
+        theme: prefs?.theme || "dark",
+        extras_json: mergePreferenceExtras(prefs?.extras_json, {
+          studio_telemetry: next,
+        }),
+      })
+    },
+    [user, prefs?.default_model, prefs?.overlay_opacity, prefs?.theme, prefs?.extras_json, savePrefs]
+  )
+
   const persistPreferences = useCallback(
     async (next: {
       theme: string
@@ -1021,6 +1072,61 @@ export function ProfilePage({
               description beside it, which is right for a name or a slider and
               wrong for this: wrapped, the page showed its title twice and
               indented the whole thing as though it were one control's value. */}
+          {activeSection === "telemetry" && (
+            <Section>
+              {/*
+                All off until asked for. A status bar reporting its own
+                performance to a reader who did not ask is chrome spent on a
+                question they are not holding -- and one of these is not free,
+                so it must not be running for anyone who has not read what it
+                costs.
+
+                Each row says what the figure means and which question it
+                answers, because a reader switching these on is diagnosing
+                something and the useful thing to know is which figure speaks
+                to which symptom.
+              */}
+              <p className="px-4 pb-1 pt-3 text-body leading-relaxed text-muted-foreground">
+                Figures the studio&rsquo;s status bar reports, beside the pointer
+                bindings. Off by default; switch on what a symptom calls for.
+              </p>
+              {TELEMETRY_FIGURES.map((figure) => (
+                <SettingRow
+                  key={figure.key}
+                  id={`telemetry.${figure.key}`}
+                  title={figure.label}
+                  description={figure.what}
+                  focused={focusedSetting === `telemetry.${figure.key}`}
+                  onFocus={() => setFocusedSetting(`telemetry.${figure.key}`)}
+                >
+                  <label className="flex cursor-pointer items-start gap-2.5">
+                    <input
+                      type="checkbox"
+                      className={cn("mt-0.5 shrink-0", focusRing)}
+                      checked={telemetry[figure.key] === true}
+                      onChange={(e) =>
+                        void persistTelemetry(figure.key, e.target.checked)
+                      }
+                    />
+                    <span className="min-w-0 text-body leading-relaxed text-muted-foreground">
+                      {figure.when}
+                      {figure.cost && (
+                        <>
+                          {" "}
+                          {/* The one figure that is not free says so where the
+                              switch is, not in a note somewhere else. */}
+                          <span className="text-destructive-quiet">
+                            Costs: {figure.cost}
+                          </span>
+                        </>
+                      )}
+                    </span>
+                  </label>
+                </SettingRow>
+              ))}
+            </Section>
+          )}
+
           {activeSection === "system" && (
             <Section>
               <div className="pt-3">

--- a/main.go
+++ b/main.go
@@ -114,7 +114,18 @@ func main() {
 			app,
 		},
 		Mac: &mac.Options{
-			TitleBar:   mac.TitleBarHiddenInset(),
+			/*
+				Hidden, not hidden-inset. The two differ by one field --
+				UseToolbar -- and the toolbar is what pushes the traffic lights
+				in from the corner, right and down, past the 4.5rem the header
+				reserves for them. That reservation is the standard position,
+				so the standard position is what to ask for rather than a new
+				number guessed to match an offset macOS controls.
+
+				Both keep NSWindowStyleMaskTitled, which is the part that
+				matters for compositing -- see Frameless above.
+			*/
+			TitleBar:   mac.TitleBarHidden(),
 			Appearance: mac.NSAppearanceNameDarkAqua,
 			About: &mac.AboutInfo{
 				Title:   "TERRA",

--- a/main.go
+++ b/main.go
@@ -41,6 +41,12 @@ therefore the one whose pins match the model artifacts it ships beside.
 var requirementsTxt string
 
 func main() {
+	/*
+		Before wails.Run, because the menu is built during it. See
+		editmenu_darwin.go -- on every platform but macOS this does nothing.
+	*/
+	trimEditMenu()
+
 	app := NewApp()
 
 	err := wails.Run(&options.App{

--- a/main.go
+++ b/main.go
@@ -52,7 +52,36 @@ func main() {
 		MinHeight:        220,
 		AlwaysOnTop:      true,
 		BackgroundColour: &options.RGBA{R: 8, G: 7, B: 6, A: 1},
-		Frameless:        true,
+		/*
+			NOT FRAMELESS, and the reason is measured rather than aesthetic.
+
+			While this window was frameless it degraded compositing for every
+			other window sharing its space. Safari running the WebGL aquarium
+			benchmark measured 60fps constantly on any other space and 27-41fps
+			on the one this window occupied -- a different application, slowed
+			by this one being present.
+
+			The cause is in Wails' own window construction. WailsContext.m only
+			adds NSWindowStyleMaskTitled when the window is NOT frameless, so a
+			frameless window here is borderless, and macOS composites a
+			borderless window off the path it uses for titled ones.
+
+			None of it was visible from inside the page, which is what made it
+			expensive to find: the scene submitted 9 draw calls and 72 triangles
+			and cost 0.0ms a frame, the pointer handlers cost 0.0ms, and the web
+			content and GPU processes sat at 2.8% and 0.1% while a
+			requestAnimationFrame that drew nothing was delivered at 11Hz.
+			Everything was waiting, and nothing in the application was the
+			reason.
+
+			The look is kept by TitleBar below. TitleBarHiddenInset gives a
+			titled window with a transparent, title-less bar and full-size
+			content -- the traffic lights inset over the application's own
+			header, which is what the frameless window was being used for. The
+			custom drag regions are unaffected: --wails-draggable is handled in
+			the JavaScript runtime and does not depend on the style mask.
+		*/
+		Frameless: false,
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 			/*


### PR DESCRIPTION
## Summary

The 3D viewport read as part of the interface rather than as a scene inside it:
one set of tokens described both, so changing the chassis changed the ground the
rasters sit on. This separates them, and brings back the tool that derives the
palette.

First of a stack of six. The rest build on it in order; see the base branch of
each.

## Changes

- **`frontend/src/index.css`** — viewport tokens (`--v-ink`, `--v-line`,
  `--v-grid-alpha`) split from the chassis tokens, so a scene's ground and the
  panels around it are two decisions.
- **`frontend/src/components/AccentLab.tsx`** — the palette tool, restored and
  extended: it now carries a scope, so a candidate palette can be applied to the
  interface alone, to the viewport alone, or to both.
- **`frontend/src/lib/paletteWatch.ts`** — the bridge the scene subscribes to.
  CSS tokens do not reach a WebGL context, so the viewport reads them through a
  MutationObserver rather than through the cascade.
- **`frontend/src/lib/contrast.ts`** — an `ACCEPTED` table beside `TOKENS`,
  naming the three pairs that sit below the WCAG floor with the measured ratio
  and what would clear it. Read by both the check script and the test.

## Testing

`npm run check:contrast`, `npx vitest run`, `npx tsc --noEmit`.

## Note

The three accepted sub-floor pairs are recorded rather than fixed: the values in
`index.css` are the ones asked for, and the table states what each costs instead
of quietly substituting a passing colour.