### PR TITLE
fix: persistence and studio boundaries

### DIFF
--- a/app.go
+++ b/app.go
@@ -210,6 +210,12 @@ func (a *App) startup(ctx context.Context) {
 	a.mu.Unlock()
 	a.bootLog("store ready")
 
+	// The environments built before the build path started marking them. One
+	// system call, and the alternative is that the largest thing this
+	// application writes goes on being copied to every backup forever. See
+	// pyenv.EnsureExcludedFromBackup.
+	pyenv.EnsureExcludedFromBackup(st.DataDir())
+
 	cfg := pyenv.LoadAppConfig(st.DataDir())
 	a.bootLog("resolving sidecar paths…")
 	runner, err := analysis.NewRunner(appDir, cfg.PythonPath)

--- a/app_analysis.go
+++ b/app_analysis.go
@@ -30,7 +30,7 @@ func (a *App) Predict(req analysis.PredictRequest) (*analysis.PredictResult, err
 	// Set after persisting, so the stored copy -- marshalled inside -- does not
 	// carry a run's own id inside its own row. The frontend needs it to attach
 	// compositions made while this run is on screen.
-	res.RunID = a.persistRunIfLoggedIn(req, res)
+	res.RunID = a.persistAnalysis(req, res)
 	return res, nil
 }
 
@@ -281,8 +281,24 @@ func (a *App) AnalyzeSolarTerrain(req analysis.SolarTerrainRequest) (*analysis.S
 	if err != nil {
 		return nil, err
 	}
+	/*
+		The rendering is withheld from the payload that reaches the database.
+
+		persistSolarRaster writes the PNG into the run's asset directory and
+		LoadAnalysis reads it back from there, so a data URI left on the stored
+		copy is the same image held twice -- once as base64 inside result_json
+		and once as the file that base64 was decoded into. The classification
+		and flood paths already withhold theirs and say so; these two did not,
+		and on one installation the rows they wrote carried 512 KB of base64
+		duplicating 452 KB of PNG already on disk.
+
+		A copy rather than clearing the field on res: res is what the frontend
+		is about to draw, and it needs the URI.
+	*/
+	stored := *res
+	stored.OverlayURI = ""
 	res.RunID = a.persistSolarRaster(req.PolygonGeoJSON, req.Label,
-		req.RunLabel, req.ProjectID, req.AreaID, "solar_terrain", res.Season, res,
+		req.RunLabel, req.ProjectID, req.AreaID, "solar_terrain", res.Season, &stored,
 		res.OverlayURI, res.NDates())
 	return res, nil
 }
@@ -297,8 +313,11 @@ func (a *App) AnalyzeSolarSiting(req analysis.SolarSitingRequest) (*analysis.Sol
 	if err != nil {
 		return nil, err
 	}
+	// Withheld from the stored copy for the reason AnalyzeSolarTerrain states.
+	stored := *res
+	stored.OverlayURI = ""
 	res.RunID = a.persistSolarRaster(req.PolygonGeoJSON, req.Label,
-		req.RunLabel, req.ProjectID, req.AreaID, "solar_siting", "siting", res,
+		req.RunLabel, req.ProjectID, req.AreaID, "solar_siting", "siting", &stored,
 		res.OverlayURI, 0)
 	return res, nil
 }

--- a/app_run_overlay_test.go
+++ b/app_run_overlay_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"geosense-infer/internal/analysis"
+	"geosense-infer/internal/store"
+)
+
+/*
+Every product that writes a raster records which one it is.
+
+The column exists to answer "which of this run's files is the image to show",
+and it was answered by two products out of five: water and the two solar
+rasters wrote a PNG and left the column NULL, so a reader of it would have been
+right for a fifth of the table and silently wrong for the rest. That is why no
+reader was ever written, and why the run list loads a whole result to reach an
+image already sitting on disk.
+
+Asserted by walking the run's asset directory rather than by naming the file
+each product writes. A test that repeated those names would agree with itself
+and not with the code; this one fails as soon as a product writes an image and
+does not say so, including a product that does not exist yet.
+*/
+func TestEveryRasterRunRecordsItsOverlay(t *testing.T) {
+	cases := []struct {
+		name    string
+		persist func(a *App) string
+	}{
+		{
+			name: "water",
+			persist: func(a *App) string {
+				return a.persistWaterRun(
+					analysis.WaterRequest{Label: "AOI"},
+					&analysis.WaterAnalysis{OccurrenceURI: onePixelPNG},
+				)
+			},
+		},
+		{
+			name: "solar terrain",
+			persist: func(a *App) string {
+				res := &analysis.SolarTerrainAnalysis{OverlayURI: onePixelPNG}
+				stored := *res
+				stored.OverlayURI = ""
+				return a.persistSolarRaster(nil, "AOI", "", "", "",
+					"solar_terrain", "annual", &stored, res.OverlayURI, 0)
+			},
+		},
+		{
+			name: "solar siting",
+			persist: func(a *App) string {
+				res := &analysis.SolarSitingAnalysis{OverlayURI: onePixelPNG}
+				stored := *res
+				stored.OverlayURI = ""
+				return a.persistSolarRaster(nil, "AOI", "", "", "",
+					"solar_siting", "siting", &stored, res.OverlayURI, 0)
+			},
+		},
+		{
+			name: "classification",
+			persist: func(a *App) string {
+				return a.persistAnalysis(
+					analysis.PredictRequest{Label: "AOI"},
+					&analysis.PredictResult{OverlayURI: onePixelPNG},
+				)
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			a := newTestApp(t)
+			runID := c.persist(a)
+			if runID == "" {
+				t.Fatal("nothing was saved")
+			}
+			run, err := a.store.GetRun(store.LocalUserID, runID)
+			if err != nil {
+				t.Fatalf("get run: %v", err)
+			}
+
+			images := imagesUnder(t, a.store.RunsDir(runID))
+			if len(images) == 0 {
+				t.Fatal("the product wrote no image, so this case proves nothing")
+			}
+			if run.OverlayRelPath == "" {
+				t.Fatalf("wrote %v and recorded no overlay path", images)
+			}
+			// The path is relative to the data directory, and it has to name a
+			// file that is actually there: a column pointing into a directory
+			// that does not exist is the shape saveRun already refuses to
+			// write for the assets as a whole.
+			full := filepath.Join(a.store.DataDir(), run.OverlayRelPath)
+			if _, err := os.Stat(full); err != nil {
+				t.Errorf("overlay path %q names no file: %v", run.OverlayRelPath, err)
+			}
+		})
+	}
+}
+
+// A product whose whole result is figures records no overlay, and the empty
+// column is the right answer rather than an omission.
+func TestFigureOnlyRunRecordsNoOverlay(t *testing.T) {
+	a := newTestApp(t)
+	runID := a.persistSolarRun(
+		analysis.SolarRequest{Label: "AOI"},
+		&analysis.SolarAnalysis{},
+	)
+	if runID == "" {
+		t.Fatal("nothing was saved")
+	}
+	run, err := a.store.GetRun(store.LocalUserID, runID)
+	if err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if run.OverlayRelPath != "" {
+		t.Errorf("overlay path = %q for a run that wrote no raster", run.OverlayRelPath)
+	}
+	if images := imagesUnder(t, a.store.RunsDir(runID)); len(images) != 0 {
+		t.Errorf("expected no images, found %v", images)
+	}
+}
+
+func imagesUnder(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".png") {
+			out = append(out, e.Name())
+		}
+	}
+	return out
+}

--- a/app_runs.go
+++ b/app_runs.go
@@ -67,8 +67,24 @@ type savedRun struct {
 	*/
 	result func(assetsDir, assetsRel string) any
 
-	// The file in that directory the run list paints its thumbnail from, for
-	// the products that write one.
+	/*
+		Which of the run's files is the one to show, for the products that
+		write one.
+
+		EVERY PRODUCT THAT WRITES A RASTER SETS THIS, and the completeness is
+		the point rather than a tidiness. Only the classification and the flood
+		envelope did: water and the two solar rasters wrote a PNG and recorded
+		no path to it, so the column was right for 5 rows out of 40 on one
+		installation. Nothing reads it today, and that is downstream of the
+		same fact -- a reader of a column that is right for an eighth of the
+		table is a reader that is wrong for the rest, so the run list loads a
+		whole result to find an image it already has on disk, and the studio
+		browser draws a colour instead of a thumbnail rather than pay for that.
+		Filling it is what makes a cheap reader possible; TestEveryRasterRunRecordsItsOverlay
+		is what keeps it true.
+
+		Empty is a real answer, for the products whose whole result is figures.
+	*/
 	overlayFile string
 }
 
@@ -231,14 +247,21 @@ func (a *App) persistWaterRun(req analysis.WaterRequest, res *analysis.WaterAnal
 		},
 		result: func(assetsDir, _ string) any {
 			_ = store.WriteDataURIFile(
-				res.OccurrenceURI, filepath.Join(assetsDir, "water_occurrence.png"))
+				res.OccurrenceURI, filepath.Join(assetsDir, waterOccurrencePNG))
 			// Store without the bulky data URI; the asset is restored on load.
 			stored := *res
 			stored.OccurrenceURI = ""
 			return stored
 		},
+		// The one image this product has, so the column that names a run's
+		// representative raster names it. See savedRun.overlayFile.
+		overlayFile: waterOccurrencePNG,
 	})
 }
+
+// waterOccurrencePNG is the occurrence raster's name inside a run's asset
+// directory, written here and read back by LoadAnalysis.
+const waterOccurrencePNG = "water_occurrence.png"
 
 // persistSolarRun saves a solar resource run so it survives the session and is
 // listed, opened and exported like the other analyses. Returns the row it
@@ -283,6 +306,9 @@ func (a *App) persistSolarRaster(
 		return ""
 	}
 	l := aoiLabel(label)
+	// One name for the rendering: the file written below, and the column that
+	// says which of a run's files is the one to show.
+	overlay := kindTag + ".png"
 	return a.saveRun(savedRun{
 		kind:      store.RunKindSolar,
 		modelKind: "NASA POWER",
@@ -298,9 +324,10 @@ func (a *App) persistSolarRaster(
 			"aoi_label":     l,
 		},
 		result: func(assetsDir, _ string) any {
-			_ = store.WriteDataURIFile(overlayURI, filepath.Join(assetsDir, kindTag+".png"))
+			_ = store.WriteDataURIFile(overlayURI, filepath.Join(assetsDir, overlay))
 			return payload
 		},
+		overlayFile: overlay,
 	})
 }
 
@@ -515,12 +542,6 @@ func (a *App) persistFloodRun(req analysis.FloodRequest, res *analysis.FloodAnal
 		// the one image this product has.
 		overlayFile: overlay,
 	})
