### PR TITLE
perf(macos): the window stops degrading every other window beside it

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ can be installed from Settings › System into the environment already in use.
 | [Troubleshooting](docs/TROUBLESHOOTING.md) | Python, STAC, models, macOS |
 | [Contributing](CONTRIBUTING.md) | Issues, PRs, tests |
 | [Design](docs/DESIGN.md) | Visual tokens |
+| [Performance](docs/PERFORMANCE.md) | Frame rate, memory, and what was measured |
 | [JOSS paper draft](paper/paper.md) | Manuscript and BibTeX |
 
 ## Architecture

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,185 @@
+# Performance
+
+What has been measured about this application's frame rate and memory, what
+turned out to cause it, and what was cleared. Written after an investigation
+that spent most of its time in the wrong places, so the record of what is *not*
+the cause is as much of the point as the record of what is.
+
+---
+
+## The window, not the page
+
+**A frameless macOS window slowed every other window sharing its space.**
+
+Wails builds the NSWindow in `WailsContext.m`, and it adds
+`NSWindowStyleMaskTitled` only when the window is not frameless:
+
+```objc
+if( !frameless ) {
+    if (!hideTitleBar) styleMask |= NSWindowStyleMaskTitled;
+    styleMask |= NSWindowStyleMaskClosable;
+}
+```
+
+So `Frameless: true` produced a borderless window, and macOS composites a
+borderless window off the path it uses for titled ones. The cost did not land in
+this application at all — it landed in WindowServer, and it was paid by every
+window on the same space.
+
+**The measurement that proved it.** Safari running the WebGL aquarium
+benchmark, on the same machine at the same moment:
+
+| Space | Safari's own frame rate |
+| --- | --- |
+| Any space without this window | 60fps, constant |
+| The space this window occupied | 27–41fps |
+
+A different application, slowed by ours being present. Nothing measured inside
+our page could have shown this, which is why the investigation took as long as
+it did.
+
+**The fix is `Frameless: false`.** The look is kept by `TitleBar`:
+`mac.TitleBarHidden()` gives a titled window with a transparent, title-less bar
+and full-size content — the traffic lights over the application's own header,
+which is what frameless was being used for. Custom drag regions are unaffected:
+`--wails-draggable` is handled in the JavaScript runtime and does not depend on
+the style mask.
+
+`TitleBarHiddenInset()` is the same thing plus `UseToolbar`, and the toolbar
+pushes the traffic lights in from the corner — right and down, past the `4.5rem`
+the header reserves — into the wordmark. Hidden, not hidden-inset.
+
+### What this looked like from inside
+
+Every figure below was measured while the page was being delivered frames at
+11Hz. None of them points at the cause:
+
+| Figure | Reading |
+| --- | --- |
+| Frame work (controls, draw, helper, labels) | **0.0ms** |
+| Draw calls / triangles | **9 / 72** |
+| Pointer handler cost | **0.0ms**, events arriving at 120/s |
+| WebContent process CPU | **2.8%**, 97% of samples parked in `mach_msg2_trap` |
+| WebKit GPU process CPU | **0.1%** |
+| WindowServer CPU | 35.6% |
+
+Everything was waiting and nothing in the application was the reason.
+
+---
+
+## Tested and cleared
+
+Each of these was a hypothesis with a plausible mechanism, tested in a
+**production build**, and found not to be the cause. They are listed so the next
+person does not spend the time again.
+
+| Suspect | Mechanism proposed | Result |
+| --- | --- | --- |
+| `backdrop-filter` on `.panel` | 224 elements, each forcing a compositing layer, a backdrop buffer and an 18px blur per frame | No change. 65ms → 74ms gap, which is noise |
+| Multisampling (`antialias: true`) | MSAA resolve is a full extra pass over a retina-sized buffer before the compositor can take it | No change |
+| Canvas alpha channel (`alpha: true`) | An alpha canvas must be blended by the compositor every frame; an opaque one need not be | 24Hz → 26Hz, which is noise |
+| Drawing buffer size | WebKit resolves and copies the buffer into a window-server surface every frame; 2808×1592 at 2x is 4.5M pixels | 11Hz → 24Hz. Real, and a symptom of the window problem rather than a cause |
+| Rasters as base64 data URIs | Megabyte strings held per plane | Not supported by the numbers: a run's PNGs total 392KB, the largest 168KB |
+| Development mode | Vite serving modules one at a time, React's development build, HMR, and an fsevents watcher over the whole repository including `.venv` and `node_modules` | **Real and large.** Always measure a `wails build` binary |
+
+---
+
+## The 60fps ceiling on macOS
+
+WebKit paces page rendering updates near 60fps, so `requestAnimationFrame` is
+delivered at 60Hz on a display running at 120. This is WKWebView's, not the
+display's: `system_profiler` reports the built-in panel at 120.00Hz while the
+studio's own readout showed 59–60.
+
+The preference is `PreferPageRenderingUpdatesNear60FPSEnabled` and there is **no
+public API for it**. The only route is
+`[WKPreferences _setEnabled:NO forFeature:]`, which is private.
+
+**This was implemented, measured and then removed.** It works — the page rate
+went to 111–125Hz, the variation being the display's own adaptive refresh rather
+than instability. It was taken out anyway:
+
+- The problem worth solving was 11Hz, and it is solved. 60 against 120 is polish
+  on something that already works.
+- A private preference only pays while Apple leaves it in place, and the
+  implementation was guarded to fail silently — so a macOS update returns the
+  ceiling without warning. The feature is temporary by construction.
+
+Published reports say the restriction was lifted in macOS 26 and the preference
+ignored. That is not what this machine does: macOS 26.6.1, a 120Hz display, and
+WKWebView delivering 60. Test rather than trust the note.
+
+---
+
+## React: one component holds the application
+
+`App` carries 77 `useState` hooks across itself and `AppBody`, renders every
+screen inline, and there is no `React.memo` anywhere in the frontend. Any
+`setState` there reconciles the whole tree. Two paths did it far more often than
+the work justified, and both are fixed by holding the value outside React and
+letting the one component that wants it subscribe:
+
+| Value | Was | Now |
+| --- | --- | --- |
+| The map's centre and zoom | Written into `App` on every frame of a drag, so the whole tree reconciled 60 times a second to update one line of text in the title bar | `lib/mapPose.ts`; the settled value still reaches `App` on `moveend`, where persistence wants it |
+| Which tool panel is open | In `App` because two components read it and the map screen remounts on every return, which a `useState` inside the screen forgot | `lib/panelSelection.ts`; a module outlives the remount for free |
+
+`AnimatePresence` also carried `mode="wait"`, under which the leaving screen had
+to finish its 240ms exit before the arriving one was allowed to mount — and the
+mount is the expensive half, since a screen here builds Leaflet, its overlays
+and sometimes the studio.
+
+**Still open:** the screens unmount and remount on every change. That is the
+larger remaining cost in navigation and it is deliberate for now — keeping them
+mounted means their effects keep running and the studio holds a WebGL context,
+and WebKit caps how many of those may exist.
+
+---
+
+## Measuring
+
+### The studio's own readout
+
+Seven figures, each switched separately in **Profile → Telemetry**, all off by
+default. `lib/studioTelemetry.ts` says what each one is for. The order in the
+settings page is the order to reach for them in:
+
+1. **Page frame rate** — how fast the browser delivers frames, from a loop that
+   draws nothing. First, always: it is what says whether the studio is the cause
+   at all. **It is the one figure that costs something** — it keeps the page
+   animating for as long as the studio is open.
+2. **Board frame rate** — the board draws on demand, so a long interval on a
+   still scene is idling, not a fault.
+3. **Frame work** — the only figure that accuses the scene itself.
+4. **Pointer cost** — pointer handlers run outside the animation callback, so an
+   expensive one blocks frames without appearing in the frame timing.
+5. **Draw calls**, **GPU resources**, **Drawing buffer** — what is being
+   submitted, what is being held, and how much of the frame there is to move.
+
+### Traps in the tools
+
+**`ps %CPU` on macOS is a lifetime average, not an instantaneous reading.** A
+process that was busy an hour ago reports a high figure while idle. Use
+`top -l N -s S` and read a sample after the first, which is the only one that is
+instantaneous.
+
+**On a render-on-demand surface, the interval between frames is not the frame
+time.** The gap includes however long nothing asked for a frame. Measure the
+work inside the callback separately, or a still scene reads as a slow scene.
+
+**Sample the right process.** WebKit draws canvas and WebGL in a separate GPU
+process, so a stack sample of the web content process shows almost no WebGL
+work. `sample <pid>` both, and read the CPU of each.
+
+**Attribute memory with `vmmap -summary <pid>`.** The region table separates the
+JavaScript heap from `WebKit Malloc`, which is where WebCore's own strings and
+image buffers live — a distinction that rules out or in "some JavaScript is
+holding objects" in one command.
+
+### The control experiment
+
+The one that ended this investigation in thirty seconds, after hours inside the
+page: **run a different application's benchmark on the same space.** If it is
+also slow there and fast elsewhere, nothing inside this application's page is
+the cause. Ask for that control the moment a symptom includes anything outside
+the application's own window.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -68,6 +68,33 @@ Set `TERRA_APP_DIR` to the directory that contains `sidecar/`, `areas/`, and
 Runs live under the OS user config directory for `geosense-infer` (legacy name),
 not inside the `.app` bundle. Clearing Application Support removes history.
 
