### PR TITLE
feat(flood): rainfall routed over an area, and the board that reads it

### DIFF
--- a/app_analysis.go
+++ b/app_analysis.go
@@ -344,6 +344,25 @@ func (a *App) AnalyzeFlood(req analysis.FloodRequest) (*analysis.FloodAnalysis, 
 	return res, nil
 }
 
+/*
+AnalyzeFloodRouting routes a flow over the AOI: depth, speed and arrival.
+
+DELIBERATELY NOT PERSISTED, unlike every analysis above it. This is a temporary
+module and a run of it is a parameter sweep -- volume, peak, roughness, cell
+size -- where the interesting object is the comparison between runs and not any
+one of them. Persisting each would fill the run store with sweep members before
+anyone has decided what a keepable run of this product even is. The result
+lives as long as the panel holds it; that is the whole contract for now, and it
+is why this returns no RunID while its neighbours do.
+*/
+func (a *App) AnalyzeFloodRouting(req analysis.FloodRoutingRequest) (*analysis.FloodRoutingAnalysis, error) {
+	runner := a.currentRunner()
+	if runner == nil {
+		return nil, errors.New("runner not initialized")
+	}
+	return runner.AnalyzeFloodRouting(a.ctx, req)
+}
+
 // floodProductIDs lists which DEM products the envelope was measured over, for
 // the run row. The envelope is a property of the set, so a range listed without
 // the set it spans is not attributable to anything.