-}
-
-// persistRunIfLoggedIn saves the run and returns its id, so the caller can tell
-// the frontend which run it is now looking at. Empty when nothing was saved.
-func (a *App) persistRunIfLoggedIn(req analysis.PredictRequest, res *analysis.PredictResult) string {
-	return a.persistAnalysis(req, res)
 }
 
 func (a *App) persistAnalysis(req analysis.PredictRequest, res *analysis.PredictResult) string {

--- a/frontend/node_modules
+++ b/frontend/node_modules
@@ -1,1 +1,0 @@
-/Users/fox/estudos/UTFPr/geosense/geosense-infer/frontend/node_modules

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,10 +9,12 @@ import {
 import { setStudioGutter } from "@/lib/studioGutter"
 import { notifyError, notifyInfo, notifySuccess } from "@/lib/notify"
 import type { Studio } from "@/lib/studios"
-import { listStudios, openStudio } from "@/lib/studios"
+import { listStudios, openStudio, saveStudio } from "@/lib/studios"
 import {
   clearBoardMemory,
+  readBoardMemory,
   restoreBoard,
+  snapshotBoard,
   writeBoardMemory,
 } from "@/components/studio/boardMemory"
 import { useTheme } from "next-themes"
@@ -2937,26 +2939,63 @@ function AppBody(props: {
    * `clearBoardMemory` runs first, because openInStudio writes pendingRunIds
    * into that same store and a clear afterwards would take them with it.
    */
-  const handleNewStudio = useCallback(() => {
-    clearBoardMemory()
-    props.clearRetainedRuns()
-    // Not a move from one ground to another either. See handleOpenStudio.
-    leavingRef.current = { id: undefined, result: null }
-    clearAnalysisResults()
-    clearAreaAndComposition()
-    props.setShowPredictionOverlay(true)
-    props.setSwipeCompare(false)
-    props.setSwipeRatio(0.5)
-    openInStudio([])
-  }, [
-    openInStudio,
-    clearAnalysisResults,
-    clearAreaAndComposition,
-    props.clearRetainedRuns,
-    props.setShowPredictionOverlay,
-    props.setSwipeCompare,
-    props.setSwipeRatio,
-  ])
+  const handleNewStudio = useCallback(
+    async (name: string) => {
+      clearBoardMemory()
+      props.clearRetainedRuns()
+      // Not a move from one ground to another either. See handleOpenStudio.
+      leavingRef.current = { id: undefined, result: null }
+      clearAnalysisResults()
+      clearAreaAndComposition()
+      props.setShowPredictionOverlay(true)
+      props.setSwipeCompare(false)
+      props.setSwipeRatio(0.5)
+      /*
+        WRITTEN NOW, EMPTY, RATHER THAN AT THE FIRST SAVE.
+
+        A studio that exists only in the board's memory has no name to lend,
+        and the ground drawn under it therefore took the store's provisional
+        one -- "drawn 2" -- which then became the label of the run made over
+        it. Both were written before the studio had a name of its own, and
+        neither is revisited when it gets one.
+
+        The row is created here so the name exists first. It costs a studio
+        with no members, which the store already permits: SaveStudio requires a
+        name and does not require an arrangement, because an arrangement is
+        what a studio accumulates rather than what makes it one.
+
+        Best effort. If the write fails the board is still cleared and still
+        usable; what is lost is the binding, so the next save creates the
+        studio instead of updating it -- which is exactly the behaviour this
+        replaces.
+      */
+      try {
+        const board = await saveStudio(
+          name,
+          snapshotBoard([]),
+          undefined,
+          activeProjectId
+        )
+        writeBoardMemory("savedId", board.id)
+        writeBoardMemory("savedName", board.name)
+        void refreshStudios()
+      } catch (e) {
+        notifyError("Could not start the studio", e)
+      }
+      openInStudio([])
+    },
+    [
+      openInStudio,
+      clearAnalysisResults,
+      clearAreaAndComposition,
+      activeProjectId,
+      refreshStudios,
+      props.clearRetainedRuns,
+      props.setShowPredictionOverlay,
+      props.setSwipeCompare,
+      props.setSwipeRatio,
+    ]
+  )
 
   const areaLabel = useMemo(() => {
     if (props.analysisLabel) return props.analysisLabel
@@ -3133,7 +3172,25 @@ function AppBody(props: {
         looking at a map that is waiting for them, not at half a result.
       */
       props.setCustomPolygon(geom)
-      void createArea(geom).then((entry) => {
+      /*
+        THE STUDIO IS THE STEM, WHEN THERE IS ONE.
+
+        Without it the store mints "drawn", "drawn 2", and that name becomes
+        the label of the run made over the ground -- so a studio called "Serra
+        do mel" ended up holding a run called run-drawn-2, named after nothing
+        a reader chose. The name is available here because a studio is now
+        named when it begins rather than when it is first saved; see
+        handleNewStudio. The store numbers the stem, so two grounds drawn under
+        one studio do not arrive with one name between them.
+
+        Empty when the board is not bound to a studio -- an area drawn from the
+        map with no studio open -- and then the sequence is the one it has
+        always been.
+      */
+      void createArea(
+        geom,
+        readBoardMemory<string | null>("savedName", null) ?? undefined
+      ).then((entry) => {
         if (entry) return
         lastDrawnRef.current = null
         props.setCustomPolygon(null)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1052,53 +1052,6 @@ function AppBody(props: {
     [goStudio]
   )
 
-  const handleOpenStudio = useCallback(
-    async (board: Studio) => {
-      try {
-        const opened = await openStudio(board.id)
-        if (!opened.snapshot) {
-          notifyError(
-            "Could not read this studio",
-            new Error("its arrangement is unreadable")
-          )
-          return
-        }
-        restoreBoard(opened.snapshot)
-        /*
-          The map's retained runs go with it. A stored board is the runs it was
-          saved with; anything the map happened to be holding is not one of
-          them, and `assetRuns` would add it as an area of this board.
-        */
-        props.clearRetainedRuns()
-        /*
-          The rasters are fetched by the board itself, where LoadAnalysis
-          already lives. Members whose run has been deleted are left out with
-          a word rather than silently: a board that opened with one side
-          missing and said nothing would look like it had been built that way.
-        */
-        const wanted = opened.snapshot.runIds.filter(
-          (id) => !opened.missingRunIds.includes(id)
-        )
-        writeBoardMemory("savedId", board.id)
-        writeBoardMemory("savedName", board.name)
-        if (opened.missingRunIds.length) {
-          notifyInfo(
-            `${opened.missingRunIds.length} run(s) in this studio no longer exist.`
-          )
-        }
-        /*
-          No workspace: a saved board carries its own arrangement, which
-          `restoreBoard` has just put back. Asking for one here would replace
-          what the reader saved with a preset.
-        */
-        openInStudio(wanted)
-      } catch (e) {
-        notifyError("Could not open this studio", e)
-      }
-    },
-    [openInStudio, props.clearRetainedRuns]
-  )
-
   /**
    * Open settings at System when nothing can be computed.
    *
@@ -1126,6 +1079,18 @@ function AppBody(props: {
    * then went unreported for the rest of the session, which is precisely the
    * silence the gate exists to break.
    */
+  /*
+    The ground the map is leaving, and what was on it.
+
+    DECLARED HERE, ABOVE THE TWO HANDLERS THAT HAVE TO CLEAR IT. Its effect is
+    further down, beside the state it reads; this is only the cell. See
+    handleOpenStudio for what goes wrong when a studio switch reaches that
+    effect with the cell still full.
+  */
+  const leavingRef = useRef<{
+    id: string | undefined
+    result: PredictResult | null
+  }>({ id: undefined, result: null })
   const envGateDone = useRef(false)
   useEffect(() => {
     if (!user || envGateDone.current) return
@@ -1607,6 +1572,21 @@ function AppBody(props: {
               key: Date.now(),
             })
           }
+        } else if (userInitiated) {
+          /*
+            A PROJECT WITH NO GROUND YET OPENS ON NO GROUND.
+
+            The branch above replaces the drawing when the project being opened
+            has one to resume on, so the case that was never handled is the
+            project that has none: the previous project's outline stayed on the
+            map, over a field the opened project does not own, and a run made
+            there was filed against it. The clear above this only dropped the
+            catalogued id -- the shape itself was left drawn, which is the half
+            a reader can see.
+          */
+          props.setCustomPolygon(null)
+          props.setAnalysisLabel(undefined)
+          void persistAoiLabel(null)
         }
         const overlays = (await ListProjectOverlays(
           id
@@ -2805,6 +2785,122 @@ function AppBody(props: {
   ])
 
   /**
+   * Open a saved studio.
+   *
+   * MOVED HERE FROM ABOVE THE STATE IT NEEDS. It used to sit beside
+   * openInStudio, hundreds of lines before clearAnalysisResults and the
+   * composition are declared, which is why it could not do what
+   * handleNewStudio does -- naming any of them in its dependency list from up
+   * there is a reference before initialisation. Sitting next to its mirror is
+   * also where a reader compares the two, which is the comparison that was
+   * needed to find what follows.
+   */
+  const handleOpenStudio = useCallback(
+    async (board: Studio) => {
+      try {
+        const opened = await openStudio(board.id)
+        if (!opened.snapshot) {
+          notifyError(
+            "Could not read this studio",
+            new Error("its arrangement is unreadable")
+          )
+          return
+        }
+        restoreBoard(opened.snapshot)
+        /*
+          The map's retained runs go with it. A stored board is the runs it was
+          saved with; anything the map happened to be holding is not one of
+          them, and `assetRuns` would add it as an area of this board.
+        */
+        props.clearRetainedRuns()
+        /*
+          AND THE MAP'S OWN ANALYSIS, which this path was leaving behind.
+
+          handleNewStudio says why in full: a plane on the board comes from
+          three places and only two of them are the board's, the third being
+          whatever the map is showing right now. That fix was made for the new
+          studio and not for this one, so opening a saved studio kept the
+          previous studio's run on the map -- as the live area of the board
+          just opened, since liveRunId in StudioScreen resolves from these very
+          fields.
+
+          What that costs is not cosmetic. The live area is a member like any
+          other when the board is saved, so the studio being opened inherits
+          the run of the studio being left, and saving it writes that run into
+          its arrangement. One installation carried two studios saved two
+          minutes apart naming the same run, with no analysis having been made
+          between them, and the arrangement of the second holding a name for
+          the ground of a third.
+
+          THE AOI GOES TOO. Both of these paths used to keep it, on the
+          argument that an area belongs to the project rather than to the
+          board. The argument holds for the ownership and not for the drawing:
+          a reader who has just changed studios is not standing on the ground
+          they left, and the outline of it stays on the map saying they are.
+
+          It is not only an outline. The area carries the auto-name the store
+          minted for it -- "drawn", "drawn 2" -- and that name becomes the
+          label of the next run made over it, so the run made after a switch
+          was filed under the ground of the studio before it. That is visible
+          in an installation where a studio named "Sao gonçalo" holds a run
+          called run-drawn-2, which is the area of the studio saved two minutes
+          earlier.
+        */
+        /*
+          NOT A MOVE FROM ONE GROUND TO ANOTHER, so the run being left is not
+          kept in hand.
+
+          Clearing the area below moves activeAreaId, and an effect further
+          down retains whatever the map was showing whenever that id changes --
+          which put the run of the studio being left straight back onto the
+          board of the one being opened, as an area of its own, after every
+          clear above had already run. The board showed a studio named for one
+          ground holding the run of another, which is the defect these clears
+          exist to prevent, arriving one render later than they do.
+
+          Retention is the map's affordance: a ground the map moved on from
+          stays in hand so the board can still show it beside the new one.
+          Putting the board down is the opposite gesture, and clearRetainedRuns
+          above already says so.
+        */
+        leavingRef.current = { id: undefined, result: null }
+        clearAnalysisResults()
+        clearAreaAndComposition()
+        /*
+          The rasters are fetched by the board itself, where LoadAnalysis
+          already lives. Members whose run has been deleted are left out with
+          a word rather than silently: a board that opened with one side
+          missing and said nothing would look like it had been built that way.
+        */
+        const wanted = opened.snapshot.runIds.filter(
+          (id) => !opened.missingRunIds.includes(id)
+        )
+        writeBoardMemory("savedId", board.id)
+        writeBoardMemory("savedName", board.name)
+        if (opened.missingRunIds.length) {
+          notifyInfo(
+            `${opened.missingRunIds.length} run(s) in this studio no longer exist.`
+          )
+        }
+        /*
+          No workspace: a saved board carries its own arrangement, which
+          `restoreBoard` has just put back. Asking for one here would replace
+          what the reader saved with a preset.
+        */
+        openInStudio(wanted)
+      } catch (e) {
+        notifyError("Could not open this studio", e)
+      }
+    },
+    [
+      openInStudio,
+      clearAnalysisResults,
+      clearAreaAndComposition,
+      props.clearRetainedRuns,
+    ]
+  )
+
+  /**
    * An empty board, bound to no saved studio.
    *
    * The mirror of handleOpenStudio: that one restores an arrangement and writes
@@ -2826,10 +2922,17 @@ function AppBody(props: {
    * the result to retainRun on the way out. A retained run becomes an area of
    * the board, which is the thing being emptied.
    *
-   * The AOI stays. Areas belong to the project rather than to the board, and
-   * dropping them would take the ground out from under a studio that is meant
-   * to be built on it. The composition goes, since it would otherwise be the
-   * one plane left on an empty board.
+   * THE AOI GOES WITH IT, which reverses what this used to do. It kept the
+   * drawing on the argument that an area belongs to the project and not to the
+   * board -- true of the ownership, and not of what the map should be showing
+   * a reader who has just left one studio for another. See handleOpenStudio,
+   * where the same reversal is made and where the cost of the old behaviour is
+   * recorded: the kept area carries its "drawn N" name into the label of the
+   * next run, so a run made after a switch is filed under the previous
+   * studio's ground.
+   *
+   * The composition goes with it, since it would otherwise be the one plane
+   * left on an empty board.
    *
    * `clearBoardMemory` runs first, because openInStudio writes pendingRunIds
    * into that same store and a clear afterwards would take them with it.
@@ -2837,16 +2940,18 @@ function AppBody(props: {
   const handleNewStudio = useCallback(() => {
     clearBoardMemory()
     props.clearRetainedRuns()
+    // Not a move from one ground to another either. See handleOpenStudio.
+    leavingRef.current = { id: undefined, result: null }
     clearAnalysisResults()
+    clearAreaAndComposition()
     props.setShowPredictionOverlay(true)
     props.setSwipeCompare(false)
     props.setSwipeRatio(0.5)
-    setComposition(null)
-    setCompositionGallery([])
     openInStudio([])
   }, [
     openInStudio,
     clearAnalysisResults,
+    clearAreaAndComposition,
     props.clearRetainedRuns,
     props.setShowPredictionOverlay,
     props.setSwipeCompare,
@@ -3380,10 +3485,6 @@ function AppBody(props: {
     always holds the result as it was while the previous area was still the
     active one.
   */
-  const leavingRef = useRef<{
-    id: string | undefined
-    result: PredictResult | null
-  }>({ id: undefined, result: null })
   useEffect(() => {
     const leaving = leavingRef.current
     leavingRef.current = { id: props.activeAreaId, result: resultWithWater }

--- a/frontend/src/components/studio/BoardSurface.tsx
+++ b/frontend/src/components/studio/BoardSurface.tsx
@@ -1410,9 +1410,15 @@ export function BoardSurface({
           It said "run something", and a reader who had just applied a
           composition had. Then it named four products where five record a run,
           omitting wind. And it said "carries one yet", which is not the test:
-          the test is whether the store has a ROW, and a run made while signed
-          out has none -- so a reader with a finished analysis on screen was
-          told they had not made one.
+          the test is whether the store has a ROW.
+
+          A THIRD WORDING, and this one was wrong about the Go side. It told
+          the reader that a run made while signed out has no row "having
+          nowhere to write one". It has one: saveRun falls back to
+          store.LocalUserID when no user is held, and the store creates that
+          user during migration precisely so there is somewhere to write. The
+          sentence sent a reader looking for a sign-in that would not have
+          changed the outcome.
 
           It said "run something", and a reader who had just applied a
           composition had. A composition is not a run and never becomes one:
@@ -1427,7 +1433,7 @@ export function BoardSurface({
         notifyError(
           "Nothing for a studio to record",
           new Error(
-            "a studio is the runs arranged in it, and none of these areas carries one the store has a row for. A composition is not a run -- it is saved with the project and comes back with it. A run made while signed out has no row either, having nowhere to write one. So run a classification, water, solar, wind or flood analysis here while signed in, or add an existing run from the outliner, and the studio will have something to arrange"
+            "a studio is the runs arranged in it, and none of these areas carries one the store has a row for. A composition is not a run -- it is saved with the project and comes back with it. So run a classification, water, solar, wind or flood analysis here, or add an existing run from the outliner, and the studio will have something to arrange"
           )
         )
         return

--- a/frontend/src/components/studio/BoardSurface.tsx
+++ b/frontend/src/components/studio/BoardSurface.tsx
@@ -629,7 +629,7 @@ export function BoardSurface({
    * off the current one by hand, and that leaves it still bound to the saved
    * id, so the next save wrote over the studio it started from.
    */
-  onNewStudio?: () => void
+  onNewStudio?: (name: string) => void
   /** Refreshes the list as the menu opens, so it is not a stale catalog. */
   onStudiosMenu?: () => void | Promise<void>
   /**
@@ -1227,6 +1227,16 @@ export function BoardSurface({
     })
   }, [])
   const [naming, setNaming] = useState<string | null>(null)
+  /*
+    Which of the two things the name box is being used for.
+
+    "save" is what it has always done: name the arrangement that is on the
+    board. "new" names a studio that does not exist yet -- see newBoard, where
+    the reason for asking first is set out. One box for both, because the
+    question it asks is the same question and a second box would be the second
+    way of asking that this file argues against elsewhere.
+  */
+  const [namingFor, setNamingFor] = useState<"save" | "new">("save")
   const [saving, setSaving] = useState(false)
   /** Whether the title block's catalog is open. */
   const [boardMenu, setBoardMenu] = useState(false)
@@ -1262,9 +1272,27 @@ export function BoardSurface({
     dialog for it would be the second way of asking that ConfirmDelete's own
     docblock argues against.
   */
+  /*
+    A STUDIO IS NAMED WHEN IT BEGINS, NOT WHEN IT IS FIRST SAVED.
+
+    It used to be the other way round, and the cost was not the naming. A
+    studio with no name has nothing to lend to the ground drawn under it, so an
+    area drawn inside a new studio took the store's provisional "drawn N" and
+    the run made over it was labelled run-drawn-N. The studio then got its real
+    name minutes later, at save, by which point the area and the run carrying
+    the wrong one were already written and nothing goes back to correct them.
+
+    Asked here, the name exists before the first drawing does, and createArea
+    is handed it as the stem.
+  */
   const newBoard = () => {
     if (boardIsDirty()) setPendingOpen("new")
-    else onNewStudio?.()
+    else beginNewStudio()
+  }
+
+  const beginNewStudio = () => {
+    setNamingFor("new")
+    setNaming("")
   }
 
   /*
@@ -1321,6 +1349,19 @@ export function BoardSurface({
     // change to `runs` would fetch nothing and cost a pass over the array.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  // The name box answers to whichever question it was opened with.
+  const confirmName = async (name: string) => {
+    const trimmed = name.trim()
+    if (!trimmed) return
+    if (namingFor === "new") {
+      setNaming(null)
+      setNamingFor("save")
+      onNewStudio?.(trimmed)
+      return
+    }
+    await doSave(name)
+  }
 
   const doSave = async (name: string) => {
     const trimmed = name.trim()
@@ -4885,7 +4926,7 @@ export function BoardSurface({
           onConfirm={() => {
             const board = pendingOpen
             setPendingOpen(null)
-            if (board === "new") onNewStudio?.()
+            if (board === "new") beginNewStudio()
             else onOpenStudio?.(board)
           }}
         />
@@ -5342,6 +5383,7 @@ export function BoardSurface({
               label={savedName ? "Save under another name…" : "Save studio…"}
               onSelect={() => {
                 setBoardMenu(false)
+                setNamingFor("save")
                 setNaming(savedName ?? "")
               }}
             />
@@ -5372,7 +5414,9 @@ export function BoardSurface({
             <button
               type="button"
               onClick={() =>
-                savedName ? void doSave(savedName) : setNaming("")
+                savedName
+                  ? void doSave(savedName)
+                  : (setNamingFor("save"), setNaming(""))
               }
               disabled={saving || loadingRun}
               title={
@@ -5391,14 +5435,16 @@ export function BoardSurface({
             <input
               autoFocus
               value={naming}
-              placeholder="Name this studio"
+              placeholder={
+                namingFor === "new" ? "Name the new studio" : "Name this studio"
+              }
               onChange={(e) => setNaming(e.target.value)}
               onBlur={() => setNaming(null)}
               onKeyDown={(e) => {
                 // Escape closes the board from a listener on the window, so a
                 // name abandoned here must not leave the board with it.
                 e.stopPropagation()
-                if (e.key === "Enter") void doSave(naming)
+                if (e.key === "Enter") void confirmName(naming)
                 else if (e.key === "Escape") setNaming(null)
               }}
               className="app-no-drag h-7 w-48 shrink-0 rounded-sm border-0 bg-sunk px-2 text-meta text-foreground outline-none inset-ring-1 inset-ring-ring"

--- a/frontend/src/lib/studios.ts
+++ b/frontend/src/lib/studios.ts
@@ -88,13 +88,21 @@ export async function saveStudio(
     updated_at: "",
     view_json: JSON.stringify(snapshot),
     member_count: snapshot.runIds.length,
+    /*
+      A member is the run and its place, and nothing else.
+
+      It also carried `name` and `state_json`, sent as "" and "{}" from here
+      every time: the name given on the board and the placement of its planes
+      live in the snapshot above, keyed `stack::<runId>`, which is where the
+      board reads them from when it reopens. The two constants were a second
+      place for the same thing that never held it, and the columns behind them
+      are gone.
+    */
     members: snapshot.runIds.map((runId, i) => ({
       id: "",
       studio_id: id ?? "",
       run_id: runId,
       position: i,
-      name: "",
-      state_json: "{}",
     })),
   }
   return (await SaveStudio(payload as never)) as unknown as Studio

--- a/frontend/src/pages/StudioScreen.tsx
+++ b/frontend/src/pages/StudioScreen.tsx
@@ -230,7 +230,7 @@ export interface StudioScreenProps {
   /** Saved studios, for the studio's own title block. */
   studios?: import("@/lib/studios").Studio[];
   onOpenStudio?: (board: import("@/lib/studios").Studio) => void;
-  onNewStudio?: () => void;
+  onNewStudio?: (name: string) => void;
   /** Called when the studio's board menu opens, to refresh the list. */
   /*
     Returns its promise, so a caller that needs the list BEFORE it draws again

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -7438,8 +7438,6 @@ export namespace store {
 	    studio_id: string;
 	    run_id: string;
 	    position: number;
-	    name?: string;
-	    state_json?: string;
 	    missing?: boolean;
 	
 	    static createFrom(source: any = {}) {
@@ -7452,8 +7450,6 @@ export namespace store {
 	        this.studio_id = source["studio_id"];
 	        this.run_id = source["run_id"];
 	        this.position = source["position"];
-	        this.name = source["name"];
-	        this.state_json = source["state_json"];
 	        this.missing = source["missing"];
 	    }
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/wailsapp/wails/v2 v2.13.0
 	golang.org/x/crypto v0.55.0
+	golang.org/x/sys v0.47.0
 	modernc.org/sqlite v1.34.5
 )
 
@@ -37,7 +38,6 @@ require (
 	github.com/wailsapp/go-webview2 v1.0.22 // indirect
 	github.com/wailsapp/mimetype v1.4.1 // indirect
 	golang.org/x/net v0.58.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
 	modernc.org/libc v1.55.3 // indirect
 	modernc.org/mathutil v1.6.0 // indirect

--- a/internal/pyenv/backupexclude_darwin.go
+++ b/internal/pyenv/backupexclude_darwin.go
@@ -1,0 +1,85 @@
+//go:build darwin
+
+package pyenv
+
+import (
+	"encoding/hex"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+/*
+The bytes macOS writes to mark an item excluded from Time Machine.
+
+A binary property list holding the single string "com.apple.backupd", which is
+what NSURLIsExcludedFromBackupKey and `tmutil addexclusion` both leave behind.
+Read back from a directory excluded with that command and reproduced verbatim,
+because the value is a constant: encoding one constant through a plist writer
+would be more code and more ways to be wrong.
+
+AS HEX, AND THE FIRST ATTEMPT SHOWS WHY. Written out as a byte array by hand it
+came to 60 bytes against the 61 macOS writes -- a plist trailer is 32 bytes and
+that one had 31, miscounted in the run of zeros. tmutil still reported the
+directory excluded, so the error would have shipped. A hex string is checkable
+against `xattr -px` by looking at it, which is how the two are kept the same.
+*/
+const backupExcludeHex = "62706c69737430305f1011636f6d2e6170706c652e6261636b7570" +
+	"6408000000000000010100000000000000010000000000000000000000000000001c"
+
+// Decoded once. A constant that cannot be decoded is a programming error and
+// there is no run-time answer to it, so this is the one place a panic is the
+// honest report -- it fires on the first build that changes the string.
+var backupExcludeValue = mustDecodeHex(backupExcludeHex)
+
+func mustDecodeHex(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic("pyenv: backup exclusion value is not hex: " + err.Error())
+	}
+	return b
+}
+
+const backupExcludeAttr = "com.apple.metadata:com_apple_backup_excludeItem"
+
+/*
+excludeFromBackup marks a path as not worth copying to Time Machine.
+
+Apple's guidance is not a preference here: "Any file that can be re-created or
+downloaded must be excluded from the backup." This environment is rebuilt from
+the requirements manifest the binary embeds, and it was measured at 1.9 GB on
+one installation -- copied in full to every backup, of a thing the application
+can make again from a text file.
+
+The environment stays in Application Support rather than moving to Caches,
+which would exclude it as a side effect. Apple's own description of Caches is
+that an app "should never rely on the existence of cache files", and every
+analysis this program runs relies on this one; a purge under disk pressure
+would leave a working installation unable to run anything until it rebuilt over
+the network. Excluding it from backup is the part of the cache treatment that
+applies; being discardable is the part that does not.
+*/
+func excludeFromBackup(path string) error {
+	return unix.Setxattr(path, backupExcludeAttr, backupExcludeValue, 0)
+}
+
+/*
+EnsureExcludedFromBackup marks an environment that is already on disk.
+
+The build path marks what it creates, which covers every environment made from
+here on and none of the ones already built -- and those are the large ones, the
+ones that have been copied to every backup since they were made. Called at
+startup, where it is one system call against a directory that is usually
+already marked.
+
+Silent on failure and on absence. There is nothing for the user to do about
+either, and an installation with no managed environment is the normal state for
+someone running against their own interpreter.
+*/
+func EnsureExcludedFromBackup(dataDir string) {
+	dir := ManagedEnvDir(dataDir)
+	if _, err := os.Stat(dir); err != nil {
+		return
+	}
+	_ = excludeFromBackup(dir)
+}

--- a/internal/pyenv/backupexclude_darwin_test.go
+++ b/internal/pyenv/backupexclude_darwin_test.go
@@ -1,0 +1,79 @@
+//go:build darwin
+
+package pyenv
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+/*
+What this application writes is byte for byte what macOS writes.
+
+The value is a binary plist copied out of a directory excluded with
+`tmutil addexclusion`, and the first version of it was one byte short of the
+real thing -- a 31-byte trailer where the format has 32. tmutil reported that
+directory excluded anyway, so a functional check alone would have passed the
+defect through. The comparison is against the bytes, and tmutil's verdict is
+kept beside it because agreeing with the format and being honoured by the tool
+are two claims.
+*/
+func TestBackupExclusionMatchesWhatTmutilWrites(t *testing.T) {
+	if _, err := exec.LookPath("tmutil"); err != nil {
+		t.Skip("tmutil is not available")
+	}
+	dir := t.TempDir()
+
+	ours := filepath.Join(dir, "ours")
+	if err := os.MkdirAll(ours, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := excludeFromBackup(ours); err != nil {
+		t.Fatalf("exclude: %v", err)
+	}
+
+	theirs := filepath.Join(dir, "theirs")
+	if err := os.MkdirAll(theirs, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("tmutil", "addexclusion", theirs).CombinedOutput(); err != nil {
+		t.Skipf("tmutil addexclusion is unavailable here: %v: %s", err, out)
+	}
+
+	if a, b := readExcludeAttr(t, ours), readExcludeAttr(t, theirs); a != b {
+		t.Errorf("attribute differs from the one macOS writes:\n ours   %s\n tmutil %s", a, b)
+	}
+	if out, err := exec.Command("tmutil", "isexcluded", ours).CombinedOutput(); err != nil {
+		t.Fatalf("isexcluded: %v: %s", err, out)
+	} else if !strings.Contains(string(out), "[Excluded]") {
+		t.Errorf("tmutil does not consider it excluded: %s", out)
+	}
+}
+
+// The managed environment of an installation that already has one gets the
+// mark without being rebuilt, and an installation without one is not an error.
+func TestEnsureExcludedFromBackupHandlesBothStates(t *testing.T) {
+	dir := t.TempDir()
+	EnsureExcludedFromBackup(dir) // No environment: nothing to do, nothing to say.
+
+	env := ManagedEnvDir(dir)
+	if err := os.MkdirAll(env, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	EnsureExcludedFromBackup(dir)
+	if got := readExcludeAttr(t, env); got == "" {
+		t.Error("an environment already on disk was not marked")
+	}
+}
+
+func readExcludeAttr(t *testing.T, path string) string {
+	t.Helper()
+	out, err := exec.Command("xattr", "-px", backupExcludeAttr, path).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.Join(strings.Fields(string(out)), " ")
+}

--- a/internal/pyenv/backupexclude_other.go
+++ b/internal/pyenv/backupexclude_other.go
@@ -1,0 +1,11 @@
+//go:build !darwin
+
+package pyenv
+
+// excludeFromBackup has nothing to do off macOS: Time Machine is the backup
+// this marks a directory against, and neither Windows nor Linux reads the
+// attribute it writes.
+func excludeFromBackup(string) error { return nil }
+
+// EnsureExcludedFromBackup is the no-op half of the pair. See the darwin file.
+func EnsureExcludedFromBackup(string) {}

--- a/internal/pyenv/envsetup.go
+++ b/internal/pyenv/envsetup.go
@@ -158,6 +158,14 @@ func (b *EnvBuilder) Build(
 		return fail(fmt.Errorf("the environment has no interpreter at %s", py))
 	}
 
+	// Marked before the packages go in, so the bulk of it is never copied.
+	// Not fatal: a backup that copies more than it needs to is not a reason to
+	// refuse to build the environment. See excludeFromBackup.
+	if err := excludeFromBackup(envDir); err != nil {
+		emit(EnvSetupEvent{Step: StepCreatingVenv,
+			Line: "could not mark the environment as excluded from backup: " + err.Error()})
+	}
+
 	emit(EnvSetupEvent{Step: StepUpgradingPip, Line: "updating pip"})
 	// Not fatal. An old pip installs the requirements in almost every case, and
 	// failing the whole build because the upgrade could not reach the network

--- a/internal/store/area_naming_test.go
+++ b/internal/store/area_naming_test.go
@@ -1,0 +1,79 @@
+package store
+
+import "testing"
+
+/*
+A stem the caller supplies is numbered the way "drawn" is.
+
+The numbering was moved into this package because a caller cannot see what the
+project already holds -- two draws reported in one batch read the same stale
+list and produced two areas with one name. A caller that supplies a stem is in
+exactly that position: two grounds drawn under one studio, or one file imported
+twice, arrive with the same name and no way of knowing it.
+*/
+func TestCreateAreaNumbersASuppliedStem(t *testing.T) {
+	s := openTestStore(t)
+	p, err := s.CreateProject(Project{UserID: LocalUserID, Name: "Goias"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const poly = `{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,0]]]}`
+	names := []string{}
+	for i := 0; i < 3; i++ {
+		a, err := s.CreateArea(LocalUserID, Area{
+			ProjectID:      p.ID,
+			Name:           "Serra do mel",
+			PolygonGeoJSON: poly,
+		})
+		if err != nil {
+			t.Fatalf("create %d: %v", i, err)
+		}
+		names = append(names, a.Name)
+	}
+	want := []string{"Serra do mel", "Serra do mel 2", "Serra do mel 3"}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Errorf("area %d is %q, want %q", i, names[i], want[i])
+		}
+	}
+}
+
+// With no stem the sequence is the one it has always been.
+func TestCreateAreaKeepsTheDrawnSequence(t *testing.T) {
+	s := openTestStore(t)
+	p, err := s.CreateProject(Project{UserID: LocalUserID, Name: "Goias"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const poly = `{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,0]]]}`
+	for _, want := range []string{"drawn", "drawn 2", "drawn 3"} {
+		a, err := s.CreateArea(LocalUserID, Area{ProjectID: p.ID, PolygonGeoJSON: poly})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if a.Name != want {
+			t.Errorf("name = %q, want %q", a.Name, want)
+		}
+	}
+}
+
+// The sequence is per project: a second project opens at the start of it
+// rather than continuing the first one's count.
+func TestProvisionalNamesAreScopedToTheProject(t *testing.T) {
+	s := openTestStore(t)
+	const poly = `{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,0]]]}`
+	for _, name := range []string{"Goias", "Tocantins"} {
+		p, err := s.CreateProject(Project{UserID: LocalUserID, Name: name})
+		if err != nil {
+			t.Fatal(err)
+		}
+		a, err := s.CreateArea(LocalUserID, Area{ProjectID: p.ID, PolygonGeoJSON: poly})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if a.Name != "drawn" {
+			t.Errorf("first area of %s is %q, want \"drawn\"", name, a.Name)
+		}
+	}
+}

--- a/internal/store/areas.go
+++ b/internal/store/areas.go
@@ -122,12 +122,19 @@ func (s *Store) CreateArea(userID string, a Area) (*Area, error) {
 	}
 
 	a.UserID = owner
-	a.Name = strings.TrimSpace(a.Name)
-	if a.Name == "" {
-		a.Name, err = nextDrawnName(tx, a.ProjectID)
-		if err != nil {
-			return nil, err
-		}
+	/*
+		The name is numbered whether the caller supplied a stem or not.
+
+		It used to be numbered only when the caller had nothing, and any name
+		it was given went in verbatim -- so two imports of one file, or two
+		grounds drawn under one studio, produced two areas with one name
+		between them. That is the same defect the numbering was moved in here
+		to fix, reached from the other side: the caller cannot see what the
+		project already holds, and this can.
+	*/
+	a.Name, err = provisionalName(tx, a.ProjectID, a.Name)
+	if err != nil {
+		return nil, err
 	}
 	if a.ID == "" {
 		a.ID = uuid.NewString()
@@ -154,7 +161,12 @@ func (s *Store) CreateArea(userID string, a Area) (*Area, error) {
 }
 
 /*
-nextDrawnName is "drawn", then "drawn 2", and so on within one project.
+provisionalName is the stem, then the stem and 2, and so on within one project.
+
+"drawn" when the caller has no stem of its own, which is the sequence this
+started as. A caller that does have one -- the file name an import carries, the
+studio a ground was drawn under -- passes it and gets the same treatment, since
+a name that is provisional is provisional whatever it was derived from.
 
 Scoped to the project rather than to the user: two projects each holding a
 "drawn" is not a collision, it is two fields with the same provisional name, and
@@ -163,7 +175,11 @@ numbering across them would make the second project open at "drawn 4".
 Counted by asking rather than by taking the row count, because an area renamed
 by hand leaves a gap the count would step on.
 */
-func nextDrawnName(tx *sql.Tx, projectID string) (string, error) {
+func provisionalName(tx *sql.Tx, projectID, stem string) (string, error) {
+	stem = strings.TrimSpace(stem)
+	if stem == "" {
+		stem = "drawn"
+	}
 	rows, err := tx.Query(`SELECT name FROM areas WHERE project_id = ?`, projectID)
 	if err != nil {
 		return "", err
@@ -180,11 +196,11 @@ func nextDrawnName(tx *sql.Tx, projectID string) (string, error) {
 	if err := rows.Err(); err != nil {
 		return "", err
 	}
-	if !taken["drawn"] {
-		return "drawn", nil
+	if !taken[strings.ToLower(stem)] {
+		return stem, nil
 	}
 	for i := 2; ; i++ {
-		candidate := fmt.Sprintf("drawn %d", i)
+		candidate := fmt.Sprintf("%s %d", stem, i)
 		if !taken[strings.ToLower(candidate)] {
 			return candidate, nil
 		}

--- a/internal/store/maintenance.go
+++ b/internal/store/maintenance.go
@@ -1,0 +1,168 @@
+package store
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+/*
+Keeping the data directory from growing on its own.
+
+Three things accumulate here without anyone choosing them, and none of the code
+that produces them takes them away again: the base64 a solar run used to write
+into its own row beside the file it was decoded into, the free pages a delete
+leaves in the database file, and the snapshots a discard sets aside. All three
+run at open, after migrate, because that is the moment the file is this
+process's alone and nothing is reading it yet.
+
+Every one of them is best effort in the same sense saveRun is: none of them is
+worth refusing to open the database over. A failure leaves the directory as it
+was, which is the state the previous release shipped.
+*/
+
+/*
+stripStoredOverlayURIs takes the rendering back out of the rows that carry it.
+
+AnalyzeSolarTerrain and AnalyzeSolarSiting handed persistSolarRaster the whole
+result, data URI included, so result_json held the overlay as base64 and the
+run's asset directory held the same image as a file. Measured on one
+installation: 33 rows, 511,818 bytes of base64 against 452 KB of PNG. The write
+path no longer does it; these are the rows written before it stopped.
+
+Safe because LoadAnalysis has always preferred the file: it decodes the row,
+then overwrites overlay_uri from the PNG on disk. A row that has been stripped
+opens the way it did before, and a run whose file is missing opened onto
+nothing already -- the base64 was never what it was read from.
+*/
+func (s *Store) stripStoredOverlayURIs() error {
+	res, err := s.db.Exec(`
+		UPDATE inference_runs
+		   SET result_json = json_remove(result_json, '$.overlay_uri')
+		 WHERE kind = 'solar'
+		   AND json_valid(result_json)
+		   AND json_extract(result_json, '$.overlay_uri') IS NOT NULL`)
+	if err != nil {
+		// json_remove is part of the JSON extension. A build without it leaves
+		// the rows as they are, which costs space and breaks nothing.
+		return nil
+	}
+	_, _ = res.RowsAffected()
+	return nil
+}
+
+/*
+The fraction of the file that has to be free pages before it is worth
+rewriting, and where the number comes from.
+
+Firefox measures the same ratio -- freelist_count over page_count -- to decide
+when places.sqlite needs vacuuming, and its threshold is 0.1. Taking the number
+from a program that has run this maintenance on hundreds of millions of
+profiles is better than choosing one here, and the ratio is the right measure
+either way: it is the share of the file that is being carried and not used.
+
+One installation measured 1004 free pages of 1554, or 0.65. A database at that
+ratio is two thirds air.
+*/
+const vacuumFreePageRatio = 0.1
+
+/*
+The size past which the rewrite is not done at open.
+
+VACUUM rebuilds the whole file, so its cost is the file. At the sizes this
+application produces -- the images are on disk and the rows are text -- it is
+milliseconds, and doing it before the window appears costs nothing anyone can
+see. This bound is for the case that is not those sizes: a file large enough
+for the rewrite to be felt is one where a delay at every open would be worse
+than the space, and the storage screen reports the space either way.
+*/
+const vacuumMaxBytes = 256 << 20
+
+/*
+compactIfFragmented rewrites the database when enough of it is free pages.
+
+Not auto_vacuum, and the reason is in SQLite's own documentation: the mode
+cannot be turned on for a database that already has tables without running a
+full VACUUM first, so the cheap-sounding option costs the expensive one before
+it does anything. FULL also only truncates free pages at commit -- it does not
+repack, and can leave the file more fragmented than it found it. A VACUUM when
+the ratio says so does the whole job and does it once.
+*/
+func (s *Store) compactIfFragmented() error {
+	var pages, free int64
+	if err := s.db.QueryRow(`PRAGMA page_count`).Scan(&pages); err != nil {
+		return nil
+	}
+	if err := s.db.QueryRow(`PRAGMA freelist_count`).Scan(&free); err != nil {
+		return nil
+	}
+	if pages == 0 || float64(free)/float64(pages) < vacuumFreePageRatio {
+		return nil
+	}
+	var pageSize int64
+	if err := s.db.QueryRow(`PRAGMA page_size`).Scan(&pageSize); err != nil {
+		return nil
+	}
+	if pages*pageSize > vacuumMaxBytes {
+		return nil
+	}
+	// Outside a transaction, which VACUUM requires. migrate holds none.
+	if _, err := s.db.Exec(`VACUUM`); err != nil {
+		return fmt.Errorf("compact the database: %w", err)
+	}
+	return nil
+}
+
+// replacedMarker is what a set-aside copy carries in its name. See
+// discardPreAreaData, which writes them.
+const replacedMarker = ".replaced-"
+
+/*
+pruneReplacedSnapshots keeps the most recent copy of each thing set aside and
+removes the ones behind it.
+
+A discard copies the database and moves runs/ and projects/ out of the way
+before it drops anything, stamped with the hour. Nothing has ever removed them.
+On one installation they came to 16.6 MB across four entries, of which the
+newest was the only one that could still be wanted: the older ones are states
+the file has since been migrated past twice over.
+
+ONE, NOT NONE. The most recent is the rollback the copy exists to be. Keeping a
+single generation is the retention every log rotation settles on for the same
+reason -- the last one is evidence, the ones before it are weight.
+
+Names it did not write are not touched. A reader who copied the database aside
+by hand named it something else, and this must not be the thing that decides
+their copy has aged out.
+*/
+func (s *Store) pruneReplacedSnapshots() error {
+	entries, err := os.ReadDir(s.dataDir)
+	if err != nil {
+		return nil
+	}
+	// Grouped by what was set aside, because the database, runs/ and projects/
+	// are stamped separately and each keeps its own most recent.
+	generations := map[string][]string{}
+	for _, e := range entries {
+		name := e.Name()
+		i := strings.Index(name, replacedMarker)
+		if i <= 0 {
+			continue
+		}
+		base := name[:i]
+		generations[base] = append(generations[base], name)
+	}
+	for _, names := range generations {
+		if len(names) < 2 {
+			continue
+		}
+		// The stamp is fixed-width and ordered, so lexical order is time order.
+		sort.Strings(names)
+		for _, old := range names[:len(names)-1] {
+			_ = os.RemoveAll(filepath.Join(s.dataDir, old))
+		}
+	}
+	return nil
+}

--- a/internal/store/maintenance_test.go
+++ b/internal/store/maintenance_test.go
@@ -1,0 +1,210 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+/*
+The rendering comes out of the row and the rest of the row stays.
+
+The rows this repairs were written by a path that has since stopped writing
+them, so the assertion that matters is not only that overlay_uri is gone: it is
+that the figures beside it, which are the whole reason the row exists, came
+through.
+*/
+func TestStripStoredOverlayURIsLeavesTheRestOfTheRow(t *testing.T) {
+	s := openTestStore(t)
+	seedRun(t, s, "solar-1", LocalUserID)
+	seedRun(t, s, "class-1", LocalUserID)
+
+	const withOverlay = `{"overlay_uri":"data:image/png;base64,AAAA","unit":"kWh/m2","season":"annual"}`
+	if _, err := s.db.Exec(
+		`UPDATE inference_runs SET kind = 'solar', result_json = ? WHERE id = 'solar-1'`,
+		withOverlay,
+	); err != nil {
+		t.Fatal(err)
+	}
+	// A classification stores no data URI and must not be rewritten anyway:
+	// the strip is scoped to the kind whose write path had the defect.
+	if _, err := s.db.Exec(
+		`UPDATE inference_runs SET kind = 'classification', result_json = ? WHERE id = 'class-1'`,
+		withOverlay,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.stripStoredOverlayURIs(); err != nil {
+		t.Fatalf("strip: %v", err)
+	}
+
+	solar, err := s.GetRun(LocalUserID, "solar-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(solar.ResultJSON, "overlay_uri") {
+		t.Errorf("the data uri survived: %s", solar.ResultJSON)
+	}
+	for _, keep := range []string{"kWh/m2", "annual"} {
+		if !strings.Contains(solar.ResultJSON, keep) {
+			t.Errorf("%q was removed with the overlay: %s", keep, solar.ResultJSON)
+		}
+	}
+
+	other, err := s.GetRun(LocalUserID, "class-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if other.ResultJSON != withOverlay {
+		t.Errorf("a row of another kind was rewritten: %s", other.ResultJSON)
+	}
+}
+
+// A row whose result is not JSON is left alone rather than taking the pass
+// down with it, the way one malformed view_json used to take the whole repair.
+func TestStripStoredOverlayURIsSurvivesMalformedResult(t *testing.T) {
+	s := openTestStore(t)
+	seedRun(t, s, "solar-1", LocalUserID)
+	if _, err := s.db.Exec(
+		`UPDATE inference_runs SET kind = 'solar', result_json = 'not json' WHERE id = 'solar-1'`,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.stripStoredOverlayURIs(); err != nil {
+		t.Fatalf("strip refused to run: %v", err)
+	}
+	got, err := s.GetRun(LocalUserID, "solar-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ResultJSON != "not json" {
+		t.Errorf("result was rewritten: %q", got.ResultJSON)
+	}
+}
+
+/*
+A file that is mostly free pages is rewritten; one that is not is left alone.
+
+Fragmentation is produced rather than asserted on a fixture: rows are written
+and deleted until the ratio is over the threshold, which is what a few months
+of saving and removing analyses does.
+*/
+func TestCompactIfFragmentedShrinksTheFile(t *testing.T) {
+	s := openTestStore(t)
+
+	big := strings.Repeat("x", 4096)
+	for i := 0; i < 400; i++ {
+		seedRun(t, s, "run-"+string(rune('a'+i%26))+strings.Repeat("z", i/26+1), LocalUserID)
+	}
+	if _, err := s.db.Exec(
+		`UPDATE inference_runs SET result_json = ?`, `{"pad":"`+big+`"}`,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.Exec(`DELETE FROM inference_runs`); err != nil {
+		t.Fatal(err)
+	}
+
+	before := pageCount(t, s)
+	if ratio := freeRatio(t, s); ratio < vacuumFreePageRatio {
+		t.Fatalf("the setup did not fragment the file: ratio %.3f", ratio)
+	}
+	if err := s.compactIfFragmented(); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	after := pageCount(t, s)
+	if after >= before {
+		t.Errorf("page count went from %d to %d", before, after)
+	}
+	if ratio := freeRatio(t, s); ratio >= vacuumFreePageRatio {
+		t.Errorf("still fragmented after the rewrite: %.3f", ratio)
+	}
+
+	// And a second call is a no-op, so opening the application repeatedly does
+	// not rewrite the file every time.
+	settled := pageCount(t, s)
+	if err := s.compactIfFragmented(); err != nil {
+		t.Fatal(err)
+	}
+	if got := pageCount(t, s); got != settled {
+		t.Errorf("an unfragmented file was rewritten: %d -> %d", settled, got)
+	}
+}
+
+func pageCount(t *testing.T, s *Store) int64 {
+	t.Helper()
+	var n int64
+	if err := s.db.QueryRow(`PRAGMA page_count`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+func freeRatio(t *testing.T, s *Store) float64 {
+	t.Helper()
+	var free int64
+	if err := s.db.QueryRow(`PRAGMA freelist_count`).Scan(&free); err != nil {
+		t.Fatal(err)
+	}
+	return float64(free) / float64(pageCount(t, s))
+}
+
+/*
+One generation of each set-aside copy is kept, and names the application did
+not write are not touched.
+
+The second half is the one worth a test: a reader who copies the database aside
+by hand before an experiment must not find that the application decided their
+copy had aged out.
+*/
+func TestPruneReplacedSnapshotsKeepsTheNewestAndOnlyItsOwn(t *testing.T) {
+	s := openTestStore(t)
+	dir := s.DataDir()
+
+	made := []string{
+		dbFileName + ".replaced-20260101-000000",
+		dbFileName + ".replaced-20260601-120000",
+		dbFileName + ".replaced-20260830-181250",
+		dbFileName + ".before-cleanup",
+		dbFileName + ".safety-033038",
+	}
+	for _, name := range made {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range []string{
+		"runs.replaced-20260101-000000",
+		"runs.replaced-20260830-181250",
+	} {
+		if err := os.MkdirAll(filepath.Join(dir, name, "inner"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := s.pruneReplacedSnapshots(); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+
+	for _, kept := range []string{
+		dbFileName + ".replaced-20260830-181250",
+		"runs.replaced-20260830-181250",
+		dbFileName + ".before-cleanup",
+		dbFileName + ".safety-033038",
+	} {
+		if _, err := os.Stat(filepath.Join(dir, kept)); err != nil {
+			t.Errorf("%s was removed: %v", kept, err)
+		}
+	}
+	for _, gone := range []string{
+		dbFileName + ".replaced-20260101-000000",
+		dbFileName + ".replaced-20260601-120000",
+		"runs.replaced-20260101-000000",
+	} {
+		if _, err := os.Stat(filepath.Join(dir, gone)); !os.IsNotExist(err) {
+			t.Errorf("%s survived", gone)
+		}
+	}
+}

--- a/internal/store/migrate_version_test.go
+++ b/internal/store/migrate_version_test.go
@@ -75,7 +75,7 @@ var expectedColumns = map[string][]string{
 	"projects":         {"id", "user_id", "name", "notes", "created_at", "updated_at", "last_area_id"},
 	"project_overlays": {"id", "project_id", "kind", "title", "meta_json", "png_relpath", "tif_relpath", "created_at", "run_id", "area_id"},
 	"studios":          {"id", "user_id", "name", "created_at", "updated_at", "view_json", "project_id"},
-	"studio_members":   {"id", "studio_id", "run_id", "position", "name", "state_json"},
+	"studio_members":   {"id", "studio_id", "run_id", "position"},
 	"areas":            {"id", "project_id", "user_id", "name", "polygon_geojson", "notes", "created_at", "updated_at"},
 }
 

--- a/internal/store/storage.go
+++ b/internal/store/storage.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"geosense-infer/internal/pyenv"
 )
 
 /*
@@ -138,6 +140,46 @@ func (s *Store) InspectStorage() (*StorageReport, error) {
 		report.TotalBytes += info.Size()
 	}
 
+	/*
+		The managed Python environment, which was in none of the numbers above
+		and is larger than all of them together.
+
+		Measured at 1.9 GB on one installation against 8.2 MB for the four
+		buckets that were being reported, so the screen was answering "where
+		did my disk go" with 0.4% of the answer. Listed rather than made
+		removable: the analyses do not run without it, and rebuilding it is the
+		environment screen's job, not this one's.
+	*/
+	if bytes, files := dirSize(pyenv.ManagedEnvDir(s.dataDir)); bytes > 0 {
+		report.Buckets = append(report.Buckets, StorageBucket{
+			Label:       "Python environment",
+			Bytes:       bytes,
+			Files:       files,
+			Consequence: "the interpreter and packages every analysis runs in; rebuilt from the manifest on the environment screen",
+		})
+		report.TotalBytes += bytes
+	}
+
+	/*
+		Whatever else is in the directory, in one bucket.
+
+		The buckets above are the parts with a name and a meaning. This is the
+		part that grows without anyone choosing it -- the `.replaced-*`
+		snapshots a migration leaves behind, 16.6 MB of them on the same
+		installation, and whatever a reader has copied in beside them. The
+		database bucket says the total is listed so it adds up; with these
+		omitted it did not.
+	*/
+	if bytes, files := s.measureRemainder(); bytes > 0 {
+		report.Buckets = append(report.Buckets, StorageBucket{
+			Label:       "Other files in this folder",
+			Bytes:       bytes,
+			Files:       files,
+			Consequence: "snapshots left by an upgrade, and anything placed here by hand",
+		})
+		report.TotalBytes += bytes
+	}
+
 	runs, orphanBytes, orphanCount, err := s.measureRuns()
 	if err != nil {
 		return nil, err
@@ -242,6 +284,53 @@ func fileTypeLabel(ext string) (string, string) {
 	default:
 		return "other", "Other files"
 	}
+}
+
+/*
+measureRemainder sizes everything at the top of the data directory that no
+other bucket accounts for.
+
+By exclusion rather than by a list of the names to include, because the names
+that accumulate here are the ones nothing planned: a snapshot stamped with the
+hour it was written, a copy someone made before an experiment. A list of
+patterns would have to be extended by whoever adds the next one, which is the
+same as not having it.
+
+Top level only. What is inside runs/ and projects/ is already reported per run
+and per project, and walking them again here would count those bytes twice.
+*/
+func (s *Store) measureRemainder() (int64, int) {
+	accounted := map[string]bool{
+		"runs":     true,
+		"projects": true,
+		"avatars":  true,
+		dbFileName: true,
+		filepath.Base(pyenv.ManagedEnvDir(s.dataDir)): true,
+	}
+	entries, err := os.ReadDir(s.dataDir)
+	if err != nil {
+		return 0, 0
+	}
+	var total int64
+	var count int
+	for _, e := range entries {
+		if accounted[e.Name()] {
+			continue
+		}
+		if e.IsDir() {
+			bytes, files := dirSize(filepath.Join(s.dataDir, e.Name()))
+			total += bytes
+			count += files
+			continue
+		}
+		info, err := e.Info()
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		total += info.Size()
+		count++
+	}
+	return total, count
 }
 
 // measureProjects sizes each project directory, largest first.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -913,6 +913,22 @@ CREATE INDEX IF NOT EXISTS idx_runs_project_created ON inference_runs(project_id
 	if err := s.repairStudioViews(); err != nil {
 		return err
 	}
+	/*
+		The three things that accumulate on their own. See maintenance.go.
+
+		Last, and in this order: the strip is what makes the free pages the
+		compaction then reclaims, and both are done before the snapshots are
+		pruned so a failure in either leaves the most recent copy where it is.
+	*/
+	if err := s.stripStoredOverlayURIs(); err != nil {
+		return err
+	}
+	if err := s.compactIfFragmented(); err != nil {
+		return err
+	}
+	if err := s.pruneReplacedSnapshots(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -879,6 +879,16 @@ CREATE INDEX IF NOT EXISTS idx_runs_project_created ON inference_runs(project_id
 		{"projects", "polygon_geojson"},
 		{"projects", "area_id"},
 		{"projects", "label"},
+		/*
+			studio_members.name and .state_json were the same mistake read from
+			the other end: not columns nothing writes, but columns nothing
+			reads back for any purpose. The frontend sends "" and "{}" into
+			them and keeps the arrangement, the per-group name included, in the
+			studio's own view_json. Six saved studios on one installation held
+			those two constants and nothing else. See StudioMember.
+		*/
+		{"studio_members", "name"},
+		{"studio_members", "state_json"},
 	} {
 		if err := s.dropColumn(c.table, c.column); err != nil {
 			return fmt.Errorf("migrate: %w", err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -900,6 +900,9 @@ CREATE INDEX IF NOT EXISTS idx_runs_project_created ON inference_runs(project_id
 	if err := s.ensureLocalUser(); err != nil {
 		return err
 	}
+	if err := s.repairStudioViews(); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -1531,6 +1534,19 @@ func (s *Store) DeleteRun(userID, runID string) error {
 		"belongs to the project" rather than "belongs to nothing".
 	*/
 	if _, err := tx.Exec(`DELETE FROM studio_members WHERE run_id = ?`, runID); err != nil {
+		return err
+	}
+	/*
+		AND THE ARRANGEMENT ITSELF, which the member row is only half of.
+
+		A studio keeps what it looks like in `view_json`, and that field names
+		its runs too. Removing the member and leaving the blob produced the one
+		state the Missing flag above cannot report: the row that would have
+		carried the flag is the row that was just deleted, so the studio opens
+		with a run's worth of arrangement pointing at nothing and says nothing
+		about it. See dropRunsFromViews.
+	*/
+	if _, err := dropRunsFromViews(tx, userID, map[string]bool{runID: true}); err != nil {
 		return err
 	}
 	if _, err := tx.Exec(

--- a/internal/store/studio_view_prune_test.go
+++ b/internal/store/studio_view_prune_test.go
@@ -1,0 +1,248 @@
+package store
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+/*
+The arrangement of one run, in every key convention the board writes.
+
+Built as a literal rather than through SaveStudio because the shape under test
+is the frontend's, and a test that produced it through this package's own
+writer would only prove that writer consistent with itself. The keys mirror
+components/studio/boardMemory.ts. The separator between an area id and a scene
+id is a NUL there; it is written as a JSON escape here so this source file
+carries no control character.
+*/
+const twoRunView = `{
+  "runIds": ["run-a", "run-b"],
+  "added": {"run-a": ["solar:terrain"], "run-b": ["prediction"]},
+  "order": {"run-a": ["solar:terrain"], "run-b": ["prediction"]},
+  "places": {"run-a": {"x": 1, "z": 2}, "run-b": {"x": 3, "z": 4}},
+  "extraState": {"run-a\u0000solar:terrain": {"opacity": 0.5, "visible": true},
+                 "run-b\u0000prediction": {"opacity": 1, "visible": true}},
+  "planePlaces": {"run-a\u0000solar:terrain": {"x": 0.25, "z": 0.5}},
+  "removed": ["run-a\u0000confidence", "run-b\u0000confidence"],
+  "flat": ["run-a\u0000solar:terrain"],
+  "names": {"stack::run-a": "Sol do cerrado", "stack::run-b": "Tocantins"},
+  "nodePlaces": {"product": {"x": 295.32118395303326, "y": -162.77005870841484}},
+  "gap": 0.1,
+  "links": false
+}`
+
+func TestPruneViewRunsRemovesEveryKeyConvention(t *testing.T) {
+	out, changed := pruneViewRuns(twoRunView, map[string]bool{"run-a": true})
+	if !changed {
+		t.Fatal("prune reported no change")
+	}
+	if strings.Contains(out, "run-a") {
+		t.Errorf("run-a survives somewhere in the view:\n%s", out)
+	}
+	// The other run is untouched, which is the half that makes this a prune
+	// rather than a reset.
+	for _, want := range []string{"run-b", "prediction", "Tocantins"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("%q was removed with run-a", want)
+		}
+	}
+}
+
+// A field this package has never heard of belongs to the frontend, and a
+// coordinate rewritten by a round trip is a change nothing asked for.
+func TestPruneViewRunsPreservesForeignFieldsAndPrecision(t *testing.T) {
+	out, _ := pruneViewRuns(twoRunView, map[string]bool{"run-a": true})
+	if !strings.Contains(out, "295.32118395303326") {
+		t.Errorf("coordinate was rewritten:\n%s", out)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(out), &obj); err != nil {
+		t.Fatalf("output is not json: %v", err)
+	}
+	if _, ok := obj["nodePlaces"]; !ok {
+		t.Error("nodePlaces was dropped")
+	}
+	if _, ok := obj["links"]; !ok {
+		t.Error("links was dropped")
+	}
+}
+
+func TestPruneViewRunsLeavesUnrelatedViewsAlone(t *testing.T) {
+	out, changed := pruneViewRuns(twoRunView, map[string]bool{"run-z": true})
+	if changed {
+		t.Error("a view naming none of the dropped runs was rewritten")
+	}
+	if out != twoRunView {
+		t.Error("view was modified")
+	}
+}
+
+// Unparseable input is returned as it stands: a best-effort cleanup that
+// cannot read a field has no business writing it.
+func TestPruneViewRunsDeclinesUnparseableView(t *testing.T) {
+	const bad = `{"runIds": [`
+	out, changed := pruneViewRuns(bad, map[string]bool{"run-a": true})
+	if changed || out != bad {
+		t.Errorf("rewrote an unparseable view: %q", out)
+	}
+}
+
+/*
+The invariant this exists for: after a run is deleted, nothing in any studio
+names it.
+
+Asserted over the stored blob as well as the member rows, because the defect
+was that the two disagreed -- a reader that consults only one of them would
+have passed while the other was wrong.
+*/
+func TestDeleteRunLeavesNoStudioReference(t *testing.T) {
+	s := openTestStore(t)
+	seedRun(t, s, "run-a", LocalUserID)
+	seedRun(t, s, "run-b", LocalUserID)
+
+	saved, err := s.SaveStudio(Studio{
+		UserID:   LocalUserID,
+		Name:     "two runs",
+		ViewJSON: twoRunView,
+		Members: []StudioMember{
+			{RunID: "run-a"},
+			{RunID: "run-b"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("save studio: %v", err)
+	}
+
+	if err := s.DeleteRun(LocalUserID, "run-a"); err != nil {
+		t.Fatalf("delete run: %v", err)
+	}
+
+	got, err := s.GetStudio(LocalUserID, saved.ID)
+	if err != nil {
+		t.Fatalf("get studio: %v", err)
+	}
+	if strings.Contains(got.ViewJSON, "run-a") {
+		t.Errorf("deleted run still named in view_json:\n%s", got.ViewJSON)
+	}
+	if len(got.Members) != 1 || got.Members[0].RunID != "run-b" {
+		t.Errorf("members = %+v, want only run-b", got.Members)
+	}
+	// The surviving run keeps its arrangement. A prune that cleared the field
+	// would also pass the assertion above.
+	if !strings.Contains(got.ViewJSON, "Tocantins") {
+		t.Error("the surviving run lost its name")
+	}
+}
+
+/*
+The files written before deletion reached the blob.
+
+The studio is saved naming a run no row answers to, which is the state one
+installation was found in, and the repair is the pass migrate runs at every
+open.
+*/
+func TestRepairStudioViewsDropsRunsWithNoRow(t *testing.T) {
+	s := openTestStore(t)
+	seedRun(t, s, "run-b", LocalUserID)
+
+	saved, err := s.SaveStudio(Studio{
+		UserID:   LocalUserID,
+		Name:     "carries a ghost",
+		ViewJSON: twoRunView,
+		Members:  []StudioMember{{RunID: "run-b"}},
+	})
+	if err != nil {
+		t.Fatalf("save studio: %v", err)
+	}
+
+	if err := s.repairStudioViews(); err != nil {
+		t.Fatalf("repair: %v", err)
+	}
+
+	got, err := s.GetStudio(LocalUserID, saved.ID)
+	if err != nil {
+		t.Fatalf("get studio: %v", err)
+	}
+	if strings.Contains(got.ViewJSON, "run-a") {
+		t.Errorf("run with no row survives the repair:\n%s", got.ViewJSON)
+	}
+	if !strings.Contains(got.ViewJSON, "run-b") {
+		t.Error("the run that does have a row was removed")
+	}
+
+	// Idempotent: a second pass finds nothing and writes nothing.
+	before := got.ViewJSON
+	if err := s.repairStudioViews(); err != nil {
+		t.Fatalf("second repair: %v", err)
+	}
+	after, err := s.GetStudio(LocalUserID, saved.ID)
+	if err != nil {
+		t.Fatalf("get studio again: %v", err)
+	}
+	if after.ViewJSON != before {
+		t.Errorf("second repair changed the view:\n%s\n%s", before, after.ViewJSON)
+	}
+}
+
+/*
+One unparseable arrangement must not take the repair -- or the open -- with it.
+
+json_extract raises while the statement is stepping, so before the json_valid
+guard a single row like this aborted the whole query, and the error travelled
+up through migrate to Open. Written straight to the table because SaveStudio
+now refuses to store it, which is the other half of the fix.
+*/
+func TestRepairStudioViewsSurvivesMalformedView(t *testing.T) {
+	s := openTestStore(t)
+	seedRun(t, s, "run-b", LocalUserID)
+
+	good, err := s.SaveStudio(Studio{
+		UserID:   LocalUserID,
+		Name:     "carries a ghost",
+		ViewJSON: twoRunView,
+		Members:  []StudioMember{{RunID: "run-b"}},
+	})
+	if err != nil {
+		t.Fatalf("save studio: %v", err)
+	}
+	if _, err := s.db.Exec(
+		`INSERT INTO studios (id, user_id, name, created_at, updated_at, view_json)
+		 VALUES ('broken', ?, 'not json', ?, ?, 'not json')`,
+		LocalUserID, nowISO(), nowISO(),
+	); err != nil {
+		t.Fatalf("seed malformed studio: %v", err)
+	}
+
+	if err := s.repairStudioViews(); err != nil {
+		t.Fatalf("repair refused to run: %v", err)
+	}
+
+	got, err := s.GetStudio(LocalUserID, good.ID)
+	if err != nil {
+		t.Fatalf("get studio: %v", err)
+	}
+	if strings.Contains(got.ViewJSON, "run-a") {
+		t.Error("the repair skipped the studio it could read")
+	}
+}
+
+// An arrangement that is not JSON is stored as none, the way SaveRun stores an
+// invalid summary as `{}`.
+func TestSaveStudioRejectsMalformedView(t *testing.T) {
+	s := openTestStore(t)
+	seedRun(t, s, "run-b", LocalUserID)
+
+	saved, err := s.SaveStudio(Studio{
+		UserID:   LocalUserID,
+		Name:     "bad view",
+		ViewJSON: `{"runIds": [`,
+		Members:  []StudioMember{{RunID: "run-b"}},
+	})
+	if err != nil {
+		t.Fatalf("save studio: %v", err)
+	}
+	if saved.ViewJSON != "{}" {
+		t.Errorf("view json = %q, want {}", saved.ViewJSON)
+	}
+}

--- a/internal/store/studios.go
+++ b/internal/store/studios.go
@@ -18,6 +18,7 @@ several studios.
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"strings"
 
@@ -137,7 +138,18 @@ func (s *Store) SaveStudio(c Studio) (*Studio, error) {
 		return nil, ErrInvalidInput
 	}
 	c.ProjectID = strings.TrimSpace(c.ProjectID)
-	if c.ViewJSON == "" {
+	/*
+		An arrangement that is not JSON is stored as no arrangement.
+
+		The same rule SaveRun applies to summary_json and result_json, and for
+		the same reason: this column is opaque to the store but not to
+		everything -- the frontend parses it to reopen a board, and
+		repairStudioViews reads the run ids out of it. A string that neither can
+		parse is not a board that was saved, it is a board that was lost on the
+		way in, and storing it as `{}` says so once instead of failing at every
+		later reader.
+	*/
+	if c.ViewJSON == "" || !json.Valid([]byte(c.ViewJSON)) {
 		c.ViewJSON = "{}"
 	}
 
@@ -399,4 +411,284 @@ func (s *Store) DeleteStudio(userID, id string) error {
 		return err
 	}
 	return tx.Commit()
+}
+
+/*
+Taking a run out of the arrangements that name it.
+
+A studio keeps its arrangement in one opaque field, `view_json`, written by the
+frontend and meaningless to this package -- except for one thing, which is that
+the run ids are in there. Deleting a run used to leave every one of them
+behind: the member row went, and the blob went on naming a run nothing could
+open. The studio then reported no gap, because the gap is reported from the
+member rows and those were the part that had been removed. One installation
+carried a studio in exactly that state, referencing two deleted runs and
+holding no members at all, which opens as an empty board with nothing to say
+why.
+
+FOUR KEY CONVENTIONS, and they are the frontend's, not this package's. See
+components/studio/boardMemory.ts, which writes them:
+
+An id on its own keys `added`, `order` and `places`. An id, a NUL and a scene
+id key `extraState` and `planePlaces`, and are also what the `removed` and
+`flat` lists hold. A row id whose second "::" segment is the run id keys
+`names`. And `runIds` is a bare list of them.
+
+Anything else in the object is copied through untouched. That is the point of
+walking the shape rather than rewriting it: a field this package has never
+heard of belongs to the frontend and survives, and one the frontend adds later
+that happens to be keyed by run id will be missed here rather than corrupted --
+a gap a test can close, not a loss.
+*/
+func pruneViewRuns(view string, drop map[string]bool) (string, bool) {
+	if len(drop) == 0 || strings.TrimSpace(view) == "" {
+		return view, false
+	}
+	/*
+		UseNumber, so a coordinate comes back out as it went in.
+
+		The board writes plane placements as full-precision floats. Decoded
+		into float64 and re-encoded they would be rewritten to whatever Go
+		prints them as, which is a change to a field this function has no
+		business changing.
+	*/
+	dec := json.NewDecoder(strings.NewReader(view))
+	dec.UseNumber()
+	var obj map[string]any
+	if err := dec.Decode(&obj); err != nil {
+		// Not an object this function understands. Left exactly as it is:
+		// refusing to rewrite something unparseable is the safe half of a
+		// best-effort cleanup.
+		return view, false
+	}
+
+	changed := false
+
+	// `runIds`: the membership list itself.
+	if list, ok := obj["runIds"].([]any); ok {
+		kept := make([]any, 0, len(list))
+		for _, v := range list {
+			if id, ok := v.(string); ok && drop[id] {
+				changed = true
+				continue
+			}
+			kept = append(kept, v)
+		}
+		obj["runIds"] = kept
+	}
+
+	// Keyed by the id on its own.
+	for _, field := range []string{"added", "order", "places"} {
+		m, ok := obj[field].(map[string]any)
+		if !ok {
+			continue
+		}
+		for k := range m {
+			if drop[k] {
+				delete(m, k)
+				changed = true
+			}
+		}
+	}
+
+	// Keyed by the id, a NUL, and a scene id.
+	for _, field := range []string{"extraState", "planePlaces"} {
+		m, ok := obj[field].(map[string]any)
+		if !ok {
+			continue
+		}
+		for k := range m {
+			if drop[sceneKeyArea(k)] {
+				delete(m, k)
+				changed = true
+			}
+		}
+	}
+
+	// Lists of those same scene keys.
+	for _, field := range []string{"removed", "flat"} {
+		list, ok := obj[field].([]any)
+		if !ok {
+			continue
+		}
+		kept := make([]any, 0, len(list))
+		for _, v := range list {
+			if k, ok := v.(string); ok && drop[sceneKeyArea(k)] {
+				changed = true
+				continue
+			}
+			kept = append(kept, v)
+		}
+		obj[field] = kept
+	}
+
+	// Row keys, whose second segment is the id.
+	if m, ok := obj["names"].(map[string]any); ok {
+		for k := range m {
+			if parts := strings.Split(k, "::"); len(parts) >= 2 && drop[parts[1]] {
+				delete(m, k)
+				changed = true
+			}
+		}
+	}
+
+	if !changed {
+		return view, false
+	}
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return view, false
+	}
+	return string(out), true
+}
+
+// sceneKeyArea is the area half of an `<area>\x00<scene>` key, or the whole
+// string when it carries no scene.
+func sceneKeyArea(k string) string {
+	if i := strings.IndexByte(k, 0); i >= 0 {
+		return k[:i]
+	}
+	return k
+}
+
+/*
+dropRunsFromViews rewrites every arrangement of one user that names a run in
+`drop`, and reports how many it rewrote.
+
+Takes the transaction rather than the store, because the only correct time to
+do this is inside the one that removes the run: a studio pointing at a run that
+is half deleted is the state this exists to prevent.
+*/
+func dropRunsFromViews(tx *sql.Tx, userID string, drop map[string]bool) (int, error) {
+	if len(drop) == 0 {
+		return 0, nil
+	}
+	writes, err := viewsWithout(tx, userID, drop)
+	if err != nil {
+		return 0, err
+	}
+	// After the read, not during it. The reading is a function of its own so
+	// its cursor is closed by defer before the first write goes out: this
+	// package holds a single connection, and a write issued while a cursor is
+	// open on it is a shape worth not depending on.
+	for _, w := range writes {
+		if _, err := tx.Exec(
+			`UPDATE studios SET view_json = ? WHERE id = ?`, w.view, w.id,
+		); err != nil {
+			return 0, err
+		}
+	}
+	return len(writes), nil
+}
+
+// viewRewrite is one arrangement and what it should become.
+type viewRewrite struct{ id, view string }
+
+// viewsWithout is the rewrite each of a user's studios needs, for those that
+// need one.
+func viewsWithout(tx *sql.Tx, userID string, drop map[string]bool) ([]viewRewrite, error) {
+	rows, err := tx.Query(
+		`SELECT id, view_json FROM studios WHERE user_id = ?`, userID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var writes []viewRewrite
+	for rows.Next() {
+		var id, view string
+		if err := rows.Scan(&id, &view); err != nil {
+			return nil, err
+		}
+		if next, ok := pruneViewRuns(view, drop); ok {
+			writes = append(writes, viewRewrite{id, next})
+		}
+	}
+	return writes, rows.Err()
+}
+
+/*
+repairStudioViews takes deleted runs out of every arrangement still naming one.
+
+For the files that were written before deletion reached the blob. Not gated on
+the schema version, for the reason the drops in migrate give: a version number
+can be raised without the work behind it, and a file that slipped through such
+a window is one no later gate reopens. It is idempotent and it is a single
+query over a table holding a handful of rows, so running it at every open costs
+the read and nothing else.
+*/
+func (s *Store) repairStudioViews() error {
+	writes, err := s.viewsWithoutDeletedRuns()
+	if err != nil {
+		return err
+	}
+	for _, w := range writes {
+		if _, err := s.db.Exec(
+			`UPDATE studios SET view_json = ? WHERE id = ?`, w.view, w.id,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// viewsWithoutDeletedRuns is what each arrangement naming a run with no row
+// should become. Split from the write for the reason dropRunsFromViews gives.
+func (s *Store) viewsWithoutDeletedRuns() ([]viewRewrite, error) {
+	/*
+		json_valid FIRST, and it is not defensive dressing.
+
+		json_extract raises "malformed JSON" while the statement is stepping,
+		not when it is prepared, and one such row aborts the whole query -- so a
+		single unparseable arrangement would have taken this repair down, and
+		with it migrate, and with it Open. The application would decline to
+		start over a field it holds precisely because it does not have to
+		understand it. SQLite evaluates the WHERE of the left table before
+		expanding the table-valued function, so an invalid row never reaches
+		json_extract.
+	*/
+	rows, err := s.db.Query(`
+		SELECT DISTINCT s.id, s.view_json, j.value
+		  FROM (SELECT id, view_json FROM studios WHERE json_valid(view_json)) s,
+		       json_each(json_extract(s.view_json, '$.runIds')) j
+		  LEFT JOIN inference_runs r ON r.id = j.value
+		 WHERE r.id IS NULL`)
+	if err != nil {
+		// json_each is a table-valued function; a build of SQLite without JSON
+		// support would fail here, and a repair that cannot run is not a
+		// reason to refuse to open the database.
+		return nil, nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	gone := map[string]map[string]bool{}
+	views := map[string]string{}
+	var order []string
+	for rows.Next() {
+		var id, view, runID string
+		if err := rows.Scan(&id, &view, &runID); err != nil {
+			return nil, err
+		}
+		if gone[id] == nil {
+			gone[id] = map[string]bool{}
+			order = append(order, id)
+		}
+		gone[id][runID] = true
+		views[id] = view
+	}
+	if err := rows.Err(); err != nil {
+		// Nothing repaired rather than nothing opened, for the reason the
+		// query error above gives. The guard makes this unreachable for the
+		// case that was found; it stands for the one that has not been.
+		return nil, nil
+	}
+
+	var writes []viewRewrite
+	for _, id := range order {
+		if next, ok := pruneViewRuns(views[id], gone[id]); ok {
+			writes = append(writes, viewRewrite{id, next})
+		}
+	}
+	return writes, nil
 }

--- a/internal/store/studios.go
+++ b/internal/store/studios.go
@@ -68,21 +68,23 @@ type StudioMember struct {
 	/** Order on the board, left to right. */
 	Position int `json:"position"`
 	/*
-		The name given on the board, over the one the run carries.
+		WHAT A MEMBER IS NOT, and it used to be two more things.
 
-		Empty means the run's own name is used, rather than meaning the member
-		has no name: a run renamed later is still followed until someone has
-		said otherwise.
-	*/
-	Name string `json:"name,omitempty"`
-	/*
-		Where the group sits, and how its planes are set.
+		`name` held the name given on the board over the one the run carries,
+		and `state_json` held where the group sat and how its planes were set.
+		Both were written by SaveStudio and read by GetStudio, and in six saved
+		studios on one installation every one of them held "" and "{}": the
+		frontend sends those two constants and has always kept the real values
+		in the studio's own view_json, where the whole arrangement lives. The
+		override is a real feature and it is still there -- as the `names` map
+		keyed `stack::<runId>` -- so what was dropped is a second place for it,
+		not the thing itself.
 
-		Opaque for the same reason as ViewJSON, and it is the frontend's
-		CardPlane vocabulary: offsets in board units, per-layer opacity and
-		visibility. None of it means anything to the store.
+		Dropped rather than left unwritten, which is the rule migrate states
+		for the columns it drops: a column nothing writes always reads its
+		default and will disagree with the table one day. These crossed into
+		TypeScript as well, so the disagreement had two sides to appear on.
 	*/
-	StateJSON string `json:"state_json,omitempty"`
 	/*
 		The run this member names is gone.
 
@@ -112,9 +114,7 @@ CREATE TABLE IF NOT EXISTS studio_members (
   id TEXT PRIMARY KEY,
   studio_id TEXT NOT NULL REFERENCES studios(id) ON DELETE CASCADE,
   run_id TEXT NOT NULL,
-  position INTEGER NOT NULL DEFAULT 0,
-  name TEXT NOT NULL DEFAULT '',
-  state_json TEXT NOT NULL DEFAULT '{}'
+  position INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_studio_members_studio
   ON studio_members(studio_id, position);
@@ -234,14 +234,12 @@ func (s *Store) SaveStudio(c Studio) (*Studio, error) {
 		m.ID = uuid.NewString()
 		m.StudioID = c.ID
 		m.Position = i
-		if m.StateJSON == "" {
-			m.StateJSON = "{}"
-		}
+
 		if _, err := tx.Exec(
 			`INSERT INTO studio_members
-			 (id, studio_id, run_id, position, name, state_json)
-			 VALUES (?, ?, ?, ?, ?, ?)`,
-			m.ID, m.StudioID, m.RunID, m.Position, m.Name, m.StateJSON,
+			 (id, studio_id, run_id, position)
+			 VALUES (?, ?, ?, ?)`,
+			m.ID, m.StudioID, m.RunID, m.Position,
 		); err != nil {
 			return nil, err
 		}
@@ -326,7 +324,7 @@ func (s *Store) GetStudio(userID, id string) (*Studio, error) {
 		marked, not dropped. See StudioMember.Missing.
 	*/
 	rows, err := s.db.Query(
-		`SELECT m.id, m.studio_id, m.run_id, m.position, m.name, m.state_json,
+		`SELECT m.id, m.studio_id, m.run_id, m.position,
 		        r.id IS NULL
 		 FROM studio_members m
 		 LEFT JOIN inference_runs r ON r.id = m.run_id
@@ -342,8 +340,7 @@ func (s *Store) GetStudio(userID, id string) (*Studio, error) {
 	for rows.Next() {
 		var m StudioMember
 		if err := rows.Scan(
-			&m.ID, &m.StudioID, &m.RunID, &m.Position, &m.Name,
-			&m.StateJSON, &m.Missing,
+			&m.ID, &m.StudioID, &m.RunID, &m.Position, &m.Missing,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/studios_test.go
+++ b/internal/store/studios_test.go
@@ -33,8 +33,8 @@ func TestSaveStudioRoundTrip(t *testing.T) {
 		Name:     "  Pato Branco vs Teresina  ",
 		ViewJSON: `{"spread":0.12}`,
 		Members: []StudioMember{
-			{RunID: "run-a", Name: "Pato Branco 2024", StateJSON: `{"x":0}`},
-			{RunID: "run-b", StateJSON: `{"x":1.4}`},
+			{RunID: "run-a"},
+			{RunID: "run-b"},
 		},
 	})
 	if err != nil {
@@ -71,10 +71,6 @@ func TestSaveStudioRoundTrip(t *testing.T) {
 		t.Errorf("order not preserved: %v", []string{
 			got.Members[0].RunID, got.Members[1].RunID,
 		})
-	}
-	// Empty means "use the run's own name", not "has no name".
-	if got.Members[1].Name != "" {
-		t.Errorf("unnamed member carries %q", got.Members[1].Name)
 	}
 }
 
@@ -428,11 +424,16 @@ func TestABoardSavedAsAWhiteboardOpensAsAStudio(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Put the file back into the shape the previous name left it in.
+	// Put the file back into the shape the previous name left it in. The two
+	// added columns are part of that shape: a file written under the old name
+	// carries them, and dropping them is the other thing migrate has to do to
+	// it. See StudioMember.
 	for _, stmt := range []string{
 		`ALTER TABLE studios RENAME TO whiteboards`,
 		`ALTER TABLE studio_members RENAME COLUMN studio_id TO whiteboard_id`,
 		`ALTER TABLE studio_members RENAME TO whiteboard_members`,
+		`ALTER TABLE whiteboard_members ADD COLUMN name TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE whiteboard_members ADD COLUMN state_json TEXT NOT NULL DEFAULT '{}'`,
 	} {
 		if _, err := s.db.Exec(stmt); err != nil {
 			t.Fatal(err)
@@ -478,8 +479,23 @@ func TestABoardSavedAsAWhiteboardOpensAsAStudio(t *testing.T) {
 	if len(got.Members) != 1 || got.Members[0].RunID != "run-1" {
 		t.Fatalf("the studio came back with %d member(s)", len(got.Members))
 	}
-	if got.Members[0].Name != "Left" {
-		t.Errorf("the member's own name is %q, want %q", got.Members[0].Name, "Left")
+	// The legacy row carried name and state_json; those columns are dropped by
+	// the same migrate, and what mattered about the member -- which run it is
+	// and where in the order -- came through. See StudioMember.
+	if got.Members[0].Position != 0 {
+		t.Errorf("the member's position is %d, want 0", got.Members[0].Position)
+	}
+	for _, gone := range []string{"name", "state_json"} {
+		var n int
+		if err := s.db.QueryRow(
+			`SELECT COUNT(1) FROM pragma_table_info('studio_members') WHERE name = ?`,
+			gone,
+		).Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		if n != 0 {
+			t.Errorf("studio_members still declares %s", gone)
+		}
 	}
 
 	// The old names are gone rather than left beside the new ones: two tables


### PR DESCRIPTION
Ten corrections found by tracing one solar run from the sidecar to the studio it
appears in, and then by a report that switching studios lost the previous one's
work.

## What the runs write

**A raster was saved twice.** `AnalyzeSolarTerrain` and `AnalyzeSolarSiting`
handed the whole result to `persistSolarRaster`, so the PNG went into the run's
asset directory as a file and into `result_json` as base64 beside it. Measured
on one installation: 33 rows carrying 511,818 bytes duplicating 452 KB already
on disk. The classification and flood paths already withhold theirs.

**The column naming a run's image was right for a fifth of the table.** Water
and both solar rasters wrote a PNG and recorded no path to it. A reader of a
column that is right for a fifth is wrong for the rest, which is why no reader
was ever written and why the run list loads a whole result to reach an image
already on disk. `TestEveryRasterRunRecordsItsOverlay` walks the run's directory
rather than naming the file each product writes, so it fails for a product that
does not exist yet.

**`persistRunIfLoggedIn` was neither.** A pass through to `persistAnalysis`,
which saves under `LocalUserID` when no user is held. The name had reached the
interface, telling readers a run made while signed out has no row.

## What the store keeps

**Deleting a run left it named in every studio's `view_json`.** The member row
went and the blob did not, so the studio reported no gap — the gap is reported
from the row that had just been removed. Found in a database: a studio
referencing two deleted runs and holding no members. `DeleteRun` now prunes the
blob in the same transaction, and `migrate` repairs the files written before.

Two things surfaced while writing it. `json_extract` raises while a statement is
stepping, so one unparseable `view_json` aborted the repair and the error
travelled up through `migrate` to `Open` — the application would have declined
to start. And `SaveStudio` did not validate that column, unlike `SaveRun`. Both
closed.

**`studio_members.name` and `.state_json` had no reader.** Six saved studios
held `""` and `{}`; the arrangement, the per-group name included, has always
been in `view_json`. Dropped under the rule `migrate` already states for the
four columns it drops.

**The data directory grew on its own.** Base64 from rows written before the
first fix, free pages a delete leaves, and the snapshots a discard sets aside
and nothing removes. The vacuum threshold is Firefox's: `freelist_count` over
`page_count` at 0.1. `auto_vacuum` was rejected for the reason SQLite documents.
Measured on a copy of a real installation: 6216 KB to 1672 KB, 1004 free pages
to zero, 40 runs still there.

**The storage screen reported 8.2 MB of a directory holding 1.9 GB.** The
managed Python environment was in no bucket, and neither was anything else at
the top of the directory.

**The environment is excluded from Time Machine.** Apple's guidance is not a
preference for content that can be re-created. It stays in Application Support:
Caches is for data an app should never rely on existing, and every analysis
relies on this one. The exclusion value is a plist copied from `tmutil` and
compared byte for byte in a test — the first attempt was one byte short of the
format and `tmutil` reported the directory excluded anyway.

## What a studio is

**Leaving a studio left its ground and its run behind.** Three faults in a row:
`handleOpenStudio` never got the clearing `handleNewStudio` has, so the studio
being opened inherited the run of the studio being left, and saving wrote it in.
The AOI stayed drawn, carrying its provisional name into the label of the next
run over it. And the clearing undid itself one render later, through an effect
that retains whatever the map was showing whenever the active area changes.

**A studio is now named when it begins.** A studio with no name has nothing to
lend, so an area drawn inside a new one took `drawn N` and the run came out
`run-drawn-N` — both written before the studio had a name and neither revisited
when it got one. The row is created empty at naming time, and `createArea` is
handed the name as the stem. The store numbers any stem now, not only `drawn`.

**`frontend/node_modules` was a symlink pointing at itself.** Removed from the
index; `.gitignore` has excluded the path since line 8.

## Verification

`gofmt -l .`, `go vet ./...`, `golangci-lint run ./...` (0 issues),
`go test -race ./...`, `tsc --noEmit` and the frontend build all pass, and each
of the ten commits was checked to build and test on its own in a separate
worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
