### PR TITLE
style(chrome): the shell stops behaving like a web page

### DIFF
--- a/editmenu_darwin.go
+++ b/editmenu_darwin.go
@@ -1,0 +1,22 @@
+//go:build darwin
+
+package main
+
+/*
+#cgo CFLAGS: -x objective-c -fobjc-arc
+#cgo LDFLAGS: -framework Foundation
+void TerraDisableAutoEditMenuItems(void);
+*/
+import "C"
+
+/*
+trimEditMenu declines the two Edit-menu items AppKit adds on its own.
+
+Called before wails.Run, because the menu is built during it and a default
+registered afterwards is registered too late. See editmenu_darwin.m for which
+items these are, why the menu itself has to stay, and why the values are
+registered rather than written.
+*/
+func trimEditMenu() {
+	C.TerraDisableAutoEditMenuItems()
+}

--- a/editmenu_darwin.m
+++ b/editmenu_darwin.m
@@ -1,0 +1,33 @@
+#import <Foundation/Foundation.h>
+
+/*
+ Keeps AppKit from adding its own items to the Edit menu.
+
+ The Edit menu here is Wails': Undo, Redo, Cut, Copy, Paste, Paste and Match
+ Style, Delete, Select All. AppKit appends four more to any Edit menu it finds
+ -- Speech, AutoFill, Start Dictation and Emoji & Symbols -- and two of those
+ can be declined. Neither belongs in an application whose only text fields are
+ an area's name and a search box.
+
+ THE MENU IS NOT REMOVED, and cannot be. Command-C, Command-V and Command-A in a
+ WKWebView are delivered through the responder chain, which reaches the web view
+ only because menu items carrying those key equivalents exist. An application
+ with no Edit menu is an application where copy and paste stop working inside
+ its own inputs.
+
+ registerDefaults, not setObject:forKey:. Registering places the values in the
+ defaults' registration domain, which is consulted when nothing else answers and
+ is discarded when the process ends. Writing them would put two keys in the
+ reader's own preferences and leave them there after the application is gone,
+ for a choice that is this application's rather than theirs.
+
+ Both keys are documented AppKit behaviour and public.
+ */
+void TerraDisableAutoEditMenuItems(void) {
+    [[NSUserDefaults standardUserDefaults] registerDefaults:@{
+        // "Start Dictation…"
+        @"NSDisabledDictationMenuItem" : @YES,
+        // "Emoji & Symbols"
+        @"NSDisabledCharacterPaletteMenuItem" : @YES,
+    }];
+}

--- a/editmenu_other.go
+++ b/editmenu_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin
+
+package main
+
+/*
+trimEditMenu does nothing off macOS.
+
+The items it declines are AppKit's, added to any Edit menu it finds. No other
+platform's menu grows on its own, so there is nothing to decline -- and a build
+tag says that, where a runtime check would read as though the call might do
+something.
+*/
+func trimEditMenu() {}