+## The interface feels slow
+
+### Everything is slow, including other applications
+
+Check whether it is this application at all: run a benchmark in another app —
+Safari on <https://webglsamples.org/aquarium/aquarium.html> shows its own frame
+rate — on the same macOS space, and then on a different one. If the other
+application is also slow beside TERRA and fast away from it, the cause is the
+window rather than anything on screen inside it. That symptom had one cause
+here, and it is fixed; see [Performance](PERFORMANCE.md).
+
+### The studio stutters while orbiting
+
+Switch on **Profile → Telemetry → Page frame rate** first. It measures how fast
+the browser is delivering frames at all, which is what says whether the studio
+is the cause. A low page rate with the frame work near zero means nothing being
+drawn in the studio is the reason.
+
+Leave it off afterwards: it is the one figure that costs something to have on.
+
+### It is slow when run from source but not from a build
+
+Expected, and worth measuring past. `wails dev` serves modules one at a time,
+runs React's development build, keeps a hot-reload socket open and watches the
+whole repository tree — `.venv` and `node_modules` included. Measure a
+`wails build` binary before concluding anything about performance.
+
 ## Still stuck?
 
 Open an issue at https://github.com/rexionmars/TERRA/issues with OS, TERRA

--- a/editmenu_darwin.go
+++ b/editmenu_darwin.go
@@ -1,0 +1,22 @@
+//go:build darwin
+
+package main
+
+/*
+#cgo CFLAGS: -x objective-c -fobjc-arc
+#cgo LDFLAGS: -framework Foundation
+void TerraDisableAutoEditMenuItems(void);
+*/
+import "C"
+
+/*
+trimEditMenu declines the two Edit-menu items AppKit adds on its own.
+
+Called before wails.Run, because the menu is built during it and a default
+registered afterwards is registered too late. See editmenu_darwin.m for which
+items these are, why the menu itself has to stay, and why the values are
+registered rather than written.
+*/
+func trimEditMenu() {
+	C.TerraDisableAutoEditMenuItems()
+}

--- a/editmenu_darwin.m
+++ b/editmenu_darwin.m
@@ -1,0 +1,33 @@
+#import <Foundation/Foundation.h>
+
+/*
+ Keeps AppKit from adding its own items to the Edit menu.
+
+ The Edit menu here is Wails': Undo, Redo, Cut, Copy, Paste, Paste and Match
+ Style, Delete, Select All. AppKit appends four more to any Edit menu it finds
+ -- Speech, AutoFill, Start Dictation and Emoji & Symbols -- and two of those
+ can be declined. Neither belongs in an application whose only text fields are
+ an area's name and a search box.
+
+ THE MENU IS NOT REMOVED, and cannot be. Command-C, Command-V and Command-A in a
+ WKWebView are delivered through the responder chain, which reaches the web view
+ only because menu items carrying those key equivalents exist. An application
+ with no Edit menu is an application where copy and paste stop working inside
+ its own inputs.
+
+ registerDefaults, not setObject:forKey:. Registering places the values in the
+ defaults' registration domain, which is consulted when nothing else answers and
+ is discarded when the process ends. Writing them would put two keys in the
+ reader's own preferences and leave them there after the application is gone,
+ for a choice that is this application's rather than theirs.
+
+ Both keys are documented AppKit behaviour and public.
+ */
+void TerraDisableAutoEditMenuItems(void) {
+    [[NSUserDefaults standardUserDefaults] registerDefaults:@{
+        // "Start Dictation…"
+        @"NSDisabledDictationMenuItem" : @YES,
+        // "Emoji & Symbols"
+        @"NSDisabledCharacterPaletteMenuItem" : @YES,
+    }];
+}

--- a/editmenu_other.go
+++ b/editmenu_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin
+
+package main
+
+/*
+trimEditMenu does nothing off macOS.
+
+The items it declines are AppKit's, added to any Edit menu it finds. No other
+platform's menu grows on its own, so there is nothing to decline -- and a build
+tag says that, where a runtime check would read as though the call might do
+something.
+*/
+func trimEditMenu() {}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { Dispatch, SetStateAction } from "react"
 import { AnimatePresence, motion } from "motion/react"
+import { selectPanel } from "@/lib/panelSelection"
 import { notifyError, notifyInfo, notifySuccess } from "@/lib/notify"
 import type { Whiteboard } from "@/lib/whiteboards"
 import { listWhiteboards, openWhiteboard } from "@/lib/whiteboards"