--- a/frontend/node_modules
+++ b/frontend/node_modules
@@ -1,0 +1,1 @@
+/Users/fox/estudos/UTFPr/geosense/geosense-infer/frontend/node_modules

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2997,13 +2997,37 @@ function AppBody(props: {
       return
     }
     try {
-      const { kml } = await import("@tmcw/togeojson")
       const input = document.createElement("input")
       input.type = "file"
       input.accept = ".kml,.geojson,.json"
+      /*
+        THE INPUT IS PUT IN THE DOCUMENT BEFORE IT IS CLICKED.
+
+        It used to be a detached element, created and clicked without ever being
+        attached, which is the form every snippet for this uses and which this
+        webview ignores: WKWebView opens a file picker for an input that is in
+        the document and silently does nothing for one that is not. The button
+        looked dead and reported nothing. The avatar upload on the profile page
+        never had the problem because its input is rendered into the page and
+        clicked through a ref -- the same property, arrived at by writing it in
+        JSX rather than by knowing the rule.
+
+        Hidden rather than off-screen, and removed once the dialog has been
+        answered, so nothing is left behind on a cancel either.
+
+        THE PICKER IS ALSO OPENED BEFORE ANYTHING IS AWAITED.
+
+        togeojson used to be imported first, and a dynamic import is a promise:
+        after awaiting it the call below is no longer running inside the user
+        gesture that started it, and a WKWebView refuses a programmatic click on
+        a file input outside one. The dialog then never appeared and nothing
+        said why -- the button looked dead. The parser is only needed once a
+        file has been chosen, so it is loaded there instead.
+      */
       input.onchange = async () => {
         const file = input.files?.[0]
         if (!file) return
+        const { kml } = await import("@tmcw/togeojson")
         const text = await file.text()
         let geom: GeoJSONGeometry | null = null
         try {
@@ -3035,10 +3059,18 @@ function AppBody(props: {
           notifyError("No polygon found in the file.")
           return
         }
+        input.remove()
         const entry = await createArea(geom, file.name.replace(/\.[^.]+$/, ""))
         if (!entry) return
         notifySuccess(`Polygon saved as \u201c${entry.name}\u201d.`)
       }
+      input.style.display = "none"
+      document.body.appendChild(input)
+      const cleanup = () => input.remove()
+      // Covers the cancel, where onchange never fires. Not perfectly: a webview
+      // that reports no focus event would leave the node, which is why it is
+      // display:none and carries no listeners of its own.
+      window.addEventListener("focus", cleanup, { once: true })
       input.click()
     } catch (e) {
       notifyError("Import failed", e)

--- a/frontend/src/components/studio/BoardRunGraph.tsx
+++ b/frontend/src/components/studio/BoardRunGraph.tsx
@@ -61,6 +61,7 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react"
 import { DateField } from "@/components/ui/DateField"
 import { NumberField } from "@/components/ui/NumberField"
+import { Choice, Head } from "./nodeCard"
 import {
   MODEL_OPTIONS,
   MODE_OPTIONS,
@@ -190,80 +191,6 @@ function LayerSwitch({
     </button>
   )
 }
-
-function Choice({
-  label,
-  chosen,
-  disabled,
-  blockedBy,
-  onPick,
-}: {
-  label: string
-  chosen: boolean
-  disabled?: boolean
-  /**
-   * Why this one cannot be picked, if it cannot.
-   *
-   * Carried separately from `disabled`, which is the whole card going quiet
-   * while a run is on. A rule that refuses an option has something to say and
-   * a busy surface does not.
-   */
-  blockedBy?: string | null
-  onPick: () => void
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onPick}
-      disabled={disabled || !!blockedBy}
-      title={blockedBy ?? undefined}
-      className={cn(
-        "inline-flex h-[1.375rem] shrink-0 items-center rounded-sm px-1.5 text-meta transition-colors",
-        "focus-visible:outline-none focus-visible:inset-ring-1 focus-visible:inset-ring-ring",
-        disabled || blockedBy
-          ? "cursor-not-allowed text-muted-foreground/40"
-          : chosen
-            ? "bg-accent-dim text-foreground inset-ring-1 inset-ring-accent"
-            : "text-muted-foreground hover:bg-surface-raised hover:text-foreground"
-      )}
-    >
-      {label}
-    </button>
-  )
-}
-
-/**
- * The header of a card: its glyph and its name, in the band's own vocabulary.
- *
- * `lit` takes the glyph to the accent and leaves the name where it is. The
- * border of a card is at the edge of vision when the eye is on the value in
- * the middle of it, and the glyph is the part of the header that is already
- * being looked past -- so it is the cheapest place to put a second signal that
- * the card is carrying something.
- */
-function Head({
-  icon: Icon,
-  label,
-  lit,
-}: {
-  icon: Icon
-  label: string
-  lit?: boolean
-}) {
-  return (
-    <>
-      <Icon
-        className={cn(
-          "size-3 shrink-0",
-          lit ? "text-accent-quiet" : "text-muted-foreground"
-        )}
-        strokeWidth={2}
-      />
-      <span className="eyebrow !text-[9px] truncate">{label}</span>
-    </>
-  )
-}
-
 /**
  * What the run has said, while it is saying it.
  *

--- a/frontend/src/components/studio/BoardSurface.tsx
+++ b/frontend/src/components/studio/BoardSurface.tsx
@@ -270,6 +270,7 @@ import {
 } from "@/components/studio/LibraryLimitEditor"
 import { SpectraEditor } from "@/components/studio/SpectraEditor"
 import { SeparabilityEditor } from "@/components/studio/SeparabilityEditor"
+import { FloodRoutingPanel } from "./FloodRoutingPanel"
 import { StudioTables } from "@/components/studio/StudioTables"
 import { StudioLoading } from "@/components/studio/StudioLoading"
 import {
@@ -440,6 +441,7 @@ function isSoloed(
 
 export function BoardSurface({
   layers,
+  onImportPolygon,
   retainedRuns = [],
   onDropRetainedRun,
   legendSources,
@@ -490,6 +492,8 @@ export function BoardSurface({
   reveal = null,
   onRevealed,
 }: {
+  /** Put a shape from a file on the map as the active AOI. */
+  onImportPolygon: () => void
   /**
    * Every layer the run could draw, drawn or not.
    *
@@ -1979,6 +1983,17 @@ export function BoardSurface({
     whose two ids differ would otherwise slip through as a plane that nothing
     could find again.
   */
+  /*
+    The routed flood's overlay, held here because the board owns the stack.
+
+    Not an `added` asset and not a run: routing is not persisted, so there is
+    no RunAsset to read and nothing for `extrasFor` to find. It sits above the
+    extras for the reason those sit above the map's own -- it was asked for, and
+    burying it under the stack it joined would be a strange reading of the
+    request.
+  */
+  const [routingLayer, setRoutingLayer] = useState<RasterLayer | null>(null)
+
   const extrasFor = (areaId: string, startOrder: number): RasterLayer[] =>
     (added[areaId] ?? [])
       .map((sid) => assetOf(areaId, sid))
@@ -2123,6 +2138,7 @@ export function BoardSurface({
       layers: applyOrder(live, [
         ...layers.filter((l) => !removed.has(sceneKey(live, l.id))),
         ...extrasFor(live, 1000),
+        ...(routingLayer ? [routingLayer] : []),
       ]),
     },
     /*
@@ -4447,6 +4463,70 @@ export function BoardSurface({
       band is for the classification products.
     */
     canopyParams: <CanopyRunBar />,
+    /*
+      THE LIVE AREA, NOT THIS PANE'S.
+
+      The first version matched areaInfo against `areaId`, which reads as the
+      obvious thing and is wrong: the id renderEditor is given is the LAYOUT
+      LEAF's -- "a-routing", the rectangle -- while areaInfo is keyed by the
+      board's data areas. The find never matched, so a freshly drawn AOI showed
+      as no area at all no matter what was on the map.
+
+      A pane does not own an area here. The ones that read per-pane state hold
+      a pin for it, the way comparePins does for the comparison editor; until
+      routing has one of those, the ground it routes over is the ground the map
+      is on. `current` is that area, and it is also the one a reader has just
+      finished drawing, which is when they reach for this panel.
+    */
+    floodRouting: (
+      <FloodRoutingPanel
+        /*
+          THE ACTIVE AOI, from the map's own shape first.
+
+          `areaInfo` was the obvious source and is the wrong one. It is built
+          from the LIVE area plus the retained runs, and the live area follows
+          the SHOWN RUN -- so a shape just drawn or just imported, while a
+          result is on the board, is not in that list at all and the panel read
+          "nothing drawn" with an AOI plainly on the map.
+
+          `customPolygon` is what the globe is drawing and what createArea sets
+          on import, so it answers for both gestures. The area entry is still
+          consulted, for its name and for the case where the board opened on a
+          catalogued area without the map holding a shape.
+        */
+        geometry={
+          customPolygon ??
+          areaInfo.find((a) => a.current)?.geometry ??
+          catalogAreas.find((a) => a.id === activeAreaId)?.geometry ??
+          null
+        }
+        areaLabel={
+          catalogAreas.find((a) => a.id === activeAreaId)?.name ??
+          areaInfo.find((a) => a.current)?.title
+        }
+        onImport={onImportPolygon}
+        onResult={(res) =>
+          setRoutingLayer(
+            res?.depth_uri
+              ? {
+                  id: "flood-routing",
+                  title: `Routed depth, to ${res.depth_png_max_m.toFixed(1)} m`,
+                  uri: res.depth_uri,
+                  extent: res.extent,
+                  opacity: 1,
+                  order: 1100,
+                  // A depth field is continuous, so interpolating it is not a
+                  // claim about where a boundary is -- unlike a class raster,
+                  // which is why that one is pixelated and this is not.
+                  pixelated: false,
+                  smooth: false,
+                  visible: true,
+                }
+              : null
+          )
+        }
+      />
+    ),
     /*
       No longer `sides ? ... : null`. An editor that renders nothing at all
       when it cannot answer is indistinguishable from one that is broken, and

--- a/frontend/src/components/studio/FloodRoutingPanel.tsx
+++ b/frontend/src/components/studio/FloodRoutingPanel.tsx
@@ -1,0 +1,368 @@
+/**
+ * Overland routing over the area on the board, stated as a graph.
+ *
+ * A temporary module. It routes water across the AOI's terrain and reports
+ * what the flow leaves behind, which is a different question from the flood
+ * envelope: that one is static and measures how much of a HAND extent follows
+ * from the choice of DEM, this one moves water over a single DEM.
+ *
+ * THE SHAPE IS THE REQUEST'S, as it is for every other run on this canvas. The
+ * area, the rain and how it is routed are three inputs to one run; none
+ * consumes another, so they fan in rather than chain.
+ *
+ * A second mode routed a breach hydrograph and is gone. Not for want of
+ * hydraulics -- the equations are the same either way -- but because nothing
+ * could reliably decide WHERE a channel enters a drawn polygon, and a breach
+ * whose inlet lands on the outlet reports arithmetic rather than flood. It
+ * returns when the inlet is a point the reader places. Rain needs no point,
+ * which is why it is what remains.
+ *
+ * WHY THE CONTROLS ARE HERE AND NOT ON A RUN BAND. A run of this is a member
+ * of a parameter sweep, where the object of interest is the comparison and not
+ * any single run. A band along the foot carries the parameters of THE run, one
+ * set for the whole board; the panel holds its own instead.
+ *
+ * WHAT IT ROUTES OVER IS THE LIVE AREA. Two of these panels open on two panes
+ * currently answer about the same ground: a pane owns no area of its own until
+ * it holds a pin for one, as the comparison editor does. Their parameters are
+ * already separate, so the missing half is the pin and not the state.
+ *
+ * WHAT IS NOT SHOWN, AND WHY. There is no accuracy figure. Nothing here has
+ * been compared against an observed flood and a number in that shape would be
+ * read as one. What the result card shows instead are the two things that say
+ * whether the run is self-consistent at all: the lake-at-rest residual, which
+ * is the scheme's well-balancing check run on this terrain before any flow,
+ * and the share of water that reached a boundary and left. A run that stores
+ * everything it was given never found an outlet, and its depths are a filling
+ * level rather than a routed wave -- said in words when it happens.
+ */
+import { useCallback, useMemo, useState } from "react"
+import {
+  CloudRain,
+  Gauge,
+  Pentagon,
+  Play,
+  Upload,
+  type Icon as PhosphorIcon,
+} from "@phosphor-icons/react"
+
+import { AnalyzeFloodRouting } from "../../../wailsjs/go/main/App"
+import type { analysis } from "../../../wailsjs/go/models"
+import { NumberField } from "@/components/ui/NumberField"
+import { cn } from "@/lib/utils"
+import { NodeCanvas, type CanvasNode } from "./NodeCanvas"
+import { Head } from "./nodeCard"
+import { COL_GAP, NODE_W, ROW_GAP, type Place } from "./runGraph"
+
+type Geometry = { type: string; coordinates: unknown } | null
+
+/*
+  Placed here rather than through runGraph's SPEC table. That table is the
+  shape of a CLASSIFICATION, composition or solar request and its node ids are
+  a closed union; adding routing's cards to it would widen a type four other
+  surfaces read, to describe a graph none of them can draw. The geometry
+  constants are shared, which is what keeps the columns and the wire curves
+  identical to the run graph's.
+*/
+const NODE: Record<string, { label: string; icon: PhosphorIcon; h: number; col: number }> = {
+  area: { label: "Area", icon: Pentagon, h: 74, col: 0 },
+  rain: { label: "Rain", icon: CloudRain, h: 150, col: 0 },
+  routing: { label: "Routing", icon: Gauge, h: 200, col: 1 },
+  run: { label: "Route", icon: Play, h: 96, col: 2 },
+}
+
+function columnX(id: string): number {
+  return NODE[id].col * (NODE_W + COL_GAP)
+}
+
+function Row({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-baseline justify-between gap-2 text-meta">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="telemetry text-foreground">{value}</span>
+    </div>
+  )
+}
+
+/** Median, 90th and max on one line, or a word where nothing wetted. */
+function Spread({
+  label,
+  spread,
+  unit,
+  digits = 1,
+}: {
+  label: string
+  spread?: analysis.FloodRoutingSpread
+  unit: string
+  digits?: number
+}) {
+  const has = spread?.median !== undefined && spread?.median !== null
+  const fmt = (v: number | undefined | null) =>
+    v === undefined || v === null ? "--" : v.toFixed(digits)
+  return (
+    <Row
+      label={label}
+      value={
+        has ? (
+          <>
+            {fmt(spread?.median)}
+            <span className="text-muted-foreground">
+              {" "}
+              {fmt(spread?.p90)} {fmt(spread?.max)} {unit}
+            </span>
+          </>
+        ) : (
+          <span className="text-muted-foreground">not reached</span>
+        )
+      }
+    />
+  )
+}
+
+const num = (min: number) => (t: string) => {
+  const n = Number.parseFloat(t)
+  return Number.isFinite(n) && n >= min ? n : null
+}
+
+export function FloodRoutingPanel({
+  geometry,
+  areaLabel,
+  onResult,
+  onImport,
+}: {
+  geometry: Geometry
+  areaLabel?: string
+  /**
+   * The routed depths, for the board to put on the map.
+   *
+   * The panel does not own map layers and should not: every other overlay on
+   * this board is placed by the surface that owns the stack, and a second
+   * placement path is how two surfaces come to disagree about what is drawn.
+   * It hands the result up and the board decides.
+   *
+   * Called with null when a run starts, so the previous run's overlay does not
+   * sit under a set of controls that no longer produced it.
+   */
+  onResult?: (result: analysis.FloodRoutingAnalysis | null) => void
+  /**
+   * Put a shape from a file on the map as the active AOI.
+   *
+   * The same handler the run graph's own area card offers, reached from here
+   * because this panel is often the first surface a reader opens: a board with
+   * nothing drawn shows "nothing drawn" and no way forward, and sending them
+   * to another editor to import is a step the card can take itself.
+   */
+  onImport?: () => void
+}) {
+  const [rainMMH, setRainMMH] = useState(60)
+  const [rainMinutes, setRainMinutes] = useState(30)
+  const [minutes, setMinutes] = useState(60)
+  const [manning, setManning] = useState(0.05)
+  const [resolutionM, setResolutionM] = useState(90)
+
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [result, setResult] = useState<analysis.FloodRoutingAnalysis | null>(null)
+  const [places, setPlaces] = useState<Record<string, Place>>({})
+
+  const run = useCallback(async () => {
+    if (!geometry) return
+    setBusy(true)
+    setError(null)
+    onResult?.(null)
+    try {
+      const req = {
+        polygon_geojson: geometry,
+        minutes,
+        manning,
+        resolution_m: resolutionM,
+        rain_mm_h: rainMMH,
+        rain_minutes: rainMinutes,
+      }
+      // The binding is generated against the Go request type, whose fields are
+      // pointers so absence selects the sidecar's default. An object carrying
+      // only what this panel sets is what that expects.
+      const res = await AnalyzeFloodRouting(req as never)
+      setResult(res)
+      onResult?.(res)
+    } catch (e) {
+      // The sidecar refuses by name -- a headwater AOI with no inflow, an area
+      // too large for the cell size it was given -- and those messages say what
+      // to change. Passing them through unedited is the point.
+      setError(e instanceof Error ? e.message : String(e))
+      setResult(null)
+      onResult?.(null)
+    } finally {
+      setBusy(false)
+    }
+  }, [geometry, minutes, manning, resolutionM, rainMMH, rainMinutes, onResult])
+
+  const nodes: CanvasNode[] = useMemo(() => {
+    const ids = ["area", "rain", "routing", "run"]
+    // Default placement: two stacked in the first column, two in the second,
+    // the run alone in the third. Measured off NODE spec heights so a first
+    // draw needs no measuring, exactly as runGraph's defaultPlaces does.
+    const stackY: Record<string, number> = {
+      area: 0,
+      rain: NODE.area.h + ROW_GAP,
+      routing: 0,
+      run: 0,
+    }
+    const card = (id: string, header: React.ReactNode, body: React.ReactNode,
+                  tone?: "action" | "held"): CanvasNode => ({
+      id,
+      place: places[id] ?? { x: columnX(id), y: stackY[id] },
+      h: NODE[id].h,
+      header,
+      children: body,
+      tone,
+    })
+
+    return [
+      card(
+        "area",
+        <Head icon={NODE.area.icon} label={NODE.area.label} lit={!!geometry} />,
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-meta text-foreground">
+            {geometry ? (areaLabel ?? "this area") : (
+              <span className="text-muted-foreground">nothing drawn</span>
+            )}
+          </span>
+          {onImport && (
+            <button
+              type="button"
+              onClick={onImport}
+              disabled={busy}
+              title="Import an area from a .geojson, .json or .kml file"
+              className={cn(
+                "inline-flex size-5 shrink-0 items-center justify-center rounded-sm transition-colors",
+                "focus-visible:outline-none focus-visible:inset-ring-1 focus-visible:inset-ring-ring",
+                busy
+                  ? "cursor-not-allowed text-muted-foreground/40"
+                  : "text-muted-foreground hover:bg-surface-raised hover:text-foreground"
+              )}
+            >
+              <Upload className="size-3" />
+            </button>
+          )}
+        </div>
+      ),
+      card(
+        "rain",
+        <Head icon={NODE.rain.icon} label={NODE.rain.label} lit />,
+        <div className="flex flex-col gap-1.5">
+          <NumberField label="Rate" value={rainMMH} min={1} max={500} step={5}
+            format={(v) => `${v.toFixed(0)} mm/h`} parse={num(1)}
+            disabled={busy} onChange={setRainMMH} />
+          <NumberField label="Falls for" value={rainMinutes} min={1} max={720} step={5}
+            format={(v) => `${v.toFixed(0)} min`} parse={num(1)}
+            disabled={busy} onChange={setRainMinutes} />
+          <p className="text-[9px] leading-snug text-muted-foreground">
+            Uniform on every cell, with the terrain organising where it goes.
+            Nothing infiltrates, so the depths are an upper bound.
+          </p>
+        </div>
+      ),
+      card(
+        "routing",
+        <Head icon={NODE.routing.icon} label={NODE.routing.label} lit />,
+        <div className="flex flex-col gap-1.5">
+          <NumberField label="Simulated" value={minutes} min={5} max={720} step={5}
+            format={(v) => `${v.toFixed(0)} min`} parse={num(5)}
+            disabled={busy} onChange={setMinutes} />
+          <NumberField label="Cell" value={resolutionM} min={30} max={500} step={10}
+            format={(v) => `${v.toFixed(0)} m`} parse={num(30)}
+            disabled={busy} onChange={setResolutionM} />
+          <NumberField label="Manning n" value={manning} min={0.01} max={0.2} step={0.005}
+            format={(v) => v.toFixed(3)} parse={num(0.01)}
+            disabled={busy} onChange={setManning} />
+          <p className="text-[9px] leading-snug text-muted-foreground">
+            Cost is cells times timesteps, so a finer cell is quadratically
+            slower. n is one lumped value for sediment and bed together.
+          </p>
+        </div>
+      ),
+      card(
+        "run",
+        <Head icon={NODE.run.icon} label={result ? "Routed" : "Route"} lit={!busy} />,
+        <div className="flex flex-col gap-1.5">
+          <button
+            type="button"
+            onClick={run}
+            disabled={!geometry || busy}
+            className={cn(
+              "inline-flex h-7 w-full items-center justify-center gap-1.5 rounded-sm text-meta transition-colors",
+              "focus-visible:outline-none focus-visible:inset-ring-1 focus-visible:inset-ring-ring",
+              !geometry || busy
+                ? "cursor-not-allowed bg-surface-raised text-muted-foreground/50"
+                : "bg-accent text-accent-foreground hover:bg-accent/90"
+            )}
+          >
+            <Play className="size-3" />
+            {busy ? "Routing…" : geometry ? "Route" : "No area"}
+          </button>
+          {error && (
+            <p className="text-[9px] leading-snug text-destructive-quiet">{error}</p>
+          )}
+          {result && (
+            <div className="flex flex-col gap-0.5 pt-0.5">
+              <Row label="Flooded"
+                   value={`${result.aoi.flooded_km2.toFixed(2)} km²`} />
+              <Spread label="Depth" spread={result.depth_m} unit="m" />
+              <Spread label="Speed" spread={result.speed_ms} unit="m/s" />
+              <Spread label="Arrival" spread={result.arrival_min} unit="min" digits={0} />
+              <Row label="Left"
+                   value={`${(result.volume.left_fraction * 100).toFixed(0)}%`} />
+              <Row label="On edge"
+                   value={`${(result.aoi.on_boundary_fraction * 100).toFixed(0)}%`} />
+              <Row label="At rest"
+                   value={result.lake_at_rest_residual_ms.toExponential(0)} />
+              <p className="text-[9px] leading-snug text-muted-foreground">
+                median 90th max, over the cells inside the polygon. Terrain{" "}
+                {result.dem_id} at {result.resolution_m.toFixed(0)} m.
+              </p>
+              {result.aoi.on_boundary_fraction > 0.5 && (
+                <p className="text-[9px] leading-snug text-foreground">
+                  Most of the flow is on the boundary, so this area clips the
+                  valley rather than holding it. The routing followed the real
+                  channel; what is reported is the fragment that fell inside the
+                  drawing. Redraw around the reach to read a flood.
+                </p>
+              )}
+              {result.volume.left_fraction < 0.1 && (
+                <p className="text-[9px] leading-snug text-foreground">
+                  Almost nothing reached a boundary, so these depths are a
+                  filling level and not a routed wave. The outlet is likely
+                  outside the polygon.
+                </p>
+              )}
+            </div>
+          )}
+        </div>,
+        "action"
+      ),
+    ].filter((n) => ids.includes(n.id))
+  }, [
+    places, geometry, areaLabel, busy, error, result, run, onImport,
+    rainMMH, rainMinutes, minutes, manning, resolutionM,
+  ])
+
+  const edges = useMemo(
+    () =>
+      [
+        ["area", "run"],
+        ["rain", "run"],
+        ["routing", "run"],
+      ] as const,
+    []
+  )
+
+  return (
+    <NodeCanvas
+      nodes={nodes}
+      edges={edges}
+      onMove={(id, place) => setPlaces((p) => ({ ...p, [id]: place }))}
+      className="h-full w-full"
+    />
+  )
+}

--- a/frontend/src/components/studio/nodeCard.tsx
+++ b/frontend/src/components/studio/nodeCard.tsx
@@ -1,0 +1,88 @@
+/**
+ * The two pieces every card on a node canvas is built from.
+ *
+ * Lifted out of `BoardRunGraph` when a second surface needed them. They were
+ * private to that file and copying them would have put the card idiom in two
+ * places: the same argument `lib/studioEditors.ts` makes for naming the editors
+ * once, and `lib/mapTools.ts` for its own table. A header that exists twice is
+ * a header that can disagree with itself.
+ *
+ * Nothing about runs is in here, as nothing about runs is in `NodeCanvas`. A
+ * caller supplies what the card says.
+ */
+import type { Icon as PhosphorIcon } from "@phosphor-icons/react"
+
+import { cn } from "@/lib/utils"
+
+/**
+ * A card's header row: the glyph and its label.
+ *
+ * `lit` takes the glyph to the accent and leaves the name where it is. The
+ * border of a card is at the edge of vision when the eye is on the value in
+ * the middle of it, and the glyph is the part of the header that is already
+ * being looked past -- so it is the cheapest place to put a second signal that
+ * the card is carrying something.
+ */
+export function Head({
+  icon: Icon,
+  label,
+  lit,
+}: {
+  icon: PhosphorIcon
+  label: string
+  lit?: boolean
+}) {
+  return (
+    <>
+      <Icon
+        className={cn(
+          "size-3 shrink-0",
+          lit ? "text-accent-quiet" : "text-muted-foreground"
+        )}
+      />
+      <span className="eyebrow !text-[9px] truncate">{label}</span>
+    </>
+  )
+}
+
+/** One option in a card, chosen or not. */
+export function Choice({
+  label,
+  chosen,
+  disabled,
+  blockedBy,
+  onPick,
+}: {
+  label: string
+  chosen: boolean
+  disabled?: boolean
+  /**
+   * Why this one cannot be picked, if it cannot.
+   *
+   * Carried separately from `disabled`, which is the whole card going quiet
+   * while a run is on. A rule that refuses an option has something to say and
+   * a busy surface does not.
+   */
+  blockedBy?: string | null
+  onPick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onPick}
+      disabled={disabled || !!blockedBy}
+      title={blockedBy ?? undefined}
+      className={cn(
+        "inline-flex h-[1.375rem] shrink-0 items-center rounded-sm px-1.5 text-meta transition-colors",
+        "focus-visible:outline-none focus-visible:inset-ring-1 focus-visible:inset-ring-ring",
+        disabled || blockedBy
+          ? "cursor-not-allowed text-muted-foreground/40"
+          : chosen
+            ? "bg-accent-dim text-foreground inset-ring-1 inset-ring-accent"
+            : "text-muted-foreground hover:bg-surface-raised hover:text-foreground"
+      )}
+    >
+      {label}
+    </button>
+  )
+}

--- a/frontend/src/lib/studioEditors.ts
+++ b/frontend/src/lib/studioEditors.ts
@@ -23,6 +23,7 @@ import {
   ChartLine,
   Crosshair,
   Cube,
+  Drop,
   Fan,
   FlowArrow,
   GitDiff,
@@ -52,6 +53,7 @@ export type EditorId =
   | "runParams"
   | "canopy"
   | "canopyParams"
+  | "floodRouting"
   | "globe"
   | "solarReading"
   | "windReading"
@@ -288,6 +290,27 @@ export const STUDIO_EDITORS: readonly StudioEditorMeta[] = [
     // described the voxel view this editor replaced. A hint that outlives the
     // thing it describes sends a reader to the wrong area.
     hint: "A stand: specified and drawn, or the one an AOI's season implies",
+  },
+  {
+    id: "floodRouting",
+    label: "Routing",
+    // Droplets and not Waves. Waves is already the domain-shift editor's, and
+    // an icon that means two things in one list is a label that disagrees with
+    // itself -- the same argument this file makes for naming the editors once.
+    icon: Drop,
+    minRem: 13,
+    minRowRem: 14,
+    /*
+      Not unique. Two of these on one board is the point: a sweep is read by
+      comparison, and the panel holds its own parameters precisely so that two
+      areas can carry two floods rather than sharing one set of controls.
+
+      The row floor is the tallest of the panels here because the result is
+      three spreads, a self-consistency block and the assumptions under them.
+      Below about 14rem the assumptions are the part that scrolls away, and
+      they are the part that says what the depths are not.
+    */
+    hint: "Water routed over the terrain: depth, speed and when it arrives",
   },
   {
     id: "globe",

--- a/frontend/src/lib/studioWorkspaces.ts
+++ b/frontend/src/lib/studioWorkspaces.ts
@@ -23,7 +23,7 @@
  * 1000x700, so no preset is born with an area under its editor's own floor.
  */
 import type { Icon } from "@phosphor-icons/react"
-import { Cube, Database, GitDiff, Table, Tree, Waves } from "@phosphor-icons/react"
+import { Cube, Database, Drop, GitDiff, Table, Tree, Waves } from "@phosphor-icons/react"
 
 import type { AreaNode } from "@/lib/boardAreas"
 import type { EditorId } from "@/lib/studioEditors"
@@ -195,6 +195,53 @@ export const STUDIO_WORKSPACES: readonly StudioWorkspace[] = [
           leaf("a-outliner", "outliner")
         ),
         col("w-data-right", 0.55, leaf("a-table", "table"), leaf("a-browser", "browser"))
+      ),
+  },
+  {
+    id: "routing",
+    // Diagnose already carries Waves in this bar.
+    icon: Drop,
+    label: "Routing",
+    hint: "Water routed over the area's terrain, and the ground it reaches",
+    /*
+      A board of its own rather than a type swapped into Simulation.
+
+      Simulation is the canopy's arrangement and its fractions are argued from
+      the canopy's needs: the stand takes the width because where light falls
+      between crowns is not readable in a column. A routed flood wants the
+      opposite proportion -- the map wide, because the answer IS where the
+      water went, and the parameters in a column beside it because a run is a
+      member of a sweep and the controls are turned far more often than they
+      are read.
+
+      The panel was reachable before this preset existed, by retyping an area,
+      and that was not the same thing: a product nobody can find without
+      already knowing it is there has not been added to the studio, only to the
+      type selector.
+
+      THE VIEWPORT IS HERE AND IS NOT IN SIMULATION. The canopy preset leaves
+      it out on the argument that a stack of rasters and a shaded orchard are
+      two answers to two questions and sitting them side by side invites
+      reading one as an overlay of the other. Routing has the opposite
+      relation: the depth raster IS an overlay of the ground it was computed
+      on, and the map is where it belongs.
+
+      Fractions at the 1000x700 minimum, after the 28px workspace bar, the 22px
+      status bar and each area's 26px header: the viewport is 660x420 against
+      its 192x128 floor, the outliner 660x186 against 176x128, and the routing
+      column 340x624 against the 208x224 this editor asks for.
+    */
+    build: () =>
+      row(
+        "w-route-split",
+        0.66,
+        col(
+          "w-route-left",
+          0.68,
+          leaf("a-viewport", "viewport"),
+          leaf("a-outliner", "outliner")
+        ),
+        leaf("a-routing", "floodRouting")
       ),
   },
   {

--- a/frontend/src/pages/StudioScreen.tsx
+++ b/frontend/src/pages/StudioScreen.tsx
@@ -1258,6 +1258,9 @@ export function StudioScreen(props: StudioScreenProps) {
         }
       >
         <BoardSurface
+          // The same handler the run graph's area card uses, so importing a
+          // shape means one thing wherever it is offered.
+          onImportPolygon={props.onImportPolygon}
           /*
               REMOUNTED WHEN A BOARD IS OPENED, which is what makes opening
               one from inside the studio work at all.

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -14,13 +14,13 @@ export function AnalyzeEnergyModel(arg1:analysis.EnergyModelRequest):Promise<ana
 
 export function AnalyzeFlood(arg1:analysis.FloodRequest):Promise<analysis.FloodAnalysis>;
 
+export function AnalyzeFloodRouting(arg1:analysis.FloodRoutingRequest):Promise<analysis.FloodRoutingAnalysis>;
+
 export function AnalyzeGridCongestion(arg1:analysis.GridCongestionRequest):Promise<analysis.GridCongestionAnalysis>;
 
 export function AnalyzeGridCurtailment(arg1:analysis.GridCurtailmentRequest):Promise<analysis.GridCurtailmentAnalysis>;
 
 export function AnalyzeGridFigure(arg1:analysis.GridFigureRequest):Promise<analysis.GridFigureAnalysis>;
-
-export function AnalyzeFloodRouting(arg1:analysis.FloodRoutingRequest):Promise<analysis.FloodRoutingAnalysis>;
 
 export function AnalyzeLULC(arg1:analysis.LULCRequest):Promise<analysis.LULCAnalysis>;
 

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -20,6 +20,8 @@ export function AnalyzeGridCurtailment(arg1:analysis.GridCurtailmentRequest):Pro
 
 export function AnalyzeGridFigure(arg1:analysis.GridFigureRequest):Promise<analysis.GridFigureAnalysis>;
 
+export function AnalyzeFloodRouting(arg1:analysis.FloodRoutingRequest):Promise<analysis.FloodRoutingAnalysis>;
+
 export function AnalyzeLULC(arg1:analysis.LULCRequest):Promise<analysis.LULCAnalysis>;
 
 export function AnalyzeSolar(arg1:analysis.SolarRequest):Promise<analysis.SolarAnalysis>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -28,6 +28,9 @@ export function AnalyzeGridCurtailment(arg1) {
 
 export function AnalyzeGridFigure(arg1) {
   return window['go']['main']['App']['AnalyzeGridFigure'](arg1);
+
+export function AnalyzeFloodRouting(arg1) {
+  return window['go']['main']['App']['AnalyzeFloodRouting'](arg1);
 }
 
 export function AnalyzeLULC(arg1) {

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -18,6 +18,10 @@ export function AnalyzeFlood(arg1) {
   return window['go']['main']['App']['AnalyzeFlood'](arg1);
 }
 
+export function AnalyzeFloodRouting(arg1) {
+  return window['go']['main']['App']['AnalyzeFloodRouting'](arg1);
+}
+
 export function AnalyzeGridCongestion(arg1) {
   return window['go']['main']['App']['AnalyzeGridCongestion'](arg1);
 }
@@ -28,9 +32,6 @@ export function AnalyzeGridCurtailment(arg1) {
 
 export function AnalyzeGridFigure(arg1) {
   return window['go']['main']['App']['AnalyzeGridFigure'](arg1);
-
-export function AnalyzeFloodRouting(arg1) {
-  return window['go']['main']['App']['AnalyzeFloodRouting'](arg1);
 }
 
 export function AnalyzeLULC(arg1) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -3618,6 +3618,212 @@ export namespace analysis {
 		    return a;
 		}
 	}
+	export class FloodRoutingAOI {
+	    cells: number;
+	    area_km2: number;
+	    flooded_cells: number;
+	    flooded_km2: number;
+	    flooded_fraction: number;
+	    on_boundary_fraction: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new FloodRoutingAOI(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.cells = source["cells"];
+	        this.area_km2 = source["area_km2"];
+	        this.flooded_cells = source["flooded_cells"];
+	        this.flooded_km2 = source["flooded_km2"];
+	        this.flooded_fraction = source["flooded_fraction"];
+	        this.on_boundary_fraction = source["on_boundary_fraction"];
+	    }
+	}
+	export class FloodRoutingRain {
+	    mm_h: number;
+	    minutes: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new FloodRoutingRain(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.mm_h = source["mm_h"];
+	        this.minutes = source["minutes"];
+	    }
+	}
+	export class FloodRoutingVolume {
+	    in_m3: number;
+	    stored_m3: number;
+	    out_m3: number;
+	    clipped_m3: number;
+	    left_fraction: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new FloodRoutingVolume(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.in_m3 = source["in_m3"];
+	        this.stored_m3 = source["stored_m3"];
+	        this.out_m3 = source["out_m3"];
+	        this.clipped_m3 = source["clipped_m3"];
+	        this.left_fraction = source["left_fraction"];
+	    }
+	}
+	export class FloodRoutingSpread {
+	    median?: number;
+	    p90?: number;
+	    max?: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new FloodRoutingSpread(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.median = source["median"];
+	        this.p90 = source["p90"];
+	        this.max = source["max"];
+	    }
+	}
+	export class FloodRoutingCellSize {
+	    x: number;
+	    y: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new FloodRoutingCellSize(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.x = source["x"];
+	        this.y = source["y"];
+	    }
+	}
+	export class FloodRoutingAnalysis {
+	    dem_id: string;
+	    minutes: number;
+	    manning: number;
+	    steps: number;
+	    void_cells_filled: number;
+	    lake_at_rest_residual_ms: number;
+	    resolution_m: number;
+	    coarsened_from_m?: number;
+	    grid: FloodGrid;
+	    cell_size_m: FloodRoutingCellSize;
+	    aoi: FloodRoutingAOI;
+	    depth_m: FloodRoutingSpread;
+	    speed_ms: FloodRoutingSpread;
+	    arrival_min: FloodRoutingSpread;
+	    volume: FloodRoutingVolume;
+	    rain: FloodRoutingRain;
+	    assumptions: Record<string, string>;
+	    depth_tif: string;
+	    depth_png: string;
+	    depth_uri?: string;
+	    depth_png_max_m: number;
+	    extent: Bounds;
+	
+	    static createFrom(source: any = {}) {
+	        return new FloodRoutingAnalysis(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.dem_id = source["dem_id"];
+	        this.minutes = source["minutes"];
+	        this.manning = source["manning"];
+	        this.steps = source["steps"];
+	        this.void_cells_filled = source["void_cells_filled"];
+	        this.lake_at_rest_residual_ms = source["lake_at_rest_residual_ms"];
+	        this.resolution_m = source["resolution_m"];
+	        this.coarsened_from_m = source["coarsened_from_m"];
+	        this.grid = this.convertValues(source["grid"], FloodGrid);
+	        this.cell_size_m = this.convertValues(source["cell_size_m"], FloodRoutingCellSize);
+	        this.aoi = this.convertValues(source["aoi"], FloodRoutingAOI);
+	        this.depth_m = this.convertValues(source["depth_m"], FloodRoutingSpread);
+	        this.speed_ms = this.convertValues(source["speed_ms"], FloodRoutingSpread);
+	        this.arrival_min = this.convertValues(source["arrival_min"], FloodRoutingSpread);
+	        this.volume = this.convertValues(source["volume"], FloodRoutingVolume);
+	        this.rain = this.convertValues(source["rain"], FloodRoutingRain);
+	        this.assumptions = source["assumptions"];
+	        this.depth_tif = source["depth_tif"];
+	        this.depth_png = source["depth_png"];
+	        this.depth_uri = source["depth_uri"];
+	        this.depth_png_max_m = source["depth_png_max_m"];
+	        this.extent = this.convertValues(source["extent"], Bounds);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	
+	
+	export class FloodRoutingRequest {
+	    polygon_geojson?: GeoJSONGeometry;
+	    dem_id?: string;
+	    resolution_m?: number;
+	    buffer_m?: number;
+	    minutes?: number;
+	    manning?: number;
+	    rain_mm_h?: number;
+	    rain_minutes?: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new FloodRoutingRequest(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.polygon_geojson = this.convertValues(source["polygon_geojson"], GeoJSONGeometry);
+	        this.dem_id = source["dem_id"];
+	        this.resolution_m = source["resolution_m"];
+	        this.buffer_m = source["buffer_m"];
+	        this.minutes = source["minutes"];
+	        this.manning = source["manning"];
+	        this.rain_mm_h = source["rain_mm_h"];
+	        this.rain_minutes = source["rain_minutes"];
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	
+	
 	
 	export class GridAttachment {
 	    id_ons: string;

--- a/internal/analysis/flood_routing_test.go
+++ b/internal/analysis/flood_routing_test.go
@@ -1,0 +1,103 @@
+package analysis
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+/*
+TestFloodRoutingPayloadParses reads a RECORDED sidecar payload into the struct.
+
+It exists because the first version of this contract did not. Extent was typed
+[]float64 from reading the sidecar's code rather than its output, and
+composite.extent_from_profile returns an object; the Go build was clean, the
+sidecar ran, and the failure arrived in the application as "cannot unmarshal
+object into Go struct field ... extent of type []float64". types_flood.go says
+of its own fields that each was read off a recorded payload rather than
+predicted from the contract text -- this is that recording, for this product.
+
+The Go/TypeScript contract check does not cover this: it compares structs
+against same-named TypeScript interfaces, and FloodRoutingAnalysis has none, so
+it sits in the unguarded set that check reports only as a count.
+*/
+func TestFloodRoutingPayloadParses(t *testing.T) {
+	raw, err := os.ReadFile("testdata/flood_routing.json")
+	if err != nil {
+		t.Fatalf("reading the recorded payload: %v", err)
+	}
+
+	var wrapped struct {
+		Routing *FloodRoutingAnalysis `json:"flood_routing"`
+	}
+	// DisallowUnknownFields is deliberately NOT set. The sidecar may add a key
+	// before Go learns to read it, and that is not a failure of this contract;
+	// what this guards is a field the struct DOES claim being the wrong shape.
+	if err := json.Unmarshal(raw, &wrapped); err != nil {
+		t.Fatalf("the recorded payload does not fit the struct: %v", err)
+	}
+	got := wrapped.Routing
+	if got == nil {
+		t.Fatal("the payload parsed but carried no flood_routing object")
+	}
+
+	// The fields the panel reads, checked against the recording rather than
+	// against expectations: a zero here means the JSON tag does not match.
+	if got.DEMID == "" {
+		t.Error("dem_id is empty, so the tag does not match the payload")
+	}
+	if got.Grid.Width == 0 || got.Grid.Height == 0 {
+		t.Errorf("grid did not parse: %+v", got.Grid)
+	}
+	if got.AOI.AreaKm2 == 0 {
+		t.Error("aoi.area_km2 is zero")
+	}
+	// Zero is a legitimate value for a channel wholly inside the AOI, so what
+	// is checked is that the key exists and stays a fraction rather than that
+	// it is non-zero.
+	if got.AOI.OnBoundaryFraction < 0 || got.AOI.OnBoundaryFraction > 1 {
+		t.Errorf("aoi.on_boundary_fraction is not a fraction: %v",
+			got.AOI.OnBoundaryFraction)
+	}
+	if got.DepthM.Median == nil {
+		t.Error("depth_m.median is nil on a run that flooded")
+	}
+	if got.Volume.InM3 == 0 {
+		t.Error("volume.in_m3 is zero")
+	}
+	// The balance the sidecar measures, checked here on the recorded run:
+	// in + clip = stored + out. It is
+	// asserted in Go as well as in Python because these are the five numbers
+	// the panel puts on screen, and a tag that stops matching would show them
+	// all as zero and still close.
+	residual := got.Volume.InM3 + got.Volume.ClippedM3 -
+		got.Volume.StoredM3 - got.Volume.OutM3
+	if residual > 1 || residual < -1 {
+		t.Errorf("the recorded balance does not close: %.3f m3 unaccounted", residual)
+	}
+	if got.Rain.MMH == 0 {
+		t.Error("rain.mm_h is zero")
+	}
+	// The field that failed. An object, four named bounds, never a list.
+	if got.Extent.LonMin == 0 || got.Extent.LatMax == 0 {
+		t.Errorf("extent did not parse: %+v", got.Extent)
+	}
+	if got.Extent.LonMin >= got.Extent.LonMax || got.Extent.LatMin >= got.Extent.LatMax {
+		t.Errorf("extent is not a box: %+v", got.Extent)
+	}
+	if got.LakeAtRestResidualMS == 0 {
+		t.Error("lake_at_rest_residual_ms is zero, which no real run reports")
+	}
+	if len(got.Assumptions) == 0 {
+		t.Error("assumptions did not parse")
+	}
+}
+
+// TestFloodRoutingNormalizeNilSlices covers what the frontend would throw on.
+func TestFloodRoutingNormalizeNilSlices(t *testing.T) {
+	f := &FloodRoutingAnalysis{}
+	f.NormalizeNilSlices()
+	if f.Assumptions == nil {
+		t.Error("assumptions stayed nil, and the panel maps over it")
+	}
+}

--- a/internal/analysis/runner.go
+++ b/internal/analysis/runner.go
@@ -1957,6 +1957,88 @@ func (r *Runner) AnalyzeFlood(ctx context.Context, req FloodRequest) (*FloodAnal
 	return wrapped.Flood, nil
 }
 
+/*
+AnalyzeFloodRouting routes rainfall over the AOI and returns depth, speed and
+arrival as fields.
+
+Separate from AnalyzeFlood because the products are separate: the envelope is a
+static disagreement measure over four DEMs, this moves water over one. They
+share a slice in the sidecar and nothing else.
+*/
+func (r *Runner) AnalyzeFloodRouting(ctx context.Context, req FloodRoutingRequest) (*FloodRoutingAnalysis, error) {
+	if _, err := os.Stat(r.sidecar); err != nil {
+		return nil, fmt.Errorf("sidecar not found at %s", r.sidecar)
+	}
+	if req.PolygonGeoJSON == nil {
+		return nil, fmt.Errorf("no polygon provided")
+	}
+
+	workDir, err := os.MkdirTemp("", "terra-flood-")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create work dir: %w", err)
+	}
+	// Kept, for the reason AnalyzeFlood gives: DepthTIF is a path into this
+	// directory and nothing copies it out, so a defer would hand the caller a
+	// path to a file that no longer exists. The prefix is in
+	// keptWorkDirPrefixes, which is what bounds the directory.
+
+	payload := map[string]any{
+		"action":          "flood_routing",
+		"polygon_geojson": req.PolygonGeoJSON,
+		"work_dir":        workDir,
+	}
+	// Each parameter travels only when the caller set it, so absence keeps
+	// selecting the sidecar's default rather than sending a zero that the
+	// sidecar would have to distinguish from a real request.
+	if req.DEMID != "" {
+		payload["dem_id"] = req.DEMID
+	}
+	for key, value := range map[string]*float64{
+		"resolution_m": req.ResolutionM,
+		"buffer_m":     req.BufferM,
+		"minutes":      req.Minutes,
+		"manning":      req.Manning,
+		"rain_mm_h":    req.RainMMH,
+		"rain_minutes": req.RainMinutes,
+	} {
+		if value != nil {
+			payload[key] = *value
+		}
+	}
+
+	reqBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode request: %w", err)
+	}
+
+	raw, err := r.runSidecarJSON(ctx, reqBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	var wrapped struct {
+		Routing *FloodRoutingAnalysis `json:"flood_routing"`
+	}
+	if err := json.Unmarshal([]byte(raw), &wrapped); err != nil {
+		return nil, fmt.Errorf("failed to parse flood routing result: %w", err)
+	}
+	if wrapped.Routing == nil {
+		return nil, fmt.Errorf("sidecar returned empty flood routing payload")
+	}
+
+	// The overlay becomes a data URI here, as every other raster does: the
+	// webview is served from its own origin and cannot open a path on disk. A
+	// failure to read it leaves DepthURI empty rather than discarding the run,
+	// because every figure in the payload stands without the picture.
+	if wrapped.Routing.DepthPNG != "" {
+		if uri, uerr := pngToDataURI(wrapped.Routing.DepthPNG); uerr == nil {
+			wrapped.Routing.DepthURI = uri
+		}
+	}
+	wrapped.Routing.NormalizeNilSlices()
+	return wrapped.Routing, nil
+}
+
 // The largest field the runner will carry back to the webview.
 //
 // The grid crosses as base64 inside a Wails return, so its cost is memory on

--- a/internal/analysis/testdata/flood_routing.json
+++ b/internal/analysis/testdata/flood_routing.json
@@ -1,0 +1,75 @@
+{
+ "flood_routing": {
+  "dem_id": "cop30",
+  "minutes": 60.0,
+  "manning": 0.05,
+  "steps": 1800,
+  "lake_at_rest_residual_ms": 2.2292147019970933e-14,
+  "resolution_m": 90.0,
+  "coarsened_from_m": 30.7,
+  "void_cells_filled": 0,
+  "grid": {
+   "width": 132,
+   "height": 157,
+   "bounds": {
+    "lon_min": 85.28152777777778,
+    "lat_min": 28.11731185794986,
+    "lon_max": 85.38900018595582,
+    "lat_max": 28.24513888888889
+   }
+  },
+  "cell_size_m": {
+   "x": 79.89115609520027,
+   "y": 90.0
+  },
+  "aoi": {
+   "cells": 9184,
+   "area_km2": 66.0348,
+   "flooded_cells": 6219,
+   "flooded_km2": 44.7159,
+   "flooded_fraction": 0.6772,
+   "on_boundary_fraction": 0.0399
+  },
+  "depth_m": {
+   "median": 0.037,
+   "p90": 0.114,
+   "max": 10.569
+  },
+  "speed_ms": {
+   "median": 0.035,
+   "p90": 0.104,
+   "max": 0.687
+  },
+  "arrival_min": {
+   "median": 15.1,
+   "p90": 20.367,
+   "max": 59.533
+  },
+  "rain": {
+   "mm_h": 80.0,
+   "minutes": 30.0
+  },
+  "volume": {
+   "in_m3": 5967014.2,
+   "stored_m3": 5899485.4,
+   "out_m3": 67528.8,
+   "clipped_m3": 0.0,
+   "left_fraction": 0.0113
+  },
+  "assumptions": {
+   "water": "Clear water over a fixed bed, depth-averaged, with one Manning n of 0.05 for the whole domain, and no infiltration: every millimetre that falls stays on the surface. A real catchment absorbs some of it, so the depths here are an upper bound on what the same rain would leave.",
+   "terrain": "cop30 at 90 m, coarsened from 31 m, read 2018 m beyond the AOI, with its closed depressions filled before routing. The filling is not cosmetic: a solver takes a sampling artefact in a channel literally, water runs in and stops, and the run reports a pond level instead of a flow. Every figure above is taken over the cells inside the AOI polygon; the buffer exists so the flow arrives correctly and is not reported on.",
+   "boundary": "Every edge is free outflow, and one-way: water reaching a boundary leaves, and 1% of what fell had left by the end of the run. A domain that stores everything it was given never reached an outlet, and its depths are a filling level rather than a flow.",
+   "aoi_fit": "4% of the flooded cells lie on the AOI boundary itself. A channel crossing an area touches that ring twice, where it enters and where it leaves, so a low share means the reach is inside the polygon. A high one means the polygon clips the valley rather than holding it: the routing is still correct, but what is reported is the fragment that fell inside the drawing."
+  },
+  "depth_tif": "<work_dir>/flood_depth.tif",
+  "depth_png": "<work_dir>/flood_depth.png",
+  "depth_png_max_m": 0.683,
+  "extent": {
+   "lon_min": 85.30188240053877,
+   "lat_min": 28.135223925979535,
+   "lon_max": 85.36864556319483,
+   "lat_max": 28.226412635948776
+  }
+ }
+}

--- a/internal/analysis/types_flood_routing.go
+++ b/internal/analysis/types_flood_routing.go
@@ -1,0 +1,188 @@
+package analysis
+
+// Overland routing: rain moved across the AOI, as depth, speed and arrival.
+//
+// A separate product from the flood envelope next door and deliberately a
+// separate contract. The envelope is static and measures how much of a HAND
+// extent follows from the choice of DEM; this one routes an actual flow and is
+// answered by fields in time.
+//
+// A second mode routed a breach hydrograph and has been removed. Not for want
+// of hydraulics -- the equations are the same either way -- but because nothing
+// could reliably decide WHERE a channel enters a drawn polygon: ranking the
+// boundary by accumulated flow finds the outlet, and so does ranking it by how
+// far the water then travels. It can return once the inlet arrives as a
+// coordinate the caller gives rather than a guess. Rain needs no such point.
+//
+// WHAT THE FIGURES COVER. As with the envelope, the DEM is read beyond the AOI
+// so that flow arrives correctly, and every count, area and spread reported
+// here is nevertheless taken over the cells inside the AOI polygon. The
+// buffered window survives as provenance in Grid alone.
+//
+// THE THREE FIELDS THAT ARE NOT DECORATION. LakeAtRestResidualMS is the
+// well-balancing check, run on the actual bed before the flow: an unbalanced
+// scheme manufactures currents on every slope and each depth would be that
+// error plus the flow. Volume.LeftFraction says whether the water reached an
+// outlet at all -- a domain that stores everything it was given reports a
+// filling level, not a routed wave. ResolutionM says which cell size the
+// answer is for, because the cost is cells times timesteps and a coarser run
+// is the usual way to get one at all.
+
+// FloodRoutingRequest selects an AOI and what to route over it.
+//
+// The parameters are pointers for the reason FloodRequest gives: absence is
+// what selects the sidecar's default, and zero is a legitimate request for
+// none of these -- a zero volume, a zero rain rate or a zero duration is a
+// request for nothing to happen, which the sidecar refuses by name.
+type FloodRoutingRequest struct {
+	PolygonGeoJSON *GeoJSONGeometry `json:"polygon_geojson,omitempty"`
+	// Which DEM to route over, by dem.COLLECTIONS id. Empty selects cop30.
+	// One product and not the envelope's four: this is not a disagreement
+	// measure, and the extent still moves with the choice, which is why the
+	// id travels back in the result.
+	DEMID string `json:"dem_id,omitempty"`
+	// Cell size for the routing, in metres. Empty routes at the DEM's native
+	// resolution, which for a large AOI is slower than a user will wait.
+	ResolutionM *float64 `json:"resolution_m,omitempty"`
+	// How far beyond the AOI to read the DEM. Empty sizes it from the AOI.
+	BufferM *float64 `json:"buffer_m,omitempty"`
+	// Simulated duration in minutes. Empty selects 60.
+	Minutes *float64 `json:"minutes,omitempty"`
+	// Lumped Manning n. Empty selects 0.05. A calibration parameter standing
+	// in for sediment load and bed roughness together, not a measurement.
+	Manning *float64 `json:"manning,omitempty"`
+
+	// The rainfall rate and how long it falls. Required.
+	RainMMH     *float64 `json:"rain_mm_h,omitempty"`
+	RainMinutes *float64 `json:"rain_minutes,omitempty"`
+}
+
+// FloodRoutingSpread is one field's median and the range that matters.
+//
+// Pointers because a run where nothing wetted has no median, and zero is a
+// depth. The panel shows a dash for absent rather than a plausible 0.00 m.
+type FloodRoutingSpread struct {
+	Median *float64 `json:"median"`
+	P90    *float64 `json:"p90"`
+	Max    *float64 `json:"max"`
+}
+
+// FloodRoutingAOI counts what happened inside the polygon, not the window.
+type FloodRoutingAOI struct {
+	Cells           int     `json:"cells"`
+	AreaKm2         float64 `json:"area_km2"`
+	FloodedCells    int     `json:"flooded_cells"`
+	FloodedKm2      float64 `json:"flooded_km2"`
+	FloodedFraction float64 `json:"flooded_fraction"`
+	// What share of the flooded cells sit on the AOI's own boundary ring.
+	//
+	// A channel crossing an area touches that ring twice, where it enters and
+	// where it leaves, so this stays low. It goes high when the polygon CLIPS
+	// a valley instead of holding it -- the routing is still correct and still
+	// follows the real channel, but the reach inside the drawing is a fragment
+	// and every figure beside this one describes the fragment. Visible on the
+	// map as a flow that hugs one edge; invisible to a reader who is reading
+	// the numbers, which is why it is a number.
+	OnBoundaryFraction float64 `json:"on_boundary_fraction"`
+}
+
+// FloodRoutingVolume is the mass balance, reported rather than assumed.
+type FloodRoutingVolume struct {
+	// What the boundary actually put into the domain, measured cell by cell.
+	InM3     float64 `json:"in_m3"`
+	StoredM3 float64 `json:"stored_m3"`
+	// Measured across the boundary step by step, not differenced. A
+	// conservative scheme cancels every interior flux, so the mass the domain
+	// loses over one step IS what crossed its edge once the positivity clip is
+	// taken back out -- and differencing instead reported an inflow of -779 Mm3
+	// on a real AOI, which was the accounting rather than the flow.
+	OutM3 float64 `json:"out_m3"`
+	// What the positivity clip at the wetting front invented. Small on a
+	// healthy run, and the first place to look when the balance does not close.
+	// Reported because a balance that hides its own source term is not a
+	// balance.
+	ClippedM3 float64 `json:"clipped_m3"`
+	// What share of the water reached a boundary and left. Near zero means the
+	// flow never found an outlet inside this AOI and the depths are a filling
+	// level; the panel says so rather than leaving the reader to notice.
+	LeftFraction float64 `json:"left_fraction"`
+}
+
+// FloodRoutingRain is the rate that fell and for how long.
+type FloodRoutingRain struct {
+	MMH     float64 `json:"mm_h"`
+	Minutes float64 `json:"minutes"`
+}
+
+// FloodRoutingCellSize is the ground size of one cell, both ways.
+type FloodRoutingCellSize struct {
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
+}
+
+// FloodRoutingAnalysis is one routed run.
+type FloodRoutingAnalysis struct {
+	DEMID       string  `json:"dem_id"`
+	Minutes     float64 `json:"minutes"`
+	Manning     float64 `json:"manning"`
+	Steps       int     `json:"steps"`
+	VoidsFilled int     `json:"void_cells_filled"`
+
+	// The lake-at-rest residual, in m/s. Machine noise on a well-balanced
+	// scheme. The sidecar refuses to report a run above 1e-6, so a value that
+	// arrives here has already passed; it is carried so the panel can show
+	// that the check ran rather than only that it passed.
+	LakeAtRestResidualMS float64 `json:"lake_at_rest_residual_ms"`
+
+	ResolutionM float64 `json:"resolution_m"`
+	// Set when the DEM was coarsened before routing, holding the native cell
+	// size it came from. Nil when the run used the product as read.
+	CoarsenedFromM *float64 `json:"coarsened_from_m"`
+
+	Grid     FloodGrid            `json:"grid"`
+	CellSize FloodRoutingCellSize `json:"cell_size_m"`
+	AOI      FloodRoutingAOI      `json:"aoi"`
+
+	DepthM     FloodRoutingSpread `json:"depth_m"`
+	SpeedMS    FloodRoutingSpread `json:"speed_ms"`
+	ArrivalMin FloodRoutingSpread `json:"arrival_min"`
+	Volume     FloodRoutingVolume `json:"volume"`
+
+	Rain FloodRoutingRain `json:"rain"`
+
+	// What the run assumed, in the caller's own words rather than a footnote:
+	// the water model, the terrain, and the boundary. Shown in the panel.
+	Assumptions map[string]string `json:"assumptions"`
+
+	// The depth raster over the whole computed window, on Grid. A path into the
+	// run's work directory, which AnalyzeFloodRouting deliberately leaves in
+	// place for the reason AnalyzeFlood gives about its agreement raster.
+	DepthTIF string `json:"depth_tif"`
+	// The same depths clipped to the AOI and coloured, for the map. The webview
+	// cannot open a path on disk, so DepthURI carries it; added by
+	// AnalyzeFloodRouting and not by the sidecar.
+	DepthPNG     string  `json:"depth_png"`
+	DepthURI     string  `json:"depth_uri,omitempty"`
+	DepthPNGMaxM float64 `json:"depth_png_max_m"`
+	// Where to put the PNG. The extent of the CLIPPED image, not of Grid: those
+	// describe the buffered window and placing the image on them would stretch
+	// it over ground it does not cover.
+	//
+	// Bounds and not a []float64, which is what this was and what made the
+	// first run fail to parse. composite.extent_from_profile returns an OBJECT
+	// -- lon_min, lat_min, lon_max, lat_max -- and every other payload that
+	// places an overlay types it as Bounds for exactly that reason. The
+	// Go/TypeScript contract check did not catch it: it compares structs
+	// against same-named interfaces, and this one has none yet, so it sat in
+	// the unguarded set the check reports by count.
+	Extent Bounds `json:"extent"`
+}
+
+// NormalizeNilSlices gives the frontend an empty array where the sidecar sent
+// null, for the reason the other payloads carry the same method: TypeScript
+// reads a null where it expects a list and the panel throws on .length.
+func (f *FloodRoutingAnalysis) NormalizeNilSlices() {
+	if f.Assumptions == nil {
+		f.Assumptions = map[string]string{}
+	}
+}

--- a/sidecar/terra/flood/actions.py
+++ b/sidecar/terra/flood/actions.py
@@ -299,3 +299,298 @@ def flood_envelope(req, work_dir):
     protocol.emit_progress(100, 'done')
     sys.stdout.write(json.dumps({'flood': payload}))
     sys.stdout.flush()
+
+
+def flood_routing(req, work_dir):
+    """Route rainfall over the AOI and report depth, speed and arrival.
+
+    A different product from flood_envelope and deliberately a separate action.
+    The envelope is static and measures disagreement between DEM products; this
+    moves water over one of them and is answered by fields in time.
+
+    A second mode routed a breach hydrograph and has been removed. Not for want
+    of hydraulics -- the equations are the same either way -- but because
+    nothing could reliably decide WHERE a channel enters a drawn polygon:
+    ranking the boundary by accumulated flow finds the outlet, which carries
+    every cell upstream of it, and ranking it by how far the water then travels
+    finds the outlet too on a short AOI. It can return once the inlet arrives as
+    a coordinate the caller gives. Rain needs no such point.
+    """
+    from terra import aoi
+    from terra.flood import envelope as flood_mod
+    from terra.flood import routing as route_mod
+    from terra.imagery import composite as comp
+    from terra.terrain import dem as dem_mod
+    from terra.terrain import hand
+
+    cog.configure()
+
+    if not req.get('polygon_geojson'):
+        protocol.fail('no polygon provided (polygon_geojson required)')
+    polygon = aoi.polygon_from_geojson(req['polygon_geojson'])
+    if polygon.is_empty:
+        protocol.fail('the AOI polygon is empty, so there is no window to read a DEM over')
+
+    # A caller sending the keys of the mode that used to exist expects a
+    # different product, and quietly routing rain for them would answer a
+    # question they did not ask.
+    for gone in ('mode', 'volume_m3', 'peak_minutes'):
+        if req.get(gone) is not None:
+            protocol.fail(f'{gone!r} is not a parameter of this action. Routing a '
+                          f'breach needs an inlet location, and no reliable way to '
+                          f'find one from a drawn polygon was found, so the mode was '
+                          f'removed rather than left guessing. What remains is '
+                          f'rainfall over the area: give rain_mm_h.')
+
+    dem_id = req.get('dem_id') or 'cop30'
+    try:
+        product = dem_mod.resolve(dem_id)
+    except ValueError as e:
+        protocol.fail(str(e))
+
+    # One product, not the envelope's four. This is not a disagreement measure,
+    # and reading four DEMs to route over one of them would quadruple the read
+    # for nothing. Which one was used travels in the payload, because the extent
+    # a route produces moves with the DEM exactly as the envelope shows.
+    buffer_m = protocol.request_number(req, 'buffer_m', None)
+    if buffer_m is None:
+        buffer_m = dem_mod.recommended_buffer_m(polygon.bounds)
+    elif buffer_m < 0:
+        protocol.fail(f'buffer_m is a distance beyond the AOI and cannot be negative, '
+                      f'got {buffer_m}')
+
+    minutes = protocol.request_positive(req, 'minutes', 60.0)
+    manning = protocol.request_positive(req, 'manning', route_mod.MANNING_DEFAULT)
+    snapshots = int(protocol.request_number(req, 'snapshots', 0) or 0)
+    rain_mm_h = protocol.request_number(req, 'rain_mm_h', None)
+    rain_minutes = protocol.request_number(req, 'rain_minutes', None)
+    if not rain_mm_h:
+        protocol.fail('rain_mm_h is required: the rainfall rate in millimetres per '
+                      'hour to put on every cell of the AOI.')
+
+    protocol.emit_progress(10, f'reading {product.id}')
+    z, transform, crs = dem_mod.fetch(polygon, product.collection, buffer_m,
+                                      progress=lambda m: protocol.emit_progress(15, m))
+    z = np.asarray(z, dtype=float)
+    z[z < dem_mod.VOID_BELOW_M] = np.nan
+    if np.isnan(z).all():
+        protocol.fail(f'{product.id} is void over this AOI, so there is no surface to route on')
+    n_void = int(np.isnan(z).sum())
+    if n_void:
+        # Voids are filled to the surrounding median rather than left as NaN: a
+        # NaN cell poisons every flux that touches it and the hole spreads
+        # across the domain in a few steps. How many were filled is reported.
+        z = np.where(np.isnan(z), float(np.nanmedian(z)), z)
+
+    lat = float(polygon.centroid.y)
+    dx, dy = hand.pixel_size_m(lat, abs(transform.a), abs(transform.e))
+
+    # Coarsen before routing, if asked. The explicit scheme costs cells times
+    # steps, and halving the cell size roughly quadruples both: the same AOI
+    # that routes in a minute at 90 m does not finish in ten at 30 m, which is
+    # the difference between a control a user turns and a run they abandon.
+    #
+    # What it costs is measured rather than assumed. On one confined reach
+    # (n=1), refining 60 m to 45 m moved the median peak stage by 1%, the 90th
+    # percentile by 3% and the flooded area by 2% -- the geometry of the valley,
+    # not the cell size, was setting the answer at that scale.
+    resolution_m = protocol.request_number(req, 'resolution_m', None)
+    native_m = float(max(dx, dy))
+    coarsened_from = None
+    if resolution_m and resolution_m > native_m * 1.05:
+        from scipy.ndimage import zoom
+
+        factor = native_m / float(resolution_m)
+        z = zoom(z, factor, order=1)
+        if min(z.shape) < 16:
+            protocol.fail(f'resolution_m of {resolution_m:.0f} m leaves a '
+                          f'{z.shape[1]} by {z.shape[0]} grid over this AOI, which is '
+                          f'too coarse to route on. Ask for a finer cell or a larger AOI.')
+        transform = transform * transform.scale(1 / factor, 1 / factor)
+        coarsened_from = native_m
+        dx, dy = dx / factor, dy / factor
+
+    grid = dem_mod.Grid.of(z, transform, crs)
+    n_cells = int(z.size)
+    # A ceiling, because the cost is the user's wait and nothing in the request
+    # bounds it. Refused with the arithmetic rather than silently coarsened: a
+    # run that quietly changed its own resolution would report figures the
+    # caller did not ask for.
+    if n_cells > 400_000:
+        protocol.fail(f'this AOI is {grid.width} by {grid.height} = {n_cells:,} cells at '
+                      f'{max(dx, dy):.0f} m, and the explicit solver costs cells times '
+                      f'timesteps. Set resolution_m coarser (about '
+                      f'{max(dx, dy) * (n_cells / 400_000) ** 0.5:.0f} m for this AOI) '
+                      f'or draw a smaller area.')
+
+    protocol.emit_progress(30, 'terrain: filling depressions')
+    # Filled and nothing more. The D8 graph and the flow accumulation were
+    # computed here only to locate a breach inlet; rain falls everywhere and
+    # needs neither, so a run is shorter by that whole chain.
+    zf = hand.fill_depressions(z)
+
+    # The scheme is well balanced or the run is not reportable. Checked on the
+    # actual bed rather than trusted, because an unbalanced scheme manufactures
+    # currents on every slope and each depth below would be that error plus the
+    # flow, with nothing in the output to say so.
+    residual = route_mod.lake_at_rest_residual(zf, dx, dy)
+    if residual > 1e-6:
+        protocol.fail(f'the scheme failed its lake-at-rest check on this terrain: a '
+                      f'motionless lake developed {residual:.3e} m/s. Depths from '
+                      f'such a run are the balancing error plus the flow and are '
+                      f'not reported.')
+
+    protocol.emit_progress(45, f'routing {minutes:.0f} min over '
+                               f'{grid.width} by {grid.height} cells')
+    try:
+        result = route_mod.route(
+            zf, dx, dy, minutes=minutes, rain_mm_h=rain_mm_h,
+            rain_minutes=rain_minutes, manning=manning, snapshots=snapshots,
+            progress=lambda m: protocol.emit_progress(60, m),
+        )
+    except ValueError as e:
+        protocol.fail(str(e))
+
+    protocol.emit_progress(85, 'measuring')
+    aoi_mask = flood_mod.aoi_reporting_mask(polygon, grid)
+    depth = result['peak_depth_m']
+    speed = result['peak_speed_ms']
+    arrival = result['arrival_s']
+    cell_km2 = dx * dy / 1e6
+
+    wet = (depth > route_mod.HMIN) & aoi_mask
+    inside_n = int(aoi_mask.sum())
+    wet_vals = depth[wet]
+
+    # DOES THE CHANNEL RUN THROUGH THIS AREA, OR ONLY CLIP IT?
+    #
+    # A drawn AOI need not contain the valley it overlaps. Where it catches a
+    # corner the routing is still correct, but the reach inside the polygon is a
+    # fragment, the flow hugs one edge, and every figure below describes that
+    # fragment. The map shows it plainly and a reader who is not looking at the
+    # map cannot see it at all, so it is measured: the share of flooded cells
+    # lying on the AOI's own boundary ring. A channel crossing an area touches
+    # that ring twice, where it enters and where it leaves.
+    from scipy.ndimage import binary_erosion
+
+    interior = binary_erosion(aoi_mask, np.ones((3, 3), bool), border_value=0)
+    rim = aoi_mask & ~interior
+    rim_fraction = round(int((wet & rim).sum()) / int(wet.sum()), 4) if wet.any() else 0.0
+
+    payload = {
+        'dem_id': product.id,
+        'minutes': float(minutes),
+        'manning': float(manning),
+        'steps': int(result['steps']),
+        'lake_at_rest_residual_ms': float(residual),
+        'resolution_m': round(float(max(dx, dy)), 1),
+        'coarsened_from_m': round(coarsened_from, 1) if coarsened_from else None,
+        'void_cells_filled': n_void,
+        'grid': dem_mod.payload_grid(grid),
+        'cell_size_m': {'x': float(dx), 'y': float(dy)},
+        'aoi': {
+            'cells': inside_n,
+            'area_km2': round(inside_n * cell_km2, 4),
+            'flooded_cells': int(wet.sum()),
+            'flooded_km2': round(int(wet.sum()) * cell_km2, 4),
+            'flooded_fraction': round(float(wet.sum()) / inside_n, 4) if inside_n else 0.0,
+            'on_boundary_fraction': rim_fraction,
+        },
+        'depth_m': _spread(wet_vals),
+        'speed_ms': _spread(speed[wet]),
+        'arrival_min': _spread(arrival[wet] / 60.0),
+        'rain': {'mm_h': float(rain_mm_h), 'minutes': float(rain_minutes or minutes)},
+        'volume': {
+            'in_m3': round(result['volume_in_m3'], 1),
+            'stored_m3': round(result['volume_stored_m3'], 1),
+            'out_m3': round(result['volume_out_m3'], 1),
+            'clipped_m3': round(result['volume_clipped_m3'], 1),
+            'left_fraction': (round(result['volume_out_m3'] / result['volume_in_m3'], 4)
+                              if result['volume_in_m3'] else 0.0),
+        },
+    }
+
+    payload['assumptions'] = {
+        'water': (
+            'Clear water over a fixed bed, depth-averaged, with one Manning n '
+            f'of {manning} for the whole domain, and no infiltration: every '
+            'millimetre that falls stays on the surface. A real catchment '
+            'absorbs some of it, so the depths here are an upper bound on what '
+            'the same rain would leave.'
+        ),
+        'terrain': (
+            f'{product.id} at {max(dx, dy):.0f} m'
+            + (f', coarsened from {coarsened_from:.0f} m' if coarsened_from else '')
+            + f', read {buffer_m:.0f} m beyond the AOI, with its closed '
+            'depressions filled before routing. The filling is not cosmetic: a '
+            'solver takes a sampling artefact in a channel literally, water runs '
+            'in and stops, and the run reports a pond level instead of a flow. '
+            'Every figure above is taken over the cells inside the AOI polygon; '
+            'the buffer exists so the flow arrives correctly and is not '
+            'reported on.'
+        ),
+        'boundary': (
+            'Every edge is free outflow, and one-way: water reaching a boundary '
+            f'leaves, and {payload["volume"]["left_fraction"] * 100:.0f}% of what '
+            'fell had left by the end of the run. A domain that stores '
+            'everything it was given never reached an outlet, and its depths are '
+            'a filling level rather than a flow.'
+        ),
+        'aoi_fit': (
+            f'{rim_fraction * 100:.0f}% of the flooded cells lie on the AOI '
+            'boundary itself. A channel crossing an area touches that ring '
+            'twice, where it enters and where it leaves, so a low share means '
+            'the reach is inside the polygon. A high one means the polygon clips '
+            'the valley rather than holding it: the routing is still correct, '
+            'but what is reported is the fragment that fell inside the drawing.'
+        ),
+    }
+
+    # Rasters, on the same footing the envelope puts them: the GeoTIFF over the
+    # whole computed window, the PNG clipped to the AOI so the map overlay
+    # covers the ground the figures are measured over and no more.
+    depth_tif = Path(work_dir) / 'flood_depth.tif'
+    with rasterio.open(
+        depth_tif, 'w', driver='GTiff', width=grid.width, height=grid.height,
+        count=1, dtype='float32', crs=grid.crs, transform=grid.transform,
+        nodata=0.0, compress='deflate',
+    ) as dst:
+        dst.write(depth.astype('float32'), 1)
+
+    rows = np.flatnonzero(aoi_mask.any(axis=1))
+    cols = np.flatnonzero(aoi_mask.any(axis=0))
+    ar0, ar1 = int(rows[0]), int(rows[-1]) + 1
+    ac0, ac1 = int(cols[0]), int(cols[-1]) + 1
+    dmax = float(np.percentile(wet_vals, 98)) if wet_vals.size else 1.0
+    depth_png = Path(work_dir) / 'flood_depth.png'
+    comp.write_rgba_png(
+        route_mod.depth_rgba(depth[ar0:ar1, ac0:ac1], dmax,
+                             inside=aoi_mask[ar0:ar1, ac0:ac1]),
+        depth_png,
+    )
+    payload['depth_tif'] = str(depth_tif)
+    payload['depth_png'] = str(depth_png)
+    payload['depth_png_max_m'] = round(dmax, 3)
+    payload['extent'] = comp.extent_from_profile({
+        'transform': rasterio.windows.transform(
+            rasterio.windows.Window(ac0, ar0, ac1 - ac0, ar1 - ar0), grid.transform
+        ),
+        'height': ar1 - ar0,
+        'width': ac1 - ac0,
+        'crs': grid.crs,
+    })
+
+    protocol.emit_progress(100, 'done')
+    sys.stdout.write(json.dumps({'flood_routing': payload}))
+    sys.stdout.flush()
+
+
+def _spread(values):
+    """Median and the range that matters, or nulls when nothing is wet."""
+    v = np.asarray(values, dtype=float)
+    v = v[np.isfinite(v)]
+    if v.size == 0:
+        return {'median': None, 'p90': None, 'max': None}
+    return {'median': round(float(np.median(v)), 3),
+            'p90': round(float(np.percentile(v, 90)), 3),
+            'max': round(float(v.max()), 3)}

--- a/sidecar/terra/flood/actions.py
+++ b/sidecar/terra/flood/actions.py
@@ -317,11 +317,9 @@ def flood_routing(req, work_dir):
     a coordinate the caller gives. Rain needs no such point.
     """
     from terra import aoi
-    from terra.flood import envelope as flood_mod
-    from terra.flood import routing as route_mod
+    from terra.flood import envelope as flood_mod, routing as route_mod
     from terra.imagery import composite as comp
-    from terra.terrain import dem as dem_mod
-    from terra.terrain import hand
+    from terra.terrain import dem as dem_mod, hand
 
     cog.configure()
 

--- a/sidecar/terra/flood/routing.py
+++ b/sidecar/terra/flood/routing.py
@@ -1,0 +1,361 @@
+"""
+Overland routing: where rain goes over an AOI, how deep, and when.
+
+A different question from the one `envelope` answers. The envelope asks how much
+of a HAND extent is terrain and how much is the choice of DEM; it is static, and
+it never moves water. This puts a rainfall rate on every cell and lets the
+terrain organise the flow, so it can answer what an hour of rain does to a
+valley.
+
+It shares the terrain chain rather than repeating it. `terra.terrain.hand`
+already fills depressions with an epsilon gradient, because HAND needs that;
+this module takes the filled surface and adds only the hydraulics.
+
+WHAT WAS HERE AND IS NOT. A second mode routed a breach hydrograph entering
+through the AOI's own drainage, and it is gone. Not because the hydraulics
+failed -- they are the same equations either way -- but because nothing here
+could reliably decide WHERE a channel enters a drawn polygon. Two heuristics
+were tried. Ranking boundary cells by accumulated flow finds the OUTLET, which
+carries every cell upstream of it. Ranking by how far the water then travels
+inside finds the outlet too on a short AOI, where the outward reach is the
+longer one. A breach whose inlet is placed on the outlet reports depths that
+are arithmetic rather than flood.
+
+It can come back, and the physics below is ready for it, on one condition: the
+inlet arrives as a COORDINATE the caller gives, not as a guess this module
+makes. Rainfall needs no such point, which is why it is what remains.
+
+THE SCHEME, AND WHY EACH PIECE IS THERE.
+
+Audusse hydrostatic reconstruction, which makes the scheme well balanced: a
+motionless lake over irregular bed stays motionless. Without it the bed source
+term and the pressure flux do not cancel and the model manufactures currents on
+every slope, which on mountain terrain swamps the signal entirely.
+`lake_at_rest_residual` measures it rather than asserting it, and the action
+refuses to report a run whose residual is not at machine noise.
+
+HLL rather than Rusanov. Rusanov is the more dissipative of the two and smears
+the steep front that is the whole character of a flood wave.
+
+Semi-implicit Manning friction, because an explicit treatment diverges as the
+depth tends to zero at the wetting front.
+
+THREE THINGS THAT LOOK LIKE DETAIL AND ARE NOT. Each was a defect measured on a
+prototype, and each is silent -- the run completes, the numbers look plausible,
+and they are wrong.
+
+  Depressions must be filled before routing. A 30 m DEM resampled into a valley
+  carries spurious closed sinks along the channel; a shallow water solver takes
+  them literally, water runs in and stops. Measured on a raw bed: 99.94 Mm3 in,
+  99.94 Mm3 still standing after three hours, the outflow row never wetting.
+
+  Every boundary is free outflow, and none is a wall. A reach that runs south
+  and swings west leaves its box through the WEST edge; with west set as a wall
+  the whole flood banked against it and the domain filled like a tank.
+
+  Outflow is ONE-WAY. A ghost cell that copies its neighbour copies the
+  momentum too, so wherever the flow at an edge points inward the ghost supplies
+  water from nothing and keeps supplying it -- measured at 24,000% of what was
+  put in. The ghost is dried where the flow points inward, and only there,
+  because a blanket dry rim would drain a lake at rest.
+
+WHAT THIS IS NOT. Clear water over a fixed bed, depth-averaged, with one lumped
+Manning n. Real floods carry sediment, entrain their bed and are not Newtonian;
+n absorbs all of that and is a calibration parameter, not a roughness
+measurement. The terrain is whatever the DEM was.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+G = 9.81
+
+# Below this a cell is dry. Not a tuning knob: it is the depth at which q/h
+# stops being a velocity, and both the flux and the timestep read it.
+HMIN = 0.02
+
+# Manning n per reach type. Defaults only; the request overrides them. The
+# spread is what matters more than any single value -- a debris-laden upper
+# reach and a lower river differ by more than the uncertainty on either.
+MANNING_DEFAULT = 0.05
+
+# CFL for the explicit update. 0.4 rather than the stable 0.9 because the
+# wetting front on steep ground is where this scheme is least comfortable.
+CFL = 0.4
+
+# Above this inward velocity an outflow ghost is treated as dry, so it cannot
+# feed the domain. Chosen between the two scales it has to separate: the
+# well-balanced scheme's residual on a lake at rest is around 1e-14 m/s, and the
+# slowest flow this product reports is of order 0.1 m/s.
+INWARD_MS = 1e-4
+
+def sweep(h, qn, qt, z, axis, dx):
+    """HLL fluxes with Audusse reconstruction along `axis`.
+
+    Returns per-cell updates (dh, dqn, dqt) already divided by dx, with the
+    well-balancing source folded into dqn.
+    """
+    hs = np.maximum(h, 0.0)
+    un = np.where(hs > HMIN, qn / np.maximum(hs, HMIN), 0.0)
+    ut = np.where(hs > HMIN, qt / np.maximum(hs, HMIN), 0.0)
+
+    hR = np.roll(hs, -1, axis)
+    unR = np.roll(un, -1, axis)
+    utR = np.roll(ut, -1, axis)
+    zL, zR = z, np.roll(z, -1, axis)
+    zI = np.maximum(zL, zR)
+
+    # Reconstruct each side's depth against the higher of the two beds.
+    hLs = np.maximum(hs + zL - zI, 0.0)
+    hRs = np.maximum(hR + zR - zI, 0.0)
+    cL, cR = np.sqrt(G * hLs), np.sqrt(G * hRs)
+
+    sL = np.minimum(np.minimum(un - cL, unR - cR), 0.0)
+    sR = np.maximum(np.maximum(un + cL, unR + cR), 0.0)
+
+    qLs, qRs = hLs * un, hRs * unR
+    FnL = qLs * un + 0.5 * G * hLs ** 2
+    FnR = qRs * unR + 0.5 * G * hRs ** 2
+
+    den = np.where(sR - sL > 1e-12, sR - sL, 1.0)
+    Fh = (sR * qLs - sL * qRs + sL * sR * (hRs - hLs)) / den
+    Fn = (sR * FnL - sL * FnR + sL * sR * (qRs - qLs)) / den
+    Ft = (sR * qLs * ut - sL * qRs * utR
+          + sL * sR * (hRs * utR - hLs * ut)) / den
+
+    dh = (Fh - np.roll(Fh, 1, axis)) / dx
+    dqn = (Fn - np.roll(Fn, 1, axis)) / dx
+    dqt = (Ft - np.roll(Ft, 1, axis)) / dx
+
+    # Well-balancing source. For a lake at rest hLs == hRs at every interface,
+    # so this cancels the pressure flux difference exactly and no current is
+    # created. That identity is what `lake_at_rest_residual` checks.
+    src = 0.5 * G * (hLs ** 2 - np.roll(hRs, 1, axis) ** 2) / dx
+    return dh, dqn - src, dqt
+
+
+def step(h, qx, qy, z, dx, dy, dt, n_manning):
+    """One split step on a domain padded with one ring of ghost cells.
+
+    The padding is what makes the boundary a boundary. `sweep` differences with
+    np.roll, which wraps, so on a bare array the domain is a torus and nothing
+    ever leaves it. Ghosts copy depth, momentum and bed outward, which is free
+    outflow and also keeps the reconstruction well balanced at the edge: a
+    motionless lake sees no gradient across it.
+
+    """
+    hp = np.pad(h, 1, mode="edge")
+    qxp = np.pad(qx, 1, mode="edge")
+    qyp = np.pad(qy, 1, mode="edge")
+    zp = np.pad(z, 1, mode="edge")
+
+    # OUTFLOW IS ONE-WAY.
+    #
+    # A ghost that copies its neighbour copies the momentum too, so wherever the
+    # flow at an edge points inward the ghost supplies water from nothing and
+    # keeps supplying it. Measured before this: boundary inflow of 24,000% of
+    # what the inlet delivered, on a domain whose edges simply sloped inward.
+    # Clamping the normal component so it can only leave makes the edge an
+    # outlet rather than an unlimited reservoir. Depth is still copied, which is
+    # what keeps a lake at rest at rest.
+    # Clamping the ghost's momentum is not enough on its own: the interior cell
+    # keeps its own inward momentum and the interface still carries mass in. A
+    # DRY ghost carries nothing, so wherever the flow at an edge points inward
+    # the ghost is emptied as well as stilled.
+    #
+    # Only where it points inward. At rest the normal momentum is zero, the
+    # ghost keeps its copied depth and bed, and the lake stays a lake -- which
+    # is the property the C-property test checks and which a blanket dry rim
+    # would destroy.
+    # The test is on VELOCITY and against a threshold, not on momentum against
+    # zero. A motionless lake is not exactly motionless: the well-balanced
+    # scheme holds it to about 1e-14 m/s, which is above zero, and a bare `> 0`
+    # read that noise as inflow, dried the rim and drained the lake -- the
+    # C-property test caught it immediately. INWARD_MS sits far above that noise
+    # and far below anything a flood does.
+    uy = qyp / np.maximum(hp, HMIN)
+    ux = qxp / np.maximum(hp, HMIN)
+    for ghost, inner, sign in ((0, 1, +1.0), (-1, -2, -1.0)):
+        inward = sign * uy[inner, :] > INWARD_MS
+        qyp[ghost, inward] = 0.0
+        hp[ghost, inward] = 0.0
+    for ghost, inner, sign in ((0, 1, +1.0), (-1, -2, -1.0)):
+        inward = sign * ux[:, inner] > INWARD_MS
+        qxp[inward, ghost] = 0.0
+        hp[inward, ghost] = 0.0
+
+    dh_x, dqx_x, dqy_x = sweep(hp, qxp, qyp, zp, 1, dx)
+    dh_y, dqy_y, dqx_y = sweep(hp, qyp, qxp, zp, 0, dy)
+    core = (slice(1, -1), slice(1, -1))
+
+    raw = h - dt * (dh_x[core] + dh_y[core])
+    # The clip is not free. Where the update drives a cell below zero, raising
+    # it to zero CREATES mass, and on a wetting front that happens constantly.
+    # It is small and it is not nothing, so it is returned rather than absorbed:
+    # a balance that hides its own source term is not a balance.
+    clipped = float(np.sum(np.where(raw < 0.0, -raw, 0.0)))
+    h_new = np.maximum(raw, 0.0)
+    qx_new = qx - dt * (dqx_x[core] + dqx_y[core])
+    qy_new = qy - dt * (dqy_x[core] + dqy_y[core])
+
+    dry = h_new <= HMIN
+    qx_new[dry] = 0.0
+    qy_new[dry] = 0.0
+    # Semi-implicit: q <- q / (1 + dt g n^2 |u| / h^(4/3)).
+    hh = np.maximum(h_new, HMIN)
+    speed = np.hypot(qx_new, qy_new) / hh
+    fr = G * n_manning ** 2 * speed / hh ** (4.0 / 3.0)
+    return h_new, qx_new / (1.0 + dt * fr), qy_new / (1.0 + dt * fr), clipped
+
+
+def timestep(h, qx, qy, dx, dy, cfl=CFL, cap_s=2.0):
+    hh = np.maximum(h, HMIN)
+    c = np.sqrt(G * hh)
+    m = max(float((np.abs(qx) / hh + c).max()) / dx,
+            float((np.abs(qy) / hh + c).max()) / dy, 1e-6)
+    return min(cfl / m, cap_s)
+
+
+def lake_at_rest_residual(z, dx, dy, steps=120):
+    """Largest spurious speed a motionless lake develops over `steps` steps.
+
+    The C-property check. A well-balanced scheme returns machine noise here; a
+    scheme whose source term does not cancel its pressure flux returns a real
+    number, and every depth it later reports is that error plus the flow.
+    """
+    level = float(np.percentile(z, 25))
+    h = np.maximum(level - z, 0.0)
+    qx = np.zeros_like(h)
+    qy = np.zeros_like(h)
+    for _ in range(steps):
+        dt = timestep(h, qx, qy, dx, dy)
+        h, qx, qy, _ = step(h, qx, qy, z, dx, dy, dt, 0.0)
+    wet = h > HMIN
+    if not wet.any():
+        return 0.0
+    return float((np.hypot(qx, qy)[wet] / np.maximum(h[wet], HMIN)).max())
+
+
+def route(z_filled, dx, dy, *, minutes=60.0, rain_mm_h=None,
+          rain_minutes=None, manning=MANNING_DEFAULT, snapshots=0, progress=None):
+    """Route rainfall over `z_filled` and return the fields it leaves behind.
+
+    `z_filled` is the depression-filled surface from terra.terrain.hand, which
+    computes it for HAND. Neither the D8 graph nor the accumulation is needed
+    any more: both existed only to find a breach inlet.
+    """
+    if not rain_mm_h:
+        raise ValueError("rain_mm_h is required: the rainfall rate in mm/h")
+    ny, nx = z_filled.shape
+    cell = dx * dy
+    t_end = float(minutes) * 60.0
+
+    h = np.zeros((ny, nx))
+    qx = np.zeros_like(h)
+    qy = np.zeros_like(h)
+    peak_h = np.zeros_like(h)
+    peak_speed = np.zeros_like(h)
+    arrival = np.full((ny, nx), np.nan)
+
+    rain_s = float(rain_minutes or minutes) * 60.0
+    rain_rate = float(rain_mm_h) / 1000.0 / 3600.0     # m/s of depth
+
+    volume_in = 0.0
+    volume_out = 0.0
+    volume_clipped = 0.0
+    t = 0.0
+    nstep = 0
+    frames = []
+    frame_t = []
+    snap_every = t_end / snapshots if snapshots else None
+    next_snap = 0.0
+
+    while t < t_end:
+        dt = min(timestep(h, qx, qy, dx, dy), t_end - t)
+        if dt <= 0:
+            break
+        # THE BALANCE IS MEASURED, NOT DIFFERENCED.
+        #
+        # In a conservative scheme every interior flux appears twice with
+        # opposite sign, so the mass the domain loses across one solver step IS
+        # what crossed its boundary, once the positivity clip is taken back out.
+        # Nothing needs instrumenting inside `sweep` for that.
+        #
+        # The earlier version differenced the requested inflow against what was
+        # standing at the end, which is not a balance at all when the inlet is a
+        # specified-depth boundary: that condition WRITES the depth rather than
+        # adding to it, so the mass it moves is whatever the interior left there,
+        # in either direction. It reported inflows of -779 Mm3 and outflows of
+        # 145% of input, both of which are the accounting and not the flow.
+        mass_before = float(h.sum())
+        h, qx, qy, clipped = step(h, qx, qy, z_filled, dx, dy, dt, manning)
+        volume_clipped += clipped * cell
+        volume_out += (mass_before - float(h.sum()) + clipped) * cell
+
+        if t <= rain_s:
+            h += dt * rain_rate
+            volume_in += dt * rain_rate * h.size * cell
+
+        t += dt
+        nstep += 1
+        wet = h > HMIN
+        newly = wet & np.isnan(arrival)
+        arrival[newly] = t
+        peak_h = np.maximum(peak_h, h)
+        peak_speed = np.maximum(
+            peak_speed, np.where(wet, np.hypot(qx, qy) / np.maximum(h, HMIN), 0.0))
+
+        if snap_every and t >= next_snap:
+            frames.append(h.astype(np.float32))
+            frame_t.append(t)
+            next_snap += snap_every
+        if progress and nstep % 500 == 0:
+            progress(f"routing: t={t / 60:.0f} of {minutes:.0f} min")
+
+    stored = float(h.sum()) * cell
+    return {
+        "peak_depth_m": peak_h,
+        "peak_speed_ms": peak_speed,
+        "arrival_s": arrival,
+        "final_depth_m": h,
+        "frames": np.array(frames) if frames else np.zeros((0, ny, nx), np.float32),
+        "frame_times_s": np.array(frame_t),
+        "steps": nstep,
+        "volume_in_m3": volume_in,
+        "volume_stored_m3": stored,
+        # Measured across the boundary step by step, not differenced: in a
+        # conservative scheme the mass the domain loses over one step IS what
+        # crossed its edge, once the positivity clip is taken back out. A domain
+        # that stores everything it was given never reached an outlet, and its
+        # depths are a filling level rather than a routed wave.
+        "volume_out_m3": volume_out,
+        # What the positivity clip at the wetting front invented. Small on a
+        # healthy run, and the first place to look when the balance does not
+        # close. Reported because a balance that hides its own source term is
+        # not a balance.
+        "volume_clipped_m3": volume_clipped,
+    }
+
+
+def depth_rgba(depth, dmax, inside=None):
+    """Depth as an RGBA overlay: transparent where dry or outside the AOI.
+
+    The shallow end stays clearly blue rather than fading to white. A ramp that
+    starts near white disappears into pale terrain and the margin of the flood
+    reads as no flood at all, which is the one part of the extent a reader most
+    needs to see.
+    """
+    h, w = depth.shape
+    out = np.zeros((h, w, 4), np.uint8)
+    wet = depth > HMIN
+    if inside is not None:
+        wet &= inside
+    if not wet.any():
+        return out
+    f = np.clip(depth / max(dmax, 1e-6), 0.0, 1.0)
+    out[..., 0] = np.where(wet, (255 * (0.42 - 0.38 * f)).astype(np.uint8), 0)
+    out[..., 1] = np.where(wet, (255 * (0.68 - 0.47 * f)).astype(np.uint8), 0)
+    out[..., 2] = np.where(wet, (255 * (0.93 - 0.34 * f)).astype(np.uint8), 0)
+    out[..., 3] = np.where(wet, (90 + 165 * f).astype(np.uint8), 0)
+    return out

--- a/sidecar/terra/registry.py
+++ b/sidecar/terra/registry.py
@@ -33,6 +33,7 @@ ACTIONS: dict[str, str] = {
     'domain_shift_cohort': 'terra.landcover.actions:domain_shift_cohort',
     'water': 'terra.water.actions:water',
     'flood_envelope': 'terra.flood.actions:flood_envelope',
+    'flood_routing': 'terra.flood.actions:flood_routing',
     'solar_resource': 'terra.energy.actions:solar_resource',
     'solar_terrain': 'terra.energy.actions:solar_terrain',
     'solar_siting': 'terra.energy.actions:solar_siting',

--- a/sidecar/tests/test_flood_routing.py
+++ b/sidecar/tests/test_flood_routing.py
@@ -1,0 +1,103 @@
+"""
+The overland routing solver, checked against what it is supposed to conserve.
+
+Every test here is a property the scheme must have rather than a number it once
+produced, because the defects this module was written around are all silent: the
+run completes, the depths look plausible, and they are wrong. Water trapped in
+unfilled sinks, a domain that never drains, and a boundary that supplies water
+from nothing are each checked directly, since all three shipped in a prototype
+and none announced itself.
+
+The breach mode these tests once covered is gone, and so are its tests. What is
+left needs no inlet, which is exactly why it is what is left.
+"""
+
+import numpy as np
+import pytest
+
+from terra.flood import routing
+from terra.terrain import hand
+
+DX = DY = 30.0
+
+
+def valley(ny=120, nx=60, sink=True):
+    """A V-shaped valley falling north to south, optionally with a false sink.
+
+    The sink is what a resampled 30 m DEM leaves in a channel: not topography,
+    sampling. It is dug deep enough that a solver taking it literally cannot
+    hide the fact.
+    """
+    y, x = np.mgrid[0:ny, 0:nx]
+    z = 1000.0 - 3.0 * y + 0.9 * np.abs(x - nx // 2) ** 1.6
+    if sink:
+        z[ny // 2:ny // 2 + 4, nx // 2 - 1:nx // 2 + 2] -= 25.0
+    return z
+
+
+def terrain(z):
+    """The filled surface, which is all the router needs now."""
+    return hand.fill_depressions(z)
+
+
+def test_a_motionless_lake_over_irregular_bed_stays_motionless():
+    zf = terrain(valley())
+    assert routing.lake_at_rest_residual(zf, DX, DY) < 1e-8
+
+
+def test_the_mass_balance_closes_on_every_term_it_reports():
+    """in + clip = stored + out, to machine noise.
+
+    Not `in - stored == out`, which is what this was and which is not a balance:
+    the positivity clip at the wetting front creates mass, and differencing it
+    away hides a source term. Every term is measured and every term is
+    asserted, so a change that quietly leaks mass has nowhere to hide it.
+    """
+    zf = terrain(valley())
+    out = routing.route(zf, DX, DY, minutes=30, rain_mm_h=120.0, rain_minutes=10.0)
+    residual = (
+        out["volume_in_m3"]
+        + out["volume_clipped_m3"]
+        - out["volume_stored_m3"]
+        - out["volume_out_m3"]
+    )
+    assert abs(residual) < 1e-9 * max(out["volume_in_m3"], 1.0), (
+        f"{residual} m3 unaccounted")
+
+
+def test_the_domain_drains_rather_than_filling_like_a_tank():
+    """A real share of the rain must reach a boundary and leave.
+
+    The failure this guards produced exactly zero: a torus, then a wall on the
+    edge the water wanted, then a ghost cell feeding the domain instead of
+    draining it. The measured symptom each time was the whole input still
+    standing after hours, with depths that are a filling level and not a flow.
+
+    The bar is a fifth rather than a half. Rain is not a breach wave: it wets
+    every cell at once, most of it moves slowly over ground that is not a
+    channel, and there is no infiltration in this model to take it away. About
+    37% leaves in 40 minutes on this valley, so a fifth clears the defect by a
+    wide margin without asserting a drainage rate the physics does not promise.
+    """
+    zf = terrain(valley())
+    out = routing.route(zf, DX, DY, minutes=40, rain_mm_h=120.0, rain_minutes=20.0)
+    assert out["volume_out_m3"] > 0.2 * out["volume_in_m3"]
+
+
+def test_an_unfilled_bed_traps_the_water_the_filled_one_carries_through():
+    # Not a check on the solver but on what it is given. Routing over the raw
+    # surface is the defect; the assertion is that it is a defect, so that the
+    # filling in the action cannot be dropped without a test noticing.
+    z = valley(sink=True)
+    zf = terrain(z)
+    kw = dict(minutes=40, rain_mm_h=150.0, rain_minutes=20.0)
+    filled = routing.route(zf, DX, DY, **kw)
+    raw = routing.route(z, DX, DY, **kw)
+    assert raw["volume_stored_m3"] > filled["volume_stored_m3"]
+
+
+def test_rain_on_the_grid_wets_ground_without_any_inlet():
+    zf = terrain(valley())
+    out = routing.route(zf, DX, DY, minutes=20, rain_mm_h=120.0, rain_minutes=10.0)
+    assert (out["peak_depth_m"] > 0.05).sum() > 0
+


### PR DESCRIPTION
5 commits, 21 files, +2,084 / -76. Stacked on #72 — it targets that branch, and
GitHub retargets it to `main` when #72 merges.

## What it adds

Rainfall routed over an area's terrain, reported as depth, speed and arrival
time. The contract is read off a recorded payload rather than described twice:
`types_flood_routing.go`, `flood_routing.json` as testdata, and
`sidecar/terra/flood/routing.py` behind the same subprocess boundary every
other product uses.

A routing board in the studio — its own workspace preset rather than a type
swapped into Simulation, because a routed flood wants the map wide and its
parameters in a column beside it, which is the opposite proportion to the
canopy's.

`Head` and `Choice` leave `BoardRunGraph` for `nodeCard.tsx`, since a second
surface needed them and a header that exists twice is a header that can
disagree with itself.

## Rebased onto #72

These were parallel to that branch, not on top of it. The rebase resolved six
conflicts, and three of them were not what the merge preview suggested:

- `MapScreen.tsx` was deleted there. Its change — passing `onImportPolygon` to
  `BoardSurface` — moved to `StudioScreen`. Analysis said this could be dropped
  because the prop was already passed; `tsc` showed that occurrence was the run
  band, not the surface. Resolved by inspection alone, this would have lost the
  handler in silence.
- `nodeCard.tsx` and `FloodRoutingPanel.tsx` imported Lucide, which #72
  uninstalls. All five icons exist under the same names in Phosphor;
  `strokeWidth` goes, since Phosphor draws with fill.
- The generated Wails bindings took a union. The first attempt displaced the
  brace closing `AnalyzeGridFigure`, which `tsc` cannot see in a `.js` — only
  `vite build` caught it.

The extraction commit had also left a nine-line docblock behind describing a
`Head` no longer in the file; it went with the function.

## Verification

`tsc`, 312 tests, `npm run build`, `check:contrast`, `check:types`,
`check:cursors`, `gofmt`, `go vet`, `go test ./internal/analysis/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)