--- a/frontend/src/components/DataTableView.tsx
+++ b/frontend/src/components/DataTableView.tsx
@@ -108,7 +108,7 @@ export function DataTableView({
 
       {/* Wide tables scroll inside the section rather than widening the page. */}
       <div className="rounded-sm border border-border bg-background max-h-[22rem] overflow-auto">
-        <table className="w-full min-w-max text-left text-[11px]">
+        <table className="selectable w-full min-w-max text-left text-[11px]">
           <thead className="sticky top-0 z-10">
             <tr
               className="border-b"

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -125,7 +125,7 @@ function CrashDetail({
         {error.message || "The thrown value carried no message."}
       </p>
       {componentStack ? (
-        <pre className="mt-1.5 max-h-40 overflow-auto whitespace-pre-wrap text-micro text-muted-foreground">
+        <pre className="selectable mt-1.5 max-h-40 overflow-auto whitespace-pre-wrap text-micro text-muted-foreground">
           {componentStack.trim()}
         </pre>
       ) : null}

--- a/frontend/src/components/ProjectSwitcher.tsx
+++ b/frontend/src/components/ProjectSwitcher.tsx
@@ -354,14 +354,57 @@ export function ProjectSwitcher({
             return !o
           })
         }
-        className="panel flex max-w-[14rem] items-center gap-1.5 rounded-sm px-2 py-1 text-left text-[11px] text-foreground hover:bg-secondary/40"
+        /*
+          NO BOX AT REST, and no accent on the glyph.
+
+          It wore `panel` -- a bordered, translucent surface -- inside the title
+          bar, which is itself a panel. A panel drawn on a panel reads as a
+          control competing with the wordmark beside it rather than as one more
+          thing on the same row, and the row already separates its parts with a
+          hairline where it means to.
+
+          The accent went with it. DESIGN.md gives that colour three jobs -- a
+          fill, a focus ring, an active state -- and a permanent tint on a
+          folder glyph is none of them. It spent the one colour on screen that
+          is not data on a decoration, beside the project's name, which is what
+          a reader is actually here to read.
+
+          Both come back when the menu is open, because that IS an active state
+          and is exactly what the accent is for.
+        */
+        className={cn(
+          "flex max-w-[14rem] items-center gap-1.5 rounded-sm px-2 py-1 text-left text-[11px] transition-colors",
+          open
+            ? "bg-secondary/60 text-foreground"
+            : "text-foreground hover:bg-secondary/40"
+        )}
         title="Active project"
       >
-        <FolderKanban className="size-3.5 shrink-0 text-primary" />
-        <span className="min-w-0 flex-1 truncate">
+        <FolderKanban
+          className={cn(
+            "size-3.5 shrink-0 transition-colors",
+            open ? "text-primary" : "text-muted-foreground"
+          )}
+        />
+        {/*
+          The name at full strength and the fallback muted, because they are
+          different kinds of thing: one is a value, the other is the absence of
+          one. Drawn alike, "No project" read as a project called that.
+        */}
+        <span
+          className={cn(
+            "min-w-0 flex-1 truncate",
+            !active && "text-muted-foreground"
+          )}
+        >
           {active ? active.name : "No project"}
         </span>
-        <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
+        <ChevronDown
+          className={cn(
+            "size-3 shrink-0 transition-transform",
+            open ? "rotate-180 text-foreground" : "text-muted-foreground"
+          )}
+        />
       </button>
       {menu}
     </div>

--- a/frontend/src/components/whiteboard/MethodPanel.tsx
+++ b/frontend/src/components/whiteboard/MethodPanel.tsx
@@ -103,7 +103,7 @@ function Trace({
       <p className="eyebrow !text-[9px] pb-1">
         {running ? "Running" : "Last run"}
       </p>
-      <ul className="panel-scroll flex max-h-40 flex-col gap-0.5 overflow-y-auto">
+      <ul className="selectable panel-scroll flex max-h-40 flex-col gap-0.5 overflow-y-auto">
         {entries.map((e, i) => {
           const last = i === entries.length - 1
           return (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -911,6 +911,51 @@
   border-top-color: rgb(var(--p-line) / 0.28) !important;
 }
 
+/*
+  THE CHROME IS NOT SELECTABLE, and the content is.
+
+  A web view selects everything by default, so dragging across this application
+  highlighted its own labels, its navigation and the words on its buttons -- a
+  gesture that means nothing here and that no application with a native shell
+  answers to. The default is the wrong way round for a program whose text is
+  overwhelmingly chrome.
+
+  So the shell says no and the places that hold something worth taking say yes.
+  What earns `.selectable` is anything a reader might carry somewhere else: a
+  measured value, a coordinate, a file path, an error, a table cell, the text of
+  a run's log. Anything they might quote back into an issue.
+
+  FORM CONTROLS ARE EXEMPT UNCONDITIONALLY. Editing text without being able to
+  select it is not a restriction, it is a broken field, and this rule sits above
+  the class so no container can take it away from an input inside it.
+*/
+body {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+input,
+textarea,
+select,
+[contenteditable="true"],
+.selectable,
+.selectable * {
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+/*
+  Code and preformatted text, wherever they appear. Both exist here to be read
+  literally -- a token block, a path, a stack -- and being read literally is the
+  same reason they would be copied.
+*/
+code,
+pre,
+.telemetry {
+  user-select: text;
+  -webkit-user-select: text;
+}
+
 /* Map swipe (imagery ↔ prediction) — handle sits above leaflet panes */
 .map-swipe-handle {
   touch-action: none;

--- a/main.go
+++ b/main.go
@@ -41,6 +41,12 @@ therefore the one whose pins match the model artifacts it ships beside.
 var requirementsTxt string
 
 func main() {
+	/*
+		Before wails.Run, because the menu is built during it. See
+		editmenu_darwin.go -- on every platform but macOS this does nothing.
+	*/
+	trimEditMenu()
+
 	app := NewApp()
 
 	err := wails.Run(&options.App{


### PR DESCRIPTION
## Summary

The application is web-based and read as one: labels, headings and menu items
could be selected and dragged like text in a document, which is not something a
desktop window does.

## Changes

- **`frontend/src/index.css`** — `user-select: none` on the body, with it
  restored where selecting is the point: `.selectable`, inputs, `code`, `pre`
  and the telemetry readouts. A reader still copies a coordinate or an error
  message; they no longer highlight a nav item by dragging past it.

## Testing

`npx vitest run`, `npm run check:contrast`, and by hand across the nav, the
panels and the studio.