@@ -886,7 +887,6 @@ function AppBody(props: {
    * every navigation away, so local state reset the dock to the classification
    * panel on every return.
    */
-  const [leftPanel, setLeftPanel] = useState<MapToolId | null>("classify")
   /**
    * Which map layout is drawn.
    *
@@ -2701,7 +2701,7 @@ function AppBody(props: {
         goEnergy()
         return
       }
-      setLeftPanel(product)
+      selectPanel(product)
       startNewClassification()
     },
     [goEnergy, startNewClassification]
@@ -3004,7 +3004,7 @@ function AppBody(props: {
       } else if (groupId === "analysis") {
         openProjectHub()
       } else {
-        if (itemId) setLeftPanel(itemId as MapToolId)
+        if (itemId) selectPanel(itemId as MapToolId)
         goMap()
       }
     },
@@ -3104,15 +3104,26 @@ function AppBody(props: {
               key="app-nav"
               hasAnalysis={!!props.result || runs.length > 0}
               onAnalysisClick={openProjectHub}
-              leftPanel={leftPanel}
-              onLeftPanelChange={setLeftPanel}
               energyTab={energyTab}
               onEnergyTabChange={setEnergyTab}
             />
           )}
         </AnimatePresence>
         <div className="relative min-h-0 min-w-0 flex-1">
-          <AnimatePresence mode="wait" initial={false}>
+          {/*
+            NOT mode="wait". Under it the leaving screen has to finish its exit
+            before the arriving one is allowed to mount, so every change of
+            screen was 240ms of an empty stage followed by the mount -- and the
+            mount is the expensive half, since a screen here builds leaflet, its
+            overlays and sometimes the studio. Serialised by construction, and
+            felt as the transition being slow rather than as the animation being
+            long.
+
+            Without it the two overlap. They are both `absolute inset-0`, so
+            overlapping is what the layout already expects, and the arriving
+            screen starts building at the moment it is asked for.
+          */}
+          <AnimatePresence initial={false}>
             {screen === "map" && (
               <motion.div
                 key="screen-map"
@@ -3156,11 +3167,9 @@ function AppBody(props: {
                   solarProgress={solar.run.progress}
                   solarProgressMsg={solar.run.message}
                   initialView={initialMapView}
-                  leftPanel={leftPanel}
                   layoutMode={layoutMode}
                   onLayoutModeChange={changeLayoutMode}
                   onNavigate={navigateTo}
-                  onLeftPanelChange={setLeftPanel}
                   areas={props.areas}
                   activeExample={props.activeExample}
                   customPolygon={props.customPolygon}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,10 @@ import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } fro
 import type { Dispatch, SetStateAction } from "react"
 import { AnimatePresence, motion } from "motion/react"
 import { selectPanel } from "@/lib/panelSelection"
+import {
+  TELEMETRY_DEFAULT,
+  setStudioTelemetry,
+} from "@/lib/studioTelemetry"
 import { notifyError, notifyInfo, notifySuccess } from "@/lib/notify"
 import type { Whiteboard } from "@/lib/whiteboards"
 import { listWhiteboards, openWhiteboard } from "@/lib/whiteboards"
@@ -344,6 +348,13 @@ function App() {
       const extras = parsePreferenceExtras(p.extras_json)
       setSavedAois(extras.saved_aois ?? [])
       setActiveAoiId(extras.active_aoi_id)
+      /*
+        Into a module rather than into state: the readers are the studio's
+        status bar and the scene, and the scene is not React. Seeded here
+        because this is where preferences arrive, and absent means none --
+        which is what a reader who has never opened the setting should get.
+      */
+      setStudioTelemetry(extras.studio_telemetry ?? TELEMETRY_DEFAULT)
     },
     [setTheme]
   )

--- a/frontend/src/components/AppNav.tsx
+++ b/frontend/src/components/AppNav.tsx
@@ -27,7 +27,12 @@ import {
   Zap,
 } from "lucide-react"
 import { motion } from "motion/react"
-import { useState, type ReactNode } from "react"
+import { useState, type ReactNode, useSyncExternalStore } from "react"
+import {
+  panelSelection,
+  selectPanel,
+  subscribePanelSelection,
+} from "@/lib/panelSelection"
 import { useAuth, type AppScreen } from "@/lib/auth"
 import { cn } from "@/lib/utils"
 import { AvatarCircle } from "@/components/AvatarCircle"
@@ -40,8 +45,6 @@ export interface AppNavProps {
   /** Used instead of goAnalysis when the analysis screen is already open. */
   onAnalysisClick?: () => void
   /** The map's open tool panel, so its children can show which is current. */
-  leftPanel: MapToolId | null
-  onLeftPanelChange: (id: MapToolId | null) => void
   /** The energy screen's open tab, for the same reason. */
   energyTab: EnergyTab
   onEnergyTabChange: (tab: EnergyTab) => void
@@ -59,12 +62,20 @@ interface NavChild {
 export function AppNav({
   hasAnalysis = false,
   onAnalysisClick,
-  leftPanel,
-  onLeftPanelChange,
   energyTab,
   onEnergyTabChange,
   projectSwitcher,
 }: AppNavProps) {
+  /*
+    Subscribed rather than received. Both this column and the map screen read
+    which panel is open, and holding it in App meant a collapse reconciled every
+    screen in order to change which of three panels was drawn. See
+    lib/panelSelection.ts.
+  */
+  const leftPanel = useSyncExternalStore(
+    subscribePanelSelection,
+    panelSelection
+  )
   const {
     user,
     loading,
@@ -106,7 +117,7 @@ export function AppNav({
     label: t.label,
     active: onMap && leftPanel === t.id,
     onSelect: () => {
-      onLeftPanelChange(t.id)
+      selectPanel(t.id)
       goMap()
     },
   }))

--- a/frontend/src/components/DataTableView.tsx
+++ b/frontend/src/components/DataTableView.tsx
@@ -108,7 +108,7 @@ export function DataTableView({
 
       {/* Wide tables scroll inside the section rather than widening the page. */}
       <div className="rounded-sm border border-border bg-background max-h-[22rem] overflow-auto">
-        <table className="w-full min-w-max text-left text-[11px]">
+        <table className="selectable w-full min-w-max text-left text-[11px]">
           <thead className="sticky top-0 z-10">
             <tr
               className="border-b"

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -125,7 +125,7 @@ function CrashDetail({
         {error.message || "The thrown value carried no message."}
       </p>
       {componentStack ? (
-        <pre className="mt-1.5 max-h-40 overflow-auto whitespace-pre-wrap text-micro text-muted-foreground">
+        <pre className="selectable mt-1.5 max-h-40 overflow-auto whitespace-pre-wrap text-micro text-muted-foreground">
           {componentStack.trim()}
         </pre>
       ) : null}

--- a/frontend/src/components/MapView.tsx
+++ b/frontend/src/components/MapView.tsx
@@ -18,6 +18,7 @@ import "./leafletDrawPatch"
 import type { LatLngBoundsExpression } from "leaflet"
 import type { Area, PredictResult, GeoJSONGeometry, CompositionOverlay } from "@/lib/types"
 import { BASEMAPS, basemapByName, type BasemapKind } from "@/lib/basemaps"
+import { publishMapPose } from "@/lib/mapPose"
 import { boundsToLatLng, isZeroExtent } from "@/lib/mapLayers"
 import { majoritySmoothOverlay } from "@/lib/smoothOverlay"
 import {
@@ -110,27 +111,40 @@ interface MapViewProps {
   onCreditChange?: (c: { kind: BasemapKind; date: string | null }) => void
 }
 
-// Report map center/zoom to the telemetry readout.
+/**
+ * Reports map centre and zoom, on two paths that run at two rates.
+ *
+ * PER FRAME, to the pose store, which the title bar's readout subscribes to.
+ * `move` fires on every frame of a drag, and this used to call onViewChange
+ * there -- a setState on App, whose subtree is every screen the application
+ * has, sixty times a second. See lib/mapPose.ts.
+ *
+ * ONCE PER GESTURE, to onViewChange, which is where the value is persisted to
+ * preferences and remembered for the return to this screen. Both wanted the
+ * settled value; neither wanted the intermediate ones.
+ */
 function ViewReporter({
   onViewChange,
 }: {
   onViewChange: (v: { lat: number; lon: number; zoom: number }) => void
 }) {
   const map = useMapEvents({
-    move: () => {
-      const c = map.getCenter()
-      onViewChange({ lat: c.lat, lon: c.lng, zoom: map.getZoom() })
-    },
-    zoom: () => {
-      const c = map.getCenter()
-      onViewChange({ lat: c.lat, lon: c.lng, zoom: map.getZoom() })
-    },
+    move: () => publishMapPose(readPose(map)),
+    zoom: () => publishMapPose(readPose(map)),
+    moveend: () => onViewChange(readPose(map)),
+    zoomend: () => onViewChange(readPose(map)),
   })
   useEffect(() => {
-    const c = map.getCenter()
-    onViewChange({ lat: c.lat, lon: c.lng, zoom: map.getZoom() })
+    const pose = readPose(map)
+    publishMapPose(pose)
+    onViewChange(pose)
   }, [map, onViewChange])
   return null
+}
+
+function readPose(map: L.Map): { lat: number; lon: number; zoom: number } {
+  const c = map.getCenter()
+  return { lat: c.lat, lon: c.lng, zoom: map.getZoom() }
 }
 
 

--- a/frontend/src/components/ProjectSwitcher.tsx
+++ b/frontend/src/components/ProjectSwitcher.tsx
@@ -354,14 +354,57 @@ export function ProjectSwitcher({
             return !o
           })
         }
-        className="panel flex max-w-[14rem] items-center gap-1.5 rounded-sm px-2 py-1 text-left text-[11px] text-foreground hover:bg-secondary/40"
+        /*
+          NO BOX AT REST, and no accent on the glyph.
+
+          It wore `panel` -- a bordered, translucent surface -- inside the title
+          bar, which is itself a panel. A panel drawn on a panel reads as a
+          control competing with the wordmark beside it rather than as one more
+          thing on the same row, and the row already separates its parts with a
+          hairline where it means to.
+
+          The accent went with it. DESIGN.md gives that colour three jobs -- a
+          fill, a focus ring, an active state -- and a permanent tint on a
+          folder glyph is none of them. It spent the one colour on screen that
+          is not data on a decoration, beside the project's name, which is what
+          a reader is actually here to read.
+
+          Both come back when the menu is open, because that IS an active state
+          and is exactly what the accent is for.
+        */
+        className={cn(
+          "flex max-w-[14rem] items-center gap-1.5 rounded-sm px-2 py-1 text-left text-[11px] transition-colors",
+          open
+            ? "bg-secondary/60 text-foreground"
+            : "text-foreground hover:bg-secondary/40"
+        )}
         title="Active project"
       >
-        <FolderKanban className="size-3.5 shrink-0 text-primary" />
-        <span className="min-w-0 flex-1 truncate">
+        <FolderKanban
+          className={cn(
+            "size-3.5 shrink-0 transition-colors",
+            open ? "text-primary" : "text-muted-foreground"
+          )}
+        />
+        {/*
+          The name at full strength and the fallback muted, because they are
+          different kinds of thing: one is a value, the other is the absence of
+          one. Drawn alike, "No project" read as a project called that.
+        */}
+        <span
+          className={cn(
+            "min-w-0 flex-1 truncate",
+            !active && "text-muted-foreground"
+          )}
+        >
           {active ? active.name : "No project"}
         </span>
-        <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
+        <ChevronDown
+          className={cn(
+            "size-3 shrink-0 transition-transform",
+            open ? "rotate-180 text-foreground" : "text-muted-foreground"
+          )}
+        />
       </button>
       {menu}
     </div>

--- a/frontend/src/components/TitleBar.tsx
+++ b/frontend/src/components/TitleBar.tsx
@@ -9,13 +9,20 @@ import {
 } from "lucide-react"
 import { BRAND_TAGLINE } from "@/lib/brand"
 import { AvatarCircle } from "@/components/AvatarCircle"
-import type { ReactNode } from "react"
+import {
+  useEffect,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react"
 import {
   BrowserOpenURL,
+  Environment,
   WindowMinimise,
   WindowToggleMaximise,
   Quit,
 } from "../../wailsjs/runtime/runtime"
+import { mapPose, subscribeMapPose } from "@/lib/mapPose"
 import type { LayoutMode, PredictResult } from "@/lib/types"
 import {
   LEAFLET_CREDIT,
@@ -127,6 +134,42 @@ export function TitleBar({
   boardOpen = false,
 }: TitleBarProps) {
   const { screen, user, loading, goProfile, goAuth } = useAuth()
+  /*
+    The live pose, subscribed to rather than received.
+
+    `view` is still the prop and still what App holds, but App only hears about
+    the settled value now, once per gesture -- the reporter used to write every
+    frame of a drag into the root component, and the root's subtree is every
+    screen the application has. This readout is the only thing that wants those
+    intermediate values, so it is the only thing that re-renders for them. The
+    prop stands in until the map has reported: on a screen with no map, and on
+    the first paint of one, the store is empty.
+  */
+  const live = useSyncExternalStore(subscribeMapPose, mapPose)
+  const shown = live ?? view
+  /*
+    Whether the platform draws the window controls, asked once.
+
+    Not a user-agent string: Wails reports the platform it was built for, which
+    is the thing being asked about. Starts false, so the buttons are absent for
+    the frame before the answer arrives -- appearing late reads as the bar
+    settling, where disappearing late reads as a glitch.
+  */
+  const [onMac, setOnMac] = useState(false)
+  useEffect(() => {
+    let cancelled = false
+    void Environment()
+      .then((env) => {
+        if (!cancelled) setOnMac(env.platform === "darwin")
+      })
+      .catch(() => {
+        /* No runtime to ask: leave the buttons drawn, which is the safe way
+           to be wrong -- a window with no controls cannot be closed. */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
   const onMap = screen === "map"
   const hasMap = onMap || screen === "energy"
   // The map's own readings, which need the map to be on screen to mean
@@ -221,13 +264,13 @@ export function TitleBar({
         {showMapTelemetry && (
           <div className="telemetry hidden items-center gap-4 text-[11px] text-muted-foreground lg:flex">
             <span>
-              LAT <span className="text-foreground">{fmtCoord(view.lat, "N", "S")}</span>
+              LAT <span className="text-foreground">{fmtCoord(shown.lat, "N", "S")}</span>
             </span>
             <span>
-              LON <span className="text-foreground">{fmtCoord(view.lon, "E", "W")}</span>
+              LON <span className="text-foreground">{fmtCoord(shown.lon, "E", "W")}</span>
             </span>
             <span>
-              Z <span className="text-foreground">{view.zoom.toFixed(0)}</span>
+              Z <span className="text-foreground">{shown.zoom.toFixed(0)}</span>
             </span>
             {credit && (
               <>
@@ -335,17 +378,32 @@ export function TitleBar({
           </button>
         )}
 
-        <div className="app-no-drag flex items-center gap-1">
-          <WindowButton onClick={WindowMinimise} title="Minimize">
-            <Minus className="h-3.5 w-3.5" />
-          </WindowButton>
-          <WindowButton onClick={WindowToggleMaximise} title="Maximize">
-            <Square className="h-3 w-3" />
-          </WindowButton>
-          <WindowButton onClick={Quit} danger title="Close">
-            <X className="h-3.5 w-3.5" />
-          </WindowButton>
-        </div>
+        {/*
+          NOT ON macOS, where the platform draws them itself.
+
+          These were written for a frameless window, which has no controls of
+          its own. The window is titled now -- frameless made macOS composite it
+          off the path it uses for titled windows, and that slowed every other
+          window sharing its space -- so the traffic lights sit at the other end
+          of this same bar, and drawing a second minimise, maximise and close
+          beside the avatar put two sets of window controls on one window.
+
+          Kept everywhere else: on Windows and Linux this bar is still the only
+          place they exist.
+        */}
+        {!onMac && (
+          <div className="app-no-drag flex items-center gap-1">
+            <WindowButton onClick={WindowMinimise} title="Minimize">
+              <Minus className="h-3.5 w-3.5" />
+            </WindowButton>
+            <WindowButton onClick={WindowToggleMaximise} title="Maximize">
+              <Square className="h-3 w-3" />
+            </WindowButton>
+            <WindowButton onClick={Quit} danger title="Close">
+              <X className="h-3.5 w-3.5" />
+            </WindowButton>
+          </div>
+        )}
       </div>
     </header>
   )

--- a/frontend/src/components/whiteboard/BoardSurface.tsx
+++ b/frontend/src/components/whiteboard/BoardSurface.tsx
@@ -101,7 +101,11 @@ import type {
   PredictResult,
 } from "@/lib/types"
 import type { BoardHandle, PlaneState } from "@/components/whiteboard/boardScene"
-import { createBoard, tokenColor } from "@/components/whiteboard/boardScene"
+import {
+  createBoard,
+  tokenColor,
+  type BoardStats,
+} from "@/components/whiteboard/boardScene"
 import { cn } from "@/lib/utils"
 import { remToPx } from "@/lib/boardPartition"
 import {
@@ -474,6 +478,24 @@ export function BoardSurface({
 }) {
   const hostRef = useRef<HTMLDivElement>(null)
   const boardRef = useRef<BoardHandle | null>(null)
+  /*
+    What the board costs, polled rather than pushed.
+
+    Twice a second, which is as fast as a figure is worth reading and slow
+    enough that displaying it is not itself the load. Pushing from the scene
+    would ask React to re-render at the frame rate in order to show the frame
+    rate, and the stall being looked for would be partly this.
+
+    Null until the scene reports: on a board with nothing on it there is no
+    frame to have taken any time.
+  */
+  const [boardStats, setBoardStats] = useState<BoardStats | null>(null)
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setBoardStats(boardRef.current?.stats() ?? null)
+    }, 500)
+    return () => window.clearInterval(id)
+  }, [])
 
   /**
    * What the column is listing, and which asset it is describing.
@@ -3943,6 +3965,7 @@ export function BoardSurface({
         legend of anything. Twenty-two pixels at the foot buys that back.
       */}
       <StudioStatusBar
+        stats={boardStats}
         running={!!runRunning}
         progress={runProgress}
         runLog={runLog ?? []}

--- a/frontend/src/components/whiteboard/MethodPanel.tsx
+++ b/frontend/src/components/whiteboard/MethodPanel.tsx
@@ -103,7 +103,7 @@ function Trace({
       <p className="eyebrow !text-[9px] pb-1">
         {running ? "Running" : "Last run"}
       </p>
-      <ul className="panel-scroll flex max-h-40 flex-col gap-0.5 overflow-y-auto">
+      <ul className="selectable panel-scroll flex max-h-40 flex-col gap-0.5 overflow-y-auto">
         {entries.map((e, i) => {
           const last = i === entries.length - 1
           return (

--- a/frontend/src/components/whiteboard/StudioStatusBar.tsx
+++ b/frontend/src/components/whiteboard/StudioStatusBar.tsx
@@ -20,12 +20,14 @@
  */
 import { Loader2 } from "lucide-react"
 import type { RunLogEntry } from "@/lib/runLog"
+import type { BoardStats } from "@/components/whiteboard/boardScene"
 import { cn } from "@/lib/utils"
 
 /** The strip's height, which the area tree subtracts from its rectangle. */
 export const STATUS_BAR_PX = 22
 
 export function StudioStatusBar({
+  stats,
   running,
   progress,
   runLog,
@@ -34,6 +36,8 @@ export function StudioStatusBar({
   areas,
   onOpenLog,
 }: {
+  /** What the surface is costing, or null before it has drawn a frame. */
+  stats: BoardStats | null
   running: boolean
   /** 0 to 100, from the sidecar's own stages. */
   progress: number
@@ -73,6 +77,75 @@ export function StudioStatusBar({
         <Binding keys="Shift Middle" what="Pan" />
         <Binding keys="Ctrl Middle" what="Zoom" />
       </span>
+
+      {/*
+        What the surface costs, beside what the pointer does, because both
+        answer questions about THIS viewport and a reader checking whether a
+        drag is smooth is already looking here.
+
+        EVERY FIGURE IS MEASURED. The frame time is the median interval between
+        the frames that actually happened -- the board renders on demand, so a
+        mean since the scene opened would hide the stall being looked for. The
+        counters are three's own renderer.info, which is what was submitted
+        rather than an estimate of it.
+
+        There is no CPU or process-memory figure here, and it is not an
+        oversight. A WKWebView exposes neither: `performance.memory` is not
+        implemented in WebKit, and the process doing the work is a WebContent
+        XPC service whose only link back to this application is a handful of
+        transient cache files. A number invented for those columns would be
+        worse than their absence.
+      */}
+      {stats && stats.fps > 0 && (
+        <span className="telemetry hidden shrink-0 items-center gap-2 text-[9px] text-muted-foreground xl:flex">
+          {/*
+            The browser's own rate first, because it is the figure that decides
+            whether anything below it is the studio's fault. It comes from a
+            loop that submits no drawing, so it measures the page rather than
+            the scene.
+          */}
+          <Figure
+            label="page"
+            value={`${stats.displayHz.toFixed(0)}hz`}
+            warn={stats.displayHz < 45}
+          />
+          <Figure
+            label="fps"
+            value={stats.fps.toFixed(0)}
+            /* Under 30 a drag reads as stepping rather than moving. */
+            warn={stats.fps < 30}
+          />
+          {/*
+            Two times, because they answer different questions and only one of
+            them accuses the surface. `work` is what a frame cost; `gap` is how
+            long the board waited before being asked for one, which on a
+            render-on-demand surface is mostly idleness and not a fault.
+          */}
+          <Figure label="work" value={`${stats.workMs.toFixed(1)}ms`} warn={stats.workMs > 16} />
+          <Figure label="gap" value={`${stats.frameMs.toFixed(0)}ms`} />
+          {/*
+            What a pointer event costs and how many arrive. The frame timing
+            cannot see these -- pointer handlers run outside the animation
+            callback -- and they are the one path that could block the main
+            thread between frames while every frame itself measured fast.
+          */}
+          <Figure label="move" value={`${stats.moveMs.toFixed(1)}ms`} warn={stats.moveMs > 4} />
+          <Figure label="ev" value={`${stats.moveHz.toFixed(0)}/s`} />
+          <Figure label="calls" value={String(stats.calls)} />
+          <Figure label="tris" value={formatCount(stats.triangles)} />
+          <Figure label="tex" value={String(stats.textures)} />
+          <Figure label="geo" value={String(stats.geometries)} />
+          {/*
+            The drawing buffer, because the cost of a frame that draws almost
+            nothing is the cost of moving it: WebKit resolves and copies this
+            many pixels into a window-server surface every frame.
+          */}
+          <Figure
+            label={`buf @${stats.pixelRatio}x`}
+            value={`${stats.bufferW}x${stats.bufferH}`}
+          />
+        </span>
+      )}
 
       <span className="flex-1" />
 
@@ -128,6 +201,36 @@ export function StudioStatusBar({
       </span>
     </div>
   )
+}
+
+/** One measured figure: the number in the foreground, its unit beside it. */
+function Figure({
+  label,
+  value,
+  warn = false,
+}: {
+  label: string
+  value: string
+  warn?: boolean
+}) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span
+        className="tabular-nums"
+        style={{ color: warn ? "var(--destructive-quiet)" : "rgb(var(--p-text))" }}
+      >
+        {value}
+      </span>
+      {label}
+    </span>
+  )
+}
+
+/** Thousands as k, because a triangle count is read for its order of size. */
+function formatCount(n: number): string {
+  if (n < 1000) return String(n)
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`
+  return `${(n / 1_000_000).toFixed(1)}M`
 }
 
 /** One binding: the key in the foreground, what it does beside it. */

--- a/frontend/src/components/whiteboard/StudioStatusBar.tsx
+++ b/frontend/src/components/whiteboard/StudioStatusBar.tsx
@@ -21,6 +21,12 @@
 import { Loader2 } from "lucide-react"
 import type { RunLogEntry } from "@/lib/runLog"
 import type { BoardStats } from "@/components/whiteboard/boardScene"
+import { useSyncExternalStore } from "react"
+import {
+  TELEMETRY_FIGURES,
+  studioTelemetry,
+  subscribeStudioTelemetry,
+} from "@/lib/studioTelemetry"
 import { cn } from "@/lib/utils"
 
 /** The strip's height, which the area tree subtracts from its rectangle. */
@@ -49,6 +55,20 @@ export function StudioStatusBar({
   onOpenLog?: () => void
 }) {
   const stage = runLog.length ? runLog[runLog.length - 1] : null
+  /*
+    Which figures to draw, subscribed rather than received.
+
+    Off by default and each switched separately in Settings, because a status
+    bar reporting its own performance to a reader who did not ask is chrome
+    spent on a question they are not holding. One of them is not free -- see
+    lib/studioTelemetry.ts -- and the scene watches the same store, so switching
+    that one off stops the work as well as the display.
+  */
+  const shows = useSyncExternalStore(
+    subscribeStudioTelemetry,
+    studioTelemetry
+  )
+  const anyShown = TELEMETRY_FIGURES.some((f) => shows[f.key])
 
   return (
     <div
@@ -96,54 +116,49 @@ export function StudioStatusBar({
         transient cache files. A number invented for those columns would be
         worse than their absence.
       */}
-      {stats && stats.fps > 0 && (
+      {stats && anyShown && (
         <span className="telemetry hidden shrink-0 items-center gap-2 text-[9px] text-muted-foreground xl:flex">
-          {/*
-            The browser's own rate first, because it is the figure that decides
-            whether anything below it is the studio's fault. It comes from a
-            loop that submits no drawing, so it measures the page rather than
-            the scene.
-          */}
-          <Figure
-            label="page"
-            value={`${stats.displayHz.toFixed(0)}hz`}
-            warn={stats.displayHz < 45}
-          />
-          <Figure
-            label="fps"
-            value={stats.fps.toFixed(0)}
-            /* Under 30 a drag reads as stepping rather than moving. */
-            warn={stats.fps < 30}
-          />
-          {/*
-            Two times, because they answer different questions and only one of
-            them accuses the surface. `work` is what a frame cost; `gap` is how
-            long the board waited before being asked for one, which on a
-            render-on-demand surface is mostly idleness and not a fault.
-          */}
-          <Figure label="work" value={`${stats.workMs.toFixed(1)}ms`} warn={stats.workMs > 16} />
-          <Figure label="gap" value={`${stats.frameMs.toFixed(0)}ms`} />
-          {/*
-            What a pointer event costs and how many arrive. The frame timing
-            cannot see these -- pointer handlers run outside the animation
-            callback -- and they are the one path that could block the main
-            thread between frames while every frame itself measured fast.
-          */}
-          <Figure label="move" value={`${stats.moveMs.toFixed(1)}ms`} warn={stats.moveMs > 4} />
-          <Figure label="ev" value={`${stats.moveHz.toFixed(0)}/s`} />
-          <Figure label="calls" value={String(stats.calls)} />
-          <Figure label="tris" value={formatCount(stats.triangles)} />
-          <Figure label="tex" value={String(stats.textures)} />
-          <Figure label="geo" value={String(stats.geometries)} />
-          {/*
-            The drawing buffer, because the cost of a frame that draws almost
-            nothing is the cost of moving it: WebKit resolves and copies this
-            many pixels into a window-server surface every frame.
-          */}
-          <Figure
-            label={`buf @${stats.pixelRatio}x`}
-            value={`${stats.bufferW}x${stats.bufferH}`}
-          />
+          {shows.page && (
+            <Figure
+              label="page"
+              value={`${stats.displayHz.toFixed(0)}hz`}
+              warn={stats.displayHz > 0 && stats.displayHz < 45}
+            />
+          )}
+          {shows.fps && (
+            <>
+              {/* Under 30 a drag reads as stepping rather than moving. */}
+              <Figure label="fps" value={stats.fps.toFixed(0)} warn={stats.fps > 0 && stats.fps < 30} />
+              <Figure label="gap" value={`${stats.frameMs.toFixed(0)}ms`} />
+            </>
+          )}
+          {shows.work && (
+            <Figure label="work" value={`${stats.workMs.toFixed(1)}ms`} warn={stats.workMs > 16} />
+          )}
+          {shows.pointer && (
+            <>
+              <Figure label="move" value={`${stats.moveMs.toFixed(1)}ms`} warn={stats.moveMs > 4} />
+              <Figure label="ev" value={`${stats.moveHz.toFixed(0)}/s`} />
+            </>
+          )}
+          {shows.draws && (
+            <>
+              <Figure label="calls" value={String(stats.calls)} />
+              <Figure label="tris" value={formatCount(stats.triangles)} />
+            </>
+          )}
+          {shows.resources && (
+            <>
+              <Figure label="tex" value={String(stats.textures)} />
+              <Figure label="geo" value={String(stats.geometries)} />
+            </>
+          )}
+          {shows.buffer && (
+            <Figure
+              label={`buf @${stats.pixelRatio}x`}
+              value={`${stats.bufferW}x${stats.bufferH}`}
+            />
+          )}
         </span>
       )}
 

--- a/frontend/src/components/whiteboard/boardScene.ts
+++ b/frontend/src/components/whiteboard/boardScene.ts
@@ -70,6 +70,10 @@ import {
   onPaletteChange,
   viewportPaletteOverride,
 } from "@/lib/paletteWatch"
+import {
+  subscribeStudioTelemetry,
+  telemetryShows,
+} from "@/lib/studioTelemetry"
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js"
 import { ViewHelper } from "three/examples/jsm/helpers/ViewHelper.js"
 
@@ -1607,7 +1611,12 @@ export function createBoard(
   let tickAt = 0
   let tickRaf = 0
   const tick = (t: number) => {
-    if (disposed) return
+    if (disposed || !telemetryShows("page")) {
+      tickRaf = 0
+      tickAt = 0
+      displayMs.length = 0
+      return
+    }
     if (tickAt) {
       displayMs.push(t - tickAt)
       if (displayMs.length > 60) displayMs.shift()
@@ -1615,7 +1624,25 @@ export function createBoard(
     tickAt = t
     tickRaf = requestAnimationFrame(tick)
   }
-  tickRaf = requestAnimationFrame(tick)
+  /*
+    Started only when the figure is switched on, and stopped when it is off.
+
+    This is the one measurement that is not free, so it does not run for a
+    reader who is not reading it. Subscribing rather than reading once means the
+    setting takes effect on the open studio instead of on the next one.
+  */
+  const syncTicker = () => {
+    if (telemetryShows("page")) {
+      if (!tickRaf && !disposed) tickRaf = requestAnimationFrame(tick)
+    } else if (tickRaf) {
+      cancelAnimationFrame(tickRaf)
+      tickRaf = 0
+      tickAt = 0
+      displayMs.length = 0
+    }
+  }
+  const stopTelemetryWatch = subscribeStudioTelemetry(syncTicker)
+  syncTicker()
 
   const render = () => {
     if (disposed || raf) return
@@ -2557,6 +2584,7 @@ export function createBoard(
       echoPool.length = 0
       if (raf) cancelAnimationFrame(raf)
       if (tickRaf) cancelAnimationFrame(tickRaf)
+      stopTelemetryWatch()
       stopPaletteWatch()
       observer.disconnect()
       controls.removeEventListener("change", render)

--- a/frontend/src/components/whiteboard/boardScene.ts
+++ b/frontend/src/components/whiteboard/boardScene.ts
@@ -154,6 +154,45 @@ export interface PlaneState {
  * Only the two units this variable is ever written in. Anything else returns 0,
  * which is the same fallback the caller had and is honest about not knowing.
  */
+/** What one board is costing to draw. Every figure is measured, none derived. */
+export interface BoardStats {
+  /**
+   * Frames per second the BROWSER delivers, from a loop that draws nothing.
+   *
+   * Near the display's own rate means the page's frame loop is healthy and a
+   * large `frameMs` is the board idling. Far below it means the browser cannot
+   * finish a frame, and nothing in this scene is the reason.
+   */
+  displayHz: number
+  /** Median time inside one pointermove handler, in milliseconds. */
+  moveMs: number
+  /** Pointer events arriving per second, over the last full second. */
+  moveHz: number
+  /** The drawing buffer, in device pixels, and the ratio it was built at. */
+  bufferW: number
+  bufferH: number
+  pixelRatio: number
+  /**
+   * Median time spent INSIDE a frame: controls, draw, helper, labels.
+   *
+   * This is the figure that says whether the surface is slow. It is not the
+   * interval -- see workMs in createBoard for why the two differ here.
+   */
+  workMs: number
+  /** Median interval between frames, which on an idle board is mostly waiting. */
+  frameMs: number
+  /** The interval as a rate, or 0 before two frames have been drawn. */
+  fps: number
+  /** three's renderer.info.render.calls for the last frame. */
+  calls: number
+  triangles: number
+  /** Live GPU resources: renderer.info.memory. */
+  textures: number
+  geometries: number
+  /** Compiled shader programs held by the renderer. */
+  programs: number
+}
+
 export interface BoardHandle {
   /** Redraw once. The board renders on demand, not in a permanent loop. */
   render: () => void
@@ -277,6 +316,14 @@ export interface BoardHandle {
    */
   focusPlane: (groupId: string, layerId: string) => boolean
   /** Release the GL context and every resource attached to it. */
+  /**
+   * What the surface is costing, for the studio's status bar.
+   *
+   * Read on demand rather than pushed: the caller polls at a rate a person can
+   * read, and a scene that reported every frame would be asking React to
+   * re-render at the frame rate to display the frame rate.
+   */
+  stats: () => BoardStats
   dispose: () => void
 }
 
@@ -1216,6 +1263,23 @@ export function createBoard(
   }
 
   const onPointerMove = (e: PointerEvent) => {
+    const began = performance.now()
+    moveCount++
+    if (!moveWindowAt) moveWindowAt = began
+    else if (began - moveWindowAt >= 1000) {
+      moveHz = (moveCount * 1000) / (began - moveWindowAt)
+      moveCount = 0
+      moveWindowAt = began
+    }
+    try {
+      onPointerMoveInner(e)
+    } finally {
+      moveMs.push(performance.now() - began)
+      if (moveMs.length > 60) moveMs.shift()
+    }
+  }
+
+  const onPointerMoveInner = (e: PointerEvent) => {
     if (!dragging) {
       sampleProbe(e)
       return
@@ -1478,10 +1542,91 @@ export function createBoard(
     opts.onLabels(spots)
   }
 
+  /*
+    What the last frames cost, and what they drew.
+
+    The board renders on demand, so a frame rate here is not "how fast the loop
+    runs" -- it is how long the frames that DID happen took, which is the number
+    that says whether a drag is smooth. Kept as a small ring rather than an
+    average since the scene opened: a mean over a session hides the stall that
+    is being looked for.
+
+    The counters come from three's own renderer.info, so they are what was
+    submitted rather than an estimate of it.
+  */
+  const frameMs: number[] = []
+  /*
+    And what the frame COST, which is a different number from what it waited.
+
+    The board renders on demand, so the gap between two frames includes however
+    long nothing asked for one. A readout of that gap alone reports a scene
+    sitting still as a slow scene -- the interval is honest about the rate and
+    says nothing about the work, and the two are only the same thing in a loop
+    that never idles. This one idles by design.
+
+    Measured around the whole callback rather than around renderer.render: what
+    a dropped frame costs includes the controls' update and the label
+    projection, and blaming only the draw would point at the wrong half.
+  */
+  const workMs: number[] = []
+  let lastFrameAt = 0
+
+  /*
+    How fast the BROWSER is handing out frames, measured by a loop that draws
+    nothing.
+
+    `frameMs` cannot answer this on its own. The board renders on demand, so a
+    gap of 70ms is either the browser delivering frames at 14Hz or the board
+    only being asked for one that often -- opposite diagnoses with opposite
+    fixes, and the same number.
+
+    This ticker asks for a frame, records when it arrives, and asks again. It
+    submits no drawing, so what it measures is the page's own frame loop:
+    whatever style, layout, paint and compositing the browser does between
+    handing out one frame and the next.
+
+    A DIAGNOSTIC, and not free: a self-scheduling rAF keeps the page animating,
+    which is the state being measured but not one the studio would otherwise
+    sit in.
+  */
+  /*
+    What a pointer event costs, measured because the frame timing cannot see it.
+
+    `workMs` covers the requestAnimationFrame callback. Pointer handlers run
+    OUTSIDE it: if a move handler were expensive, the main thread would be busy
+    between frames, the browser would deliver them late, and the readout would
+    show a fast frame and a slow page -- which is exactly what it does show. So
+    this closes the one gap in that reasoning rather than assuming it shut.
+  */
+  const moveMs: number[] = []
+  let moveCount = 0
+  let moveWindowAt = 0
+  let moveHz = 0
+
+  const displayMs: number[] = []
+  let tickAt = 0
+  let tickRaf = 0
+  const tick = (t: number) => {
+    if (disposed) return
+    if (tickAt) {
+      displayMs.push(t - tickAt)
+      if (displayMs.length > 60) displayMs.shift()
+    }
+    tickAt = t
+    tickRaf = requestAnimationFrame(tick)
+  }
+  tickRaf = requestAnimationFrame(tick)
+
   const render = () => {
     if (disposed || raf) return
     raf = requestAnimationFrame(() => {
       raf = 0
+      const began = performance.now()
+      if (lastFrameAt) {
+        frameMs.push(began - lastFrameAt)
+        if (frameMs.length > 60) frameMs.shift()
+      }
+      lastFrameAt = began
       controls.update()
       updateFog()
       renderer.clear()
@@ -1491,6 +1636,8 @@ export function createBoard(
       // behind the raster.
       viewHelper.render(renderer)
       reportLabels()
+      workMs.push(performance.now() - began)
+      if (workMs.length > 60) workMs.shift()
     })
   }
   controls.addEventListener("change", render)
@@ -2371,6 +2518,31 @@ export function createBoard(
         render()
       }
     },
+    stats() {
+      const mid = (xs: number[]) => {
+        if (!xs.length) return 0
+        const sorted = [...xs].sort((x, y) => x - y)
+        return sorted[Math.floor(sorted.length / 2)]
+      }
+      const median = mid(frameMs)
+      const display = mid(displayMs)
+      return {
+        displayHz: display > 0 ? 1000 / display : 0,
+        moveMs: mid(moveMs),
+        moveHz,
+        bufferW: renderer.domElement.width,
+        bufferH: renderer.domElement.height,
+        pixelRatio: renderer.getPixelRatio(),
+        workMs: mid(workMs),
+        frameMs: median,
+        fps: median > 0 ? 1000 / median : 0,
+        calls: renderer.info.render.calls,
+        triangles: renderer.info.render.triangles,
+        textures: renderer.info.memory.textures,
+        geometries: renderer.info.memory.geometries,
+        programs: renderer.info.programs?.length ?? 0,
+      }
+    },
     dispose() {
       disposed = true
       // Returns every echo to the pool first, so the loop below sees them all.
@@ -2384,6 +2556,7 @@ export function createBoard(
       for (const echo of echoPool) echo.material.dispose()
       echoPool.length = 0
       if (raf) cancelAnimationFrame(raf)
+      if (tickRaf) cancelAnimationFrame(tickRaf)
       stopPaletteWatch()
       observer.disconnect()
       controls.removeEventListener("change", render)

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -911,6 +911,51 @@
   border-top-color: rgb(var(--p-line) / 0.28) !important;
 }
 
+/*
+  THE CHROME IS NOT SELECTABLE, and the content is.
+
+  A web view selects everything by default, so dragging across this application
+  highlighted its own labels, its navigation and the words on its buttons -- a
+  gesture that means nothing here and that no application with a native shell
+  answers to. The default is the wrong way round for a program whose text is
+  overwhelmingly chrome.
+
+  So the shell says no and the places that hold something worth taking say yes.
+  What earns `.selectable` is anything a reader might carry somewhere else: a
+  measured value, a coordinate, a file path, an error, a table cell, the text of
+  a run's log. Anything they might quote back into an issue.
+
+  FORM CONTROLS ARE EXEMPT UNCONDITIONALLY. Editing text without being able to
+  select it is not a restriction, it is a broken field, and this rule sits above
+  the class so no container can take it away from an input inside it.
+*/
+body {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+input,
+textarea,
+select,
+[contenteditable="true"],
+.selectable,
+.selectable * {
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+/*
+  Code and preformatted text, wherever they appear. Both exist here to be read
+  literally -- a token block, a path, a stack -- and being read literally is the
+  same reason they would be copied.
+*/
+code,
+pre,
+.telemetry {
+  user-select: text;
+  -webkit-user-select: text;
+}
+
 /* Map swipe (imagery ↔ prediction) — handle sits above leaflet panes */
 .map-swipe-handle {
   touch-action: none;

--- a/frontend/src/lib/mapPose.ts
+++ b/frontend/src/lib/mapPose.ts
@@ -1,0 +1,53 @@
+/**
+ * Where the map is looking, published outside React.
+ *
+ * WHY THIS IS NOT STATE. The map reports its centre and zoom on every frame of
+ * a pan -- that is what leaflet's `move` event is -- and the only thing in the
+ * application that reads the live value is the coordinate readout in the title
+ * bar. Routing it through `useState` in App put a new object on the ROOT
+ * component sixty times a second, and App's subtree is every screen the
+ * application has. React has no way to skip that: the object is new each frame,
+ * nothing on the path is memoised, and so a drag on the map reconciled the
+ * whole tree once per frame.
+ *
+ * That is measurable as the map being heavy to pan, and it is not only the
+ * map's problem -- the same render is what a screen transition and the studio
+ * switch land in the middle of.
+ *
+ * A store instead, so the one component that wants the live value subscribes to
+ * it and nothing else hears. The committed value still goes through App on
+ * `moveend`, where it is wanted for persistence and for restoring the position
+ * across screens, and where it happens once per gesture rather than per frame.
+ */
+export interface MapPose {
+  lat: number
+  lon: number
+  zoom: number
+}
+
+let pose: MapPose | null = null
+const listeners = new Set<() => void>()
+
+/** Called from leaflet's move handler. Replaces the pose and wakes readers. */
+export function publishMapPose(next: MapPose): void {
+  pose = next
+  for (const fn of listeners) fn()
+}
+
+export function subscribeMapPose(onChange: () => void): () => void {
+  listeners.add(onChange)
+  return () => {
+    listeners.delete(onChange)
+  }
+}
+
+/**
+ * The current pose, or null before the map has reported one.
+ *
+ * The reference is stable between publishes, which is what useSyncExternalStore
+ * requires: a getSnapshot that built a new object each call would re-render its
+ * subscriber on every check.
+ */
+export function mapPose(): MapPose | null {
+  return pose
+}

--- a/frontend/src/lib/panelSelection.ts
+++ b/frontend/src/lib/panelSelection.ts
@@ -1,0 +1,44 @@
+/**
+ * Which map tool has its panel open, held outside React.
+ *
+ * WHY IT IS NOT STATE IN App. Two things wanted it there and neither wanted it
+ * to be state: the navigation column and the map screen both read it, so it had
+ * to live above both, and the map screen remounts on every return to it, so a
+ * useState inside the screen forgot the choice each time.
+ *
+ * Lifting it to App answered both and charged for it every time: App holds the
+ * whole application's tree, nothing on the path is memoised, and so collapsing a
+ * panel reconciled every screen the application has in order to change which of
+ * three panels was drawn.
+ *
+ * A module holds it instead. It outlives the screen's remount for the same
+ * reason a module always does, and the two components that read it subscribe
+ * for themselves -- so a collapse re-renders the navigation column and the map
+ * screen, which are the two things a collapse changes.
+ *
+ * Shaped like lib/mapPose.ts and deliberately not shared with it. They hold
+ * different things for different reasons, and a `createStore` covering both
+ * would be an abstraction over two call sites.
+ */
+import type { MapToolId } from "@/lib/mapTools"
+
+let selected: MapToolId | null = "classify"
+const listeners = new Set<() => void>()
+
+export function selectPanel(next: MapToolId | null): void {
+  if (next === selected) return
+  selected = next
+  for (const fn of listeners) fn()
+}
+
+export function subscribePanelSelection(onChange: () => void): () => void {
+  listeners.add(onChange)
+  return () => {
+    listeners.delete(onChange)
+  }
+}
+
+/** The open panel, or null where the column is collapsed. */
+export function panelSelection(): MapToolId | null {
+  return selected
+}

--- a/frontend/src/lib/preferenceExtras.ts
+++ b/frontend/src/lib/preferenceExtras.ts
@@ -67,6 +67,15 @@ export interface PreferenceExtras {
    * boardMemory, which states why they should not outlive a restart.
    */
   studio_layout?: import("@/lib/studioLayout").StudioLayout
+  /**
+   * Which figures the studio's status bar reports.
+   *
+   * A preference rather than a build flag because one of the figures costs
+   * something to have on -- it keeps the page animating -- and the reader who
+   * accepts that cost is the one diagnosing a stall. Absent means none, which
+   * is what a reader who has never opened the setting should get.
+   */
+  studio_telemetry?: import("@/lib/studioTelemetry").StudioTelemetry
 }
 
 export function parsePreferenceExtras(

--- a/frontend/src/lib/studioTelemetry.ts
+++ b/frontend/src/lib/studioTelemetry.ts
@@ -1,0 +1,131 @@
+/**
+ * Which figures the studio's status bar reports, and where that choice lives.
+ *
+ * A store rather than props, for the reason lib/panelSelection.ts is one: the
+ * readers are the status bar, deep inside the studio, and the scene, which is
+ * not React at all. Routing a preference to both through App would put it in
+ * the component whose every state change reconciles the application.
+ *
+ * Seeded from preferences on sign-in and written back on change, so the choice
+ * outlives a restart the way the other settings on that page do.
+ */
+
+/** One switchable figure, and what it costs to have on. */
+export interface TelemetryFigure {
+  key: TelemetryKey
+  label: string
+  /** What the figure means, in the words the settings row uses. */
+  what: string
+  /**
+   * When it is worth having on. Not a rating: each says the question it
+   * answers, because a reader turning these on is diagnosing something and the
+   * useful thing to know is which figure speaks to which symptom.
+   */
+  when: string
+  /**
+   * What having it on costs, or null where it is free.
+   *
+   * Only one of these is not free, and it is the most useful of them, so the
+   * cost is stated rather than the figure being left out or left on quietly.
+   */
+  cost: string | null
+}
+
+export type TelemetryKey =
+  | "page"
+  | "fps"
+  | "work"
+  | "pointer"
+  | "draws"
+  | "resources"
+  | "buffer"
+
+export const TELEMETRY_FIGURES: readonly TelemetryFigure[] = [
+  {
+    key: "page",
+    label: "Page frame rate",
+    what: "How fast the browser delivers frames, measured by a loop that draws nothing.",
+    when: "First, when anything feels slow. It is the figure that says whether the studio is the cause at all — if it is low while the frame work below is near zero, nothing being drawn here is the reason.",
+    cost: "Keeps the page animating for as long as the studio is open, which is the state it measures and not one the studio would otherwise sit in. On battery, leave it off until something needs diagnosing.",
+  },
+  {
+    key: "fps",
+    label: "Board frame rate",
+    what: "Frames the board actually drew, and the interval between them.",
+    when: "Beside the page rate. The board draws on demand, so a long interval on a still scene is the board idling rather than a fault.",
+    cost: null,
+  },
+  {
+    key: "work",
+    label: "Frame work",
+    what: "Time spent inside one frame: controls, draw, orientation helper, labels.",
+    when: "When the board is the suspect. This is the only figure that accuses the scene itself; a high page rate with high work here means the drawing is what costs.",
+    cost: null,
+  },
+  {
+    key: "pointer",
+    label: "Pointer cost",
+    what: "Time inside one pointer event, and how many arrive per second.",
+    when: "When a drag is worse than an idle scene. Pointer handlers run outside the animation callback, so an expensive one blocks frames without appearing in the frame timing.",
+    cost: null,
+  },
+  {
+    key: "draws",
+    label: "Draw calls",
+    what: "Draw calls and triangles submitted for the last frame.",
+    when: "When a board has grown. Both should stay small here — a raster is two triangles — so a large count means something is being drawn per plane that should not be.",
+    cost: null,
+  },
+  {
+    key: "resources",
+    label: "GPU resources",
+    what: "Textures and geometries the renderer is holding.",
+    when: "When opening and closing boards. These should return to where they were; a count that only climbs is something not being released.",
+    cost: null,
+  },
+  {
+    key: "buffer",
+    label: "Drawing buffer",
+    what: "The buffer's size in device pixels, and the ratio it was built at.",
+    when: "When the cost seems to track the window rather than the scene. A frame that draws almost nothing still has to be moved, and this is how much of it there is to move.",
+    cost: null,
+  },
+] as const
+
+export type StudioTelemetry = Partial<Record<TelemetryKey, boolean>>
+
+/**
+ * Off by default, all of it.
+ *
+ * A status bar that reports its own performance to a reader who did not ask is
+ * chrome spent on a question they are not holding. These are switched on to
+ * diagnose something and switched off after -- and the one with a cost must not
+ * be on for anyone who has not read what it costs.
+ */
+export const TELEMETRY_DEFAULT: StudioTelemetry = {}
+
+let shown: StudioTelemetry = TELEMETRY_DEFAULT
+const listeners = new Set<() => void>()
+
+/** Replaces the whole set. Called when preferences load and when one changes. */
+export function setStudioTelemetry(next: StudioTelemetry): void {
+  shown = next
+  for (const fn of listeners) fn()
+}
+
+export function subscribeStudioTelemetry(onChange: () => void): () => void {
+  listeners.add(onChange)
+  return () => {
+    listeners.delete(onChange)
+  }
+}
+
+/** The reference is stable between writes, which useSyncExternalStore needs. */
+export function studioTelemetry(): StudioTelemetry {
+  return shown
+}
+
+/** Whether one figure is on, which is the only question most callers have. */
+export function telemetryShows(key: TelemetryKey): boolean {
+  return shown[key] === true
+}

--- a/frontend/src/pages/MapScreen.tsx
+++ b/frontend/src/pages/MapScreen.tsx
@@ -6,7 +6,7 @@ import {
   Map as MapGlyph,
   type LucideIcon,
 } from "lucide-react"
-import { Suspense, lazy, useEffect, useRef, useState } from "react"
+import { Suspense, lazy, useEffect, useRef, useState, useSyncExternalStore } from "react"
 import { createPortal } from "react-dom"
 import { AnimatePresence } from "motion/react"
 import type {
@@ -24,6 +24,11 @@ import type {
   WaterAnalysis,
   WaterIndex,
 } from "@/lib/types"
+import {
+  panelSelection,
+  selectPanel,
+  subscribePanelSelection,
+} from "@/lib/panelSelection"
 import type { AoiContourSchemeId } from "@/lib/aoiStyle"
 import { MapView } from "@/components/MapView"
 import { SearchBar } from "@/components/SearchBar"
@@ -106,8 +111,6 @@ export interface MapScreenProps {
   /** Where the map was left last session; null starts at the default view. */
   initialView?: { lat: number; lon: number; zoom: number } | null
   /** Open tool tab, owned by the caller so it survives this screen unmounting. */
-  leftPanel: MapToolId | null
-  onLeftPanelChange: (id: MapToolId | null) => void
   /** Which layout draws this screen. See lib/types LayoutMode. */
   layoutMode?: LayoutMode
   /**
@@ -313,7 +316,17 @@ export function MapScreen(props: MapScreenProps) {
   // goes to another one, so local state put the dock back on "classify" on
   // every return -- including a return from a water run, which left a water
   // raster on the map with the classification panel open beside it.
-  const { leftPanel, onLeftPanelChange } = props
+  /*
+    Subscribed rather than received. It was a prop because this screen remounts
+    on every return to it and a useState here forgot the choice -- a module
+    outlives the remount for free, and App stops re-rendering for a collapse.
+    See lib/panelSelection.ts.
+  */
+  const leftPanel = useSyncExternalStore(
+    subscribePanelSelection,
+    panelSelection
+  )
+  const onLeftPanelChange = selectPanel
   /**
    * Which right-edge drawer is open, at most one.
    *

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react"
 import {
   ArrowLeft,
   Camera,
@@ -32,6 +32,14 @@ import { PageAside, PageBody, PageShell } from "@/components/ui/PageShell"
 import { btnGhost, btnPrimary } from "@/components/ui/buttons"
 import { EnvironmentPanel } from "@/components/EnvironmentPanel"
 import { StorageModal } from "@/components/StorageModal"
+import {
+  TELEMETRY_FIGURES,
+  setStudioTelemetry,
+  studioTelemetry,
+  subscribeStudioTelemetry,
+  type StudioTelemetry,
+  type TelemetryKey,
+} from "@/lib/studioTelemetry"
 import { cn } from "@/lib/utils"
 import type {
   InferenceRun,
@@ -52,7 +60,7 @@ import { runRowLine } from "@/lib/runSummary"
 
 const MAX_AVATAR_BYTES = 2_000_000
 
-type SettingsSectionId = "account" | "system"
+type SettingsSectionId = "account" | "telemetry" | "system"
 
 /**
  * The pages of settings, grouped by subject.
@@ -92,6 +100,11 @@ const SECTIONS: {
   // No count. The other page is a list of controls, and the number says how
   // long the list is. This one reports the state of an environment and offers
   // what to do about it, so "(1)" would be counting the wrong thing.
+  /*
+    Counted, unlike System: this page IS a list of controls, and the number says
+    how long the list is.
+  */
+  { id: "telemetry", label: "Telemetry", count: TELEMETRY_FIGURES.length },
   { id: "system", label: "System" },
 ]
 
@@ -168,6 +181,18 @@ export function ProfilePage({
     consumeSettingsPage()
   }, [settingsPage, consumeSettingsPage])
   const [focusedSetting, setFocusedSetting] = useState<string | null>(null)
+  /*
+    Read from the module the studio reads, not from a copy held here.
+
+    The scene and the status bar subscribe to the same store, so a switch flipped
+    here takes effect on an open studio rather than on the next one -- including
+    the one figure whose cost is the work it does, which stops when it is
+    switched off.
+  */
+  const telemetry = useSyncExternalStore(
+    subscribeStudioTelemetry,
+    studioTelemetry
+  )
   const fileRef = useRef<HTMLInputElement>(null)
   const prefsReady = useRef(false)
   const savePrefsTimer = useRef<number | null>(null)
@@ -198,6 +223,32 @@ export function ProfilePage({
     write a zero opacity and an empty model over whatever is stored. Passing
     the stored value through keeps a theme change to being a theme change.
   */
+  /*
+    The store first and the preferences after, deliberately.
+
+    Writing preferences means a round trip through the bridge and the database,
+    and a switch that waited for it would feel like it had not registered. The
+    store is what the studio reads, so flipping it first makes the change
+    immediate; the save is how it survives a restart.
+  */
+  const persistTelemetry = useCallback(
+    async (key: TelemetryKey, on: boolean) => {
+      const next: StudioTelemetry = { ...studioTelemetry(), [key]: on }
+      setStudioTelemetry(next)
+      if (!user) return
+      await savePrefs({
+        user_id: user.id,
+        default_model: prefs?.default_model || "spectral",
+        overlay_opacity: prefs?.overlay_opacity ?? 0.75,
+        theme: prefs?.theme || "dark",
+        extras_json: mergePreferenceExtras(prefs?.extras_json, {
+          studio_telemetry: next,
+        }),
+      })
+    },
+    [user, prefs?.default_model, prefs?.overlay_opacity, prefs?.theme, prefs?.extras_json, savePrefs]
+  )
+
   const persistPreferences = useCallback(
     async (next: {
       theme: string
@@ -1021,6 +1072,61 @@ export function ProfilePage({
               description beside it, which is right for a name or a slider and
               wrong for this: wrapped, the page showed its title twice and
               indented the whole thing as though it were one control's value. */}
+          {activeSection === "telemetry" && (
+            <Section>
+              {/*
+                All off until asked for. A status bar reporting its own
+                performance to a reader who did not ask is chrome spent on a
+                question they are not holding -- and one of these is not free,
+                so it must not be running for anyone who has not read what it
+                costs.
+
+                Each row says what the figure means and which question it
+                answers, because a reader switching these on is diagnosing
+                something and the useful thing to know is which figure speaks
+                to which symptom.
+              */}
+              <p className="px-4 pb-1 pt-3 text-body leading-relaxed text-muted-foreground">
+                Figures the studio&rsquo;s status bar reports, beside the pointer
+                bindings. Off by default; switch on what a symptom calls for.
+              </p>
+              {TELEMETRY_FIGURES.map((figure) => (
+                <SettingRow
+                  key={figure.key}
+                  id={`telemetry.${figure.key}`}
+                  title={figure.label}
+                  description={figure.what}
+                  focused={focusedSetting === `telemetry.${figure.key}`}
+                  onFocus={() => setFocusedSetting(`telemetry.${figure.key}`)}
+                >
+                  <label className="flex cursor-pointer items-start gap-2.5">
+                    <input
+                      type="checkbox"
+                      className={cn("mt-0.5 shrink-0", focusRing)}
+                      checked={telemetry[figure.key] === true}
+                      onChange={(e) =>
+                        void persistTelemetry(figure.key, e.target.checked)
+                      }
+                    />
+                    <span className="min-w-0 text-body leading-relaxed text-muted-foreground">
+                      {figure.when}
+                      {figure.cost && (
+                        <>
+                          {" "}
+                          {/* The one figure that is not free says so where the
+                              switch is, not in a note somewhere else. */}
+                          <span className="text-destructive-quiet">
+                            Costs: {figure.cost}
+                          </span>
+                        </>
+                      )}
+                    </span>
+                  </label>
+                </SettingRow>
+              ))}
+            </Section>
+          )}
+
           {activeSection === "system" && (
             <Section>
               <div className="pt-3">

--- a/main.go
+++ b/main.go
@@ -114,7 +114,18 @@ func main() {
 			app,
 		},
 		Mac: &mac.Options{
-			TitleBar:   mac.TitleBarHiddenInset(),
+			/*
+				Hidden, not hidden-inset. The two differ by one field --
+				UseToolbar -- and the toolbar is what pushes the traffic lights
+				in from the corner, right and down, past the 4.5rem the header
+				reserves for them. That reservation is the standard position,
+				so the standard position is what to ask for rather than a new
+				number guessed to match an offset macOS controls.
+
+				Both keep NSWindowStyleMaskTitled, which is the part that
+				matters for compositing -- see Frameless above.
+			*/
+			TitleBar:   mac.TitleBarHidden(),
 			Appearance: mac.NSAppearanceNameDarkAqua,
 			About: &mac.AboutInfo{
 				Title:   "TERRA",

--- a/main.go
+++ b/main.go
@@ -41,6 +41,12 @@ therefore the one whose pins match the model artifacts it ships beside.
 var requirementsTxt string
 
 func main() {
+	/*
+		Before wails.Run, because the menu is built during it. See
+		editmenu_darwin.go -- on every platform but macOS this does nothing.
+	*/
+	trimEditMenu()
+
 	app := NewApp()
 
 	err := wails.Run(&options.App{

--- a/main.go
+++ b/main.go
@@ -52,7 +52,36 @@ func main() {
 		MinHeight:        220,
 		AlwaysOnTop:      true,
 		BackgroundColour: &options.RGBA{R: 8, G: 7, B: 6, A: 1},
-		Frameless:        true,
+		/*
+			NOT FRAMELESS, and the reason is measured rather than aesthetic.
+
+			While this window was frameless it degraded compositing for every
+			other window sharing its space. Safari running the WebGL aquarium
+			benchmark measured 60fps constantly on any other space and 27-41fps
+			on the one this window occupied -- a different application, slowed
+			by this one being present.
+
+			The cause is in Wails' own window construction. WailsContext.m only
+			adds NSWindowStyleMaskTitled when the window is NOT frameless, so a
+			frameless window here is borderless, and macOS composites a
+			borderless window off the path it uses for titled ones.
+
+			None of it was visible from inside the page, which is what made it
+			expensive to find: the scene submitted 9 draw calls and 72 triangles
+			and cost 0.0ms a frame, the pointer handlers cost 0.0ms, and the web
+			content and GPU processes sat at 2.8% and 0.1% while a
+			requestAnimationFrame that drew nothing was delivered at 11Hz.
+			Everything was waiting, and nothing in the application was the
+			reason.
+
+			The look is kept by TitleBar below. TitleBarHiddenInset gives a
+			titled window with a transparent, title-less bar and full-size
+			content -- the traffic lights inset over the application's own
+			header, which is what the frameless window was being used for. The
+			custom drag regions are unaffected: --wails-draggable is handled in
+			the JavaScript runtime and does not depend on the style mask.
+		*/
+		Frameless: false,
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 			/*


### PR DESCRIPTION
## Summary

The application ran at 11 to 12 Hz, and the cost was not in the application. A
control test settled it: with TERRA open, Safari on the same macOS Space ran at
27 to 41 fps; on any other Space it ran at 60. The window was degrading the
compositor for everything beside it.

The branch is named `study/graphics-engine` because it began as one. It carries
production fixes, not a study.

## Changes

- **`main.go`** — `Frameless: false`. Wails only adds `NSWindowStyleMaskTitled`
  when a window is not frameless (`WailsContext.m:159`), and a borderless window
  is composited off the fast path. `TitleBarHidden` keeps the appearance the
  frameless flag was there for.
- **`editmenu_darwin.m`**, **`editmenu_darwin.go`**, **`editmenu_other.go`** —
  removes the dictation and character-palette items macOS injects into the Edit
  menu.
- **`frontend/src/lib/mapPose.ts`** — an external store for the live map pose.
  The title bar's readout subscribed through App state, so a drag re-rendered
  every screen in the application sixty times a second.
- **`frontend/src/lib/panelSelection.ts`** — the same treatment for the open
  tool panel.
- **`frontend/src/lib/studioTelemetry.ts`** and
  **`frontend/src/components/whiteboard/StudioStatusBar.tsx`** — the studio's
  status bar, and the seven figures it can show. Off by default and switched one
  at a time in Settings, because one of them is not free and the scene watches
  the same store.
- **`docs/PERFORMANCE.md`** — what was measured, what caused it, and what was
  ruled out.

## What was ruled out, and is written down

Data-URI overlays, `backdrop-filter`, and a Safari process misread from
`ps %CPU` (a lifetime average, not an instantaneous one). Each was tested and
cleared; the document says so, so the next reader does not retry them.

## Testing

Measured with `top -l N -s S` and `sample`, before and after, on the same
machine and the same Space. 11-12 Hz to a stable 59-60; with the private
`PreferPageRenderingUpdatesNear60FPSEnabled` flag it oscillates between 60 and
125 on a ProMotion display.