### PR TITLE
fix(globe): a base to read, a voltage to see, a name that finishes

### DIFF
--- a/frontend/src/components/globe/GlobeSurface.tsx
+++ b/frontend/src/components/globe/GlobeSurface.tsx
@@ -28,8 +28,11 @@ import { usePlantLayers, useNetwork } from "@/lib/plantRegister"
 import {
   Broadcast,
   Globe,
+  CompassTool,
   MagnifyingGlass,
   Mountains,
+  Planet,
+  RoadHorizon,
   Path,
   Pencil,
   ArrowsOutCardinal,
@@ -46,7 +49,7 @@ import {
 import "@/lib/maplibreWorker"
 
 import type { GlobeArea } from "@/components/globe/globeArea"
-import { MapBar, MapButton } from "@/components/globe/MapChrome"
+import { MapBar, MapButton, MapMenu } from "@/components/globe/MapChrome"
 import {
   raisedRasterLayer,
   type RaisedRasterLayer,
@@ -122,6 +125,33 @@ import { cn } from "@/lib/utils"
  * it. Written as the conversion rather than as 11, so it cannot drift from the
  * level it means.
  */
+/**
+ * What the base control offers, in the order it lists them.
+ *
+ * The names are the basemap table's own, so the menu cannot call a base
+ * something the credit line does not -- the imagery row is the near half of a
+ * pair and is named for the choice rather than for either half of it.
+ */
+type BaseKind = "imagery" | "street" | "topo"
+
+const BASE_OPTIONS: readonly {
+  id: BaseKind
+  name: string
+  icon: React.ReactNode
+}[] = [
+  { id: "imagery", name: "Imagery", icon: <Planet className="size-4" /> },
+  {
+    id: "street",
+    name: basemapByKind("street").name,
+    icon: <RoadHorizon className="size-4" />,
+  },
+  {
+    id: "topo",
+    name: basemapByKind("topo").name,
+    icon: <CompassTool className="size-4" />,
+  },
+]
+
 export const GLOBE_BASEMAP: BasemapKind = "esri"
 export const GLOBE_WIDE_BASEMAP: BasemapKind = "eox"
 const ESRI_FIRST_LEVEL = 12
@@ -805,6 +835,21 @@ export function GlobeSurface({
     belongs to the question being asked, not to the session.
   */
   const [recent, setRecent] = useState(false)
+  /*
+    WHETHER THE BASE IS A PHOTOGRAPH OR A DRAWING.
+
+    Every basemap this screen could show was imagery: the button above chooses
+    between two pictures of the ground, and there was no way to ask for a map.
+    A drawing answers what a photograph cannot -- what a place is called, where
+    the road runs, which side of the river a town is on -- and on this
+    application's products it is what a classification can be checked against
+    by name.
+
+    Held here and not remembered, like `recent` and for the same reason: it
+    belongs to the question being asked rather than to the session.
+  */
+  const [base, setBase] = useState<BaseKind>("imagery")
+  const drawing = base !== "imagery"
   const [esriHere, setEsriHere] = useState<ImageryHere>({
     date: null,
     maxLevel: null,
@@ -1187,6 +1232,7 @@ export function GlobeSurface({
       const accent = token("--p-accent", "#ED8744")
       map.setPaintProperty(AREA_FILL, "fill-color", accent)
       map.setPaintProperty(AREA_LINE, "line-color", accent)
+
     }
 
     /*
@@ -1548,6 +1594,49 @@ export function GlobeSurface({
     no visible layer references it, so the mosaic costs nothing until it is
     asked for.
   */
+  /*
+    THE BASE, SWAPPED IN THE SOURCE THE NEAR IMAGERY ALREADY USES.
+
+    setTiles rather than a fourth source, which is safe here for the reason
+    `imagery-recent` needed one of its own and did not get it: a source's
+    maxzoom is fixed at creation, and these three products all end at 19. The
+    mosaic ends at 14, which is why it is separate.
+
+    AND THE HANDOVER GOES WITH THE PHOTOGRAPH. The imagery pair splits at level
+    12 because Esri's World Imagery is a Landsat-derived composite below it --
+    an argument about that product and not about the base being a base. The
+    street and topographic maps are one drawing at every level, so the near
+    layer is opened down to the planet and the wide one withdrawn, rather than
+    handing over to a satellite mosaic a reader did not ask for.
+  */
+  useEffect(() => {
+    const map = mapRef.current
+    if (!map || !ready || !map.getSource("imagery")) return
+    const drawn = basemapByKind(drawing ? base : GLOBE_BASEMAP)
+    const source = map.getSource("imagery")
+    if (source && "setTiles" in source) {
+      ;(source as { setTiles: (t: string[]) => void }).setTiles([drawn.url])
+    }
+    map.setLayerZoomRange("imagery", drawing ? 0 : HANDOVER_ZOOM - 1, 24)
+    if (map.getLayer("imagery-wide")) {
+      map.setLayoutProperty(
+        "imagery-wide",
+        "visibility",
+        drawing ? "none" : "visible"
+      )
+    }
+  }, [base, drawing, ready])
+
+  /*
+    The recent mosaic is imagery, and it is asked for over imagery. Left on
+    under a drawing it would cover the streets that were the point of choosing
+    one -- so the ask is withdrawn with the base rather than left set on a
+    button the reader can no longer see.
+  */
+  useEffect(() => {
+    if (drawing) setRecent(false)
+  }, [drawing])
+
   useEffect(() => {
     const map = mapRef.current
     if (!map || !ready || !map.getLayer("imagery-recent")) return
@@ -1691,14 +1780,34 @@ export function GlobeSurface({
     which they came from different sides of the handover -- or from a mosaic
     the level has already put away -- would read as a claim nobody made.
   */
-  const wide = zoom < HANDOVER_ZOOM
+  /*
+    Below the handover the wide basemap is what is drawn -- of the imagery
+    pair. Under a drawing there is no pair and no handover, so this is false at
+    every level and the credit names the one map on screen.
+  */
+  const wide = !drawing && zoom < HANDOVER_ZOOM
   /* The reader's ask AND the level agreeing. Above the cap the button is still
      down and the picture is Esri again, so everything below says Esri. */
   const recentDrawn = !wide && recent && zoom < RECENT_MAX_ZOOM
   const shownBasemap = basemapByKind(
-    wide ? GLOBE_WIDE_BASEMAP : recentDrawn ? "s2recent" : GLOBE_BASEMAP
+    drawing
+      ? base
+      : wide
+        ? GLOBE_WIDE_BASEMAP
+        : recentDrawn
+          ? "s2recent"
+          : GLOBE_BASEMAP
   )
-  const shownDate = wide ? (shownBasemap.imageryDate ?? null) : esriHere.date
+  /*
+    A drawing has no acquisition. Esri's date readout is about a photograph's
+    footprint, and reporting one under a street map would answer a question
+    nothing on screen is asking.
+  */
+  const shownDate = drawing
+    ? null
+    : wide
+      ? (shownBasemap.imageryDate ?? null)
+      : esriHere.date
   /*
     WHERE THE IMAGERY ENDS UNDER THE CENTRE, which is not where the product
     ends. World Imagery's ceiling is per footprint: one town reads to z20, the
@@ -1711,7 +1820,11 @@ export function GlobeSurface({
     it is not asked past the cap.
   */
   const ceiling =
-    !recentDrawn && !wide && esriHere.magnified && esriHere.maxLevel !== null
+    !drawing &&
+    !recentDrawn &&
+    !wide &&
+    esriHere.magnified &&
+    esriHere.maxLevel !== null
       ? zoomOfLevel(esriHere.maxLevel)
       : null
   /* Both, while the mosaic is drawn OVER Esri rather than in place of it. */
@@ -1883,17 +1996,49 @@ export function GlobeSurface({
             BETWEEN FINDING THE PLACE AND LIGHTING IT, because choosing which
             imagery answers is part of looking rather than part of drawing.
           */}
-          <MapButton
-            label={
-              recent
-                ? "Imagery: recent Sentinel-2"
-                : "Imagery: Esri, deepest available"
-            }
-            active={recent}
-            onClick={() => setRecent((v) => !v)}
+          {/*
+            THE BASE, BEFORE THE QUESTION ABOUT WHICH IMAGERY. Choosing a
+            photograph or a drawing is the wider of the two asks, and the one
+            below only applies to one of its answers.
+
+            A LIST AND NOT A CYCLE, which the first version was. Three answers
+            behind one button makes the second two presses away and the third
+            either one or two depending on where the reader already is, and a
+            cycling button can only name where it is going. The list names all
+            three at one press each.
+
+            THE GLYPHS ARE THE THREE SUBJECTS AND NOT THREE MAPS. A planet for
+            the photograph, a road for the streets. Topographic takes the
+            drafting compass rather than the mountains it would otherwise
+            want: the relief toggle two controls down already wears those, and
+            two identical glyphs on one rail is a rail that cannot be read
+            without pressing it.
+          */}
+          <MapMenu
+            label="Base"
+            value={base}
+            onChange={setBase}
+            options={BASE_OPTIONS}
           >
-            <Broadcast className="size-4" />
-          </MapButton>
+            {BASE_OPTIONS.find((o) => o.id === base)?.icon}
+          </MapMenu>
+          {/*
+            Withheld under a drawing: it asks which IMAGERY answers, and under
+            a street map neither does. See the effect that clears it.
+          */}
+          {!drawing && (
+            <MapButton
+              label={
+                recent
+                  ? "Imagery: recent Sentinel-2"
+                  : "Imagery: Esri, deepest available"
+              }
+              active={recent}
+              onClick={() => setRecent((v) => !v)}
+            >
+              <Broadcast className="size-4" />
+            </MapButton>
+          )}
           <MapButton
             label="Relief"
             active={relief}

--- a/frontend/src/components/globe/GlobeSurface.tsx
+++ b/frontend/src/components/globe/GlobeSurface.tsx
@@ -25,6 +25,7 @@ import "maplibre-gl/dist/maplibre-gl.css"
 import { useEffect, useMemo, useRef, useState } from "react"
 
 import { usePlantLayers, useNetwork } from "@/lib/plantRegister"
+import { voltageColourExpression } from "@/lib/gridVoltage"
 import {
   Broadcast,
   Globe,
@@ -1095,12 +1096,15 @@ export function GlobeSurface({
                   4, ["interpolate", ["linear"], ["get", "kv"], 230, 0.4, 800, 1.4],
                   10, ["interpolate", ["linear"], ["get", "kv"], 230, 1.1, 800, 3],
                 ],
-                "line-color": [
-                  "interpolate", ["linear"], ["get", "kv"],
-                  230, "#6E7B8B",
-                  500, "#8FA3B8",
-                  800, "#C6D4E1",
-                ],
+                /*
+                  THE SECTOR'S OWN COLOURS, not a ramp of this map's choosing.
+                  It was three blue-greys interpolated across the voltage,
+                  which said which of two circuits was higher and nothing about
+                  what either one is -- and at a glance it read as one mesh
+                  drawn in two weights. See lib/gridVoltage, which holds the
+                  table and where it was read from.
+                */
+                "line-color": voltageColourExpression(),
                 // Out of service dimmed rather than dropped: it is a corridor
                 // that exists, and its absence from the map would read as
                 // ground with no line near it.
@@ -1117,14 +1121,16 @@ export function GlobeSurface({
                   4, ["interpolate", ["linear"], ["get", "kv"], 69, 0.8, 800, 2.4],
                   10, ["interpolate", ["linear"], ["get", "kv"], 69, 2, 800, 5],
                 ],
+                /*
+                  A dark disc under a coloured ring, which is what makes a bus
+                  a bus and not a small plant: the plants below are filled
+                  marks. The ring takes the same table the circuits do, so a
+                  500 kV bus and the 500 kV line arriving at it are one colour
+                  and a reader does not have to learn the station separately.
+                */
                 "circle-color": "#0F1620",
                 "circle-stroke-width": 1,
-                "circle-stroke-color": [
-                  "interpolate", ["linear"], ["get", "kv"],
-                  69, "#6E7B8B",
-                  500, "#9FB3C8",
-                  800, "#D8E3EE",
-                ],
+                "circle-stroke-color": voltageColourExpression(),
                 "circle-opacity": 0.85,
               },
             },
@@ -1232,7 +1238,17 @@ export function GlobeSurface({
       const accent = token("--p-accent", "#ED8744")
       map.setPaintProperty(AREA_FILL, "fill-color", accent)
       map.setPaintProperty(AREA_LINE, "line-color", accent)
-
+      /*
+        THE METERED PLANT FOLLOWS THE ACCENT TOO, and it did not. Its colour
+        was the accent's literal, written into the style at construction and
+        never repainted -- so when the accent moved, the one mark on the map
+        that means "this is what can be asked about" stayed the colour the
+        accent used to be. The two AOI paints above were already read from the
+        token; this is the third that should have been.
+      */
+      if (map.getLayer(PLANT_METERED)) {
+        map.setPaintProperty(PLANT_METERED, "circle-color", accent)
+      }
     }
 
     /*

--- a/frontend/src/components/globe/MapChrome.tsx
+++ b/frontend/src/components/globe/MapChrome.tsx
@@ -13,27 +13,30 @@
  * control", and a wider one reads as a different kind of control that is also
  * shouting.
  */
-import { cn } from "@/lib/utils"
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { cn } from "@/lib/utils";
 
 /** One bar of controls: the hairline, the radius and the shadow. */
 export function MapBar({
   children,
   className,
 }: {
-  children: React.ReactNode
-  className?: string
+  children: React.ReactNode;
+  className?: string;
 }) {
   return (
     <div
       className={cn(
         "overflow-hidden rounded-md border border-[rgb(var(--p-line)/0.28)]",
         "shadow-[0_2px_8px_rgb(0_0_0/0.28)]",
-        className
+        className,
       )}
     >
       {children}
     </div>
-  )
+  );
 }
 
 /**
@@ -50,10 +53,10 @@ export function MapButton({
   onClick,
   children,
 }: {
-  label: string
-  active?: boolean
-  onClick: () => void
-  children: React.ReactNode
+  label: string;
+  active?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
 }) {
   return (
     <button
@@ -69,10 +72,159 @@ export function MapButton({
         "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
         active
           ? "bg-[rgb(var(--p-surface-raised)/0.92)] text-primary"
-          : "text-muted-foreground hover:bg-[rgb(var(--p-surface-raised)/0.92)] hover:text-foreground"
+          : "text-muted-foreground hover:bg-[rgb(var(--p-surface-raised)/0.92)] hover:text-foreground",
       )}
     >
       {children}
     </button>
-  )
+  );
+}
+
+/**
+ * One control that opens a short list, at the same measurements as the rest.
+ *
+ * A CYCLE WAS THE FIRST SHAPE AND IT ASKED THE READER TO COUNT. Three answers
+ * behind one button means the second is two presses away and the third is
+ * either one or two depending on where the reader already is -- and the button
+ * can only name where it is going, never where it could go. A list names all
+ * three and costs one press to any of them.
+
+ * It opens to the LEFT because the rail is at the map's right edge; a panel
+ * hung the other way would open off the surface it belongs to.
+ *
+ * IN A PORTAL, AND THAT IS NOT CAUTION. MapBar carries `overflow-hidden` --
+ * which is what clips its buttons to its own radius -- so a panel positioned
+ * beside the rail is a panel outside the bar's box, and the first version of
+ * this drew nothing at all: the button lit up, the list rendered, and the bar
+ * cut it away. Measured from the trigger and hung on the body instead, which
+ * is also what keeps it above the map's own canvas without a z-index race.
+ *
+ * The trigger carries the current choice's own glyph rather than a fixed one:
+ * the rail is glyphs without words, so a control whose icon does not move says
+ * nothing about what it is set to.
+ */
+export function MapMenu<T extends string>({
+  label,
+  value,
+  options,
+  onChange,
+  children,
+}: {
+  label: string;
+  value: T;
+  options: readonly { id: T; name: string; icon: React.ReactNode }[];
+  onChange: (id: T) => void;
+  /** The trigger's glyph: the current option's, chosen by the caller. */
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const host = useRef<HTMLDivElement>(null);
+  const [at, setAt] = useState<{ top: number; right: number } | null>(null);
+
+  /*
+    Where the panel goes, measured rather than assumed. `right` is the distance
+    from the viewport's right edge to the trigger's left edge, less the gap --
+    the same relation the CSS had, in the coordinates a fixed element uses.
+  */
+  const place = useCallback(() => {
+    const r = host.current?.getBoundingClientRect();
+    if (!r) return;
+    setAt({ top: r.top, right: window.innerWidth - r.left + 6 });
+  }, []);
+
+  /*
+    Closed by a press anywhere else and by Escape. `pointerdown` rather than
+    `click`, so a press that lands on the map both closes this and reaches the
+    map -- a menu that swallowed the first press would cost a second one to do
+    anything after opening it.
+  */
+  useEffect(() => {
+    if (!open) return;
+    place();
+    const away = (e: PointerEvent) => {
+      const t = e.target as Node;
+      if (!host.current?.contains(t) && !panel.current?.contains(t)) {
+        setOpen(false);
+      }
+    };
+    const key = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("pointerdown", away);
+    document.addEventListener("keydown", key);
+    // The rail is anchored to the map's corner, so anything that moves the
+    // corner moves the trigger under a panel that is no longer beside it.
+    window.addEventListener("resize", place);
+    return () => {
+      document.removeEventListener("pointerdown", away);
+      document.removeEventListener("keydown", key);
+      window.removeEventListener("resize", place);
+    };
+  }, [open, place]);
+
+  const panel = useRef<HTMLDivElement>(null);
+  const current = options.find((o) => o.id === value);
+  return (
+    <div ref={host} className="relative">
+      <button
+        type="button"
+        title={`${label}: ${current?.name ?? value}`}
+        aria-label={`${label}: ${current?.name ?? value}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className={cn(
+          "flex size-[2.125rem] items-center justify-center transition-colors",
+          "border-b border-[rgb(var(--p-line)/0.22)] last:border-b-0",
+          "bg-[rgb(var(--p-ink)/0.82)] backdrop-blur-[18px]",
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+          open
+            ? "bg-[rgb(var(--p-surface-raised)/0.92)] text-primary"
+            : "text-muted-foreground hover:bg-[rgb(var(--p-surface-raised)/0.92)] hover:text-foreground",
+        )}
+      >
+        {children}
+      </button>
+      {open &&
+        at &&
+        createPortal(
+          <div
+            ref={panel}
+            role="menu"
+            style={{ position: "fixed", top: at.top, right: at.right }}
+            className={cn(
+              "z-[401] w-44 overflow-hidden",
+              "rounded-md border border-[rgb(var(--p-line)/0.28)]",
+              "bg-[rgb(var(--p-ink)/0.92)] backdrop-blur-[18px]",
+              "shadow-[0_2px_8px_rgb(0_0_0/0.28)]",
+            )}
+          >
+            {options.map((o) => (
+              <button
+                key={o.id}
+                type="button"
+                role="menuitemradio"
+                aria-checked={o.id === value}
+                onClick={() => {
+                  onChange(o.id);
+                  setOpen(false);
+                }}
+                className={cn(
+                  "flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-meta transition-colors",
+                  o.id === value
+                    ? "bg-[rgb(var(--p-surface-raised)/0.92)] text-foreground"
+                    : "text-muted-foreground hover:bg-[rgb(var(--p-surface-raised)/0.6)] hover:text-foreground",
+                )}
+              >
+                <span className={o.id === value ? "text-primary" : undefined}>
+                  {o.icon}
+                </span>
+                {o.name}
+              </button>
+            ))}
+          </div>,
+          document.body,
+        )}
+    </div>
+  );
 }

--- a/frontend/src/components/globe/OverlayCallout.tsx
+++ b/frontend/src/components/globe/OverlayCallout.tsx
@@ -54,13 +54,13 @@ import {
   useLayoutEffect,
   useRef,
   useState,
-} from "react"
-import { CaretRight } from "@phosphor-icons/react"
-import { Marker, type Map as MapLibreMap } from "maplibre-gl"
-import { createRoot, type Root } from "react-dom/client"
+} from "react";
+import { CaretRight } from "@phosphor-icons/react";
+import { Marker, type Map as MapLibreMap } from "maplibre-gl";
+import { createRoot, type Root } from "react-dom/client";
 
-import type { LayerLegend } from "@/lib/layerLegend"
-import { cn } from "@/lib/utils"
+import type { LayerLegend } from "@/lib/layerLegend";
+import { cn } from "@/lib/utils";
 
 /**
  * How far up the screen a height of `metres` lands, at this camera.
@@ -89,25 +89,25 @@ import { cn } from "@/lib/utils"
 function riseInPixels(
   map: MapLibreMap,
   at: [number, number],
-  metres: number
+  metres: number,
 ): number {
-  if (metres <= 0) return 0
-  const p = map.project({ lng: at[0], lat: at[1] })
+  if (metres <= 0) return 0;
+  const p = map.project({ lng: at[0], lat: at[1] });
   // Over a hundred pixels: unprojecting two adjacent ones is a distance of
   // centimetres through a projection that is not exact at that scale.
-  const a = map.unproject([p.x - 50, p.y])
-  const b = map.unproject([p.x + 50, p.y])
-  const mPerPx = a.distanceTo(b) / 100
-  if (!Number.isFinite(mPerPx) || mPerPx <= 0) return 0
-  return (metres / mPerPx) * Math.sin((map.getPitch() * Math.PI) / 180)
+  const a = map.unproject([p.x - 50, p.y]);
+  const b = map.unproject([p.x + 50, p.y]);
+  const mPerPx = a.distanceTo(b) / 100;
+  if (!Number.isFinite(mPerPx) || mPerPx <= 0) return 0;
+  return (metres / mPerPx) * Math.sin((map.getPitch() * Math.PI) / 180);
 }
 
 /** Where the box starts, in pixels from the anchor. Up and to the left of it. */
-const START_X = -232
-const START_Y = -112
+const START_X = -232;
+const START_Y = -112;
 
 /** The box's width. Its height is measured: see below. */
-const BOX_W = 216
+const BOX_W = 216;
 
 /**
  * The height to assume for one frame, before the box has been measured.
@@ -116,7 +116,7 @@ const BOX_W = 216
  * window draws one line fewer, and a leader computed against a height the box
  * does not have leaves from an edge that is not there.
  */
-const BOX_H_GUESS = 92
+const BOX_H_GUESS = 92;
 
 /**
  * The run the leader takes off the box before it turns.
@@ -124,10 +124,83 @@ const BOX_H_GUESS = 92
  * Not all of it straight any more: STRAIGHT below says how much is drawn as a
  * line, and the rest of this length is where the turn's control point sits.
  */
-const STUB = 22
+const STUB = 22;
+
+/**
+ * A line that says the whole of itself, but only where it cannot show it.
+ *
+ * THE DISCLOSURE EXISTS ONLY WHERE THERE IS SOMETHING BEHIND IT. A parameter
+ * line is as long as the product has parameters -- "Annual · kWh/m2/year ·
+ * Copernicus DEM GLO-30 · 10 yr · opacity 100%" in a box 216 wide -- so it
+ * clips, and a clipped line with no way past it is a box that says it knows
+ * more than it will tell. A short one fits, and there a caret would be a
+ * control that expands nothing.
+ *
+ * So it is measured rather than assumed: the span reports whether its own
+ * content overflows it, and the caret appears for that answer. Which is also
+ * why `clipped` is a dependency of the effect that measures -- the node it
+ * observes is a different one once the line becomes a button, and an observer
+ * left on the old node would answer for a box that is no longer there.
+ *
+ * `stopPropagation` on the press, because the box captures the pointer to be
+ * dragged: without it the capture takes the pointerup and the button's click
+ * never happens, which reads as a caret that does nothing.
+ */
+function Disclosed({ text, className }: { text: string; className?: string }) {
+  const [open, setOpen] = useState(false);
+  const [clipped, setClipped] = useState(false);
+  const ref = useRef<HTMLSpanElement | null>(null);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el || open) return;
+    const read = () => setClipped(el.scrollWidth > el.clientWidth + 1);
+    read();
+    const ro = new ResizeObserver(read);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [open, clipped, text]);
+
+  if (!clipped && !open) {
+    return (
+      <p className={cn("mt-0.5", className)}>
+        <span ref={ref} className="block truncate">
+          {text}
+        </span>
+      </p>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onPointerDown={(e) => e.stopPropagation()}
+      onClick={() => setOpen((v) => !v)}
+      aria-expanded={open}
+      title={open ? "Show less" : text}
+      className="mt-0.5 flex w-full items-start gap-1 text-left transition-colors hover:brightness-125"
+    >
+      <CaretRight
+        aria-hidden
+        className={cn(
+          "mt-[3px] size-2.5 shrink-0 transition-transform",
+          open && "rotate-90",
+        )}
+      />
+      <span
+        ref={ref}
+        className={cn(
+          "min-w-0 flex-1",
+          className,
+          open ? "leading-relaxed" : "truncate",
+        )}
+      >
+        {text}
+      </span>
+    </button>
+  );
+}
 
 /** How many classes or figures a floating box carries before it is a panel. */
-const MAX_ROWS = 5
+const MAX_ROWS = 5;
 
 export interface OverlayCaption {
   /**
@@ -138,9 +211,9 @@ export interface OverlayCaption {
    * raster's colours cost the last time there was one: a disagreement with the
    * renderer of up to 40 of 255 on three stops.
    */
-  legend: NonNullable<LayerLegend>
+  legend: NonNullable<LayerLegend>;
   /** The ground it was measured over. */
-  area: string
+  area: string;
   /**
    * The line of parameters under the name: what the raster is, in what unit,
    * from what source, at what opacity.
@@ -154,7 +227,7 @@ export interface OverlayCaption {
    * different kinds of thing in one line depending on where the caption came
    * from.
    */
-  detail?: string | null
+  detail?: string | null;
 }
 
 export function OverlayCallouts({
@@ -162,18 +235,18 @@ export function OverlayCallouts({
   ready,
   captions,
 }: {
-  map: MapLibreMap | null
+  map: MapLibreMap | null;
   /** The style is up. Adding a marker before it is is not an error, but the
    *  projection it would be placed by is the one about to be replaced. */
-  ready: boolean
+  ready: boolean;
   captions: readonly {
-    key: string
+    key: string;
     /** Where the dot lands, [lon, lat]: the centre of the raster's extent. */
-    at: [number, number]
+    at: [number, number];
     /** How far above the ground the raster it describes is drawn, in metres. */
-    elevationM: number
-    caption: OverlayCaption
-  }[]
+    elevationM: number;
+    caption: OverlayCaption;
+  }[];
 }) {
   /*
     One marker per raster, held across renders.
@@ -183,10 +256,10 @@ export function OverlayCallouts({
     each time the caption changed would drop the drag the reader is in the
     middle of.
   */
-  const markers = useRef(new Map<string, { marker: Marker; root: Root }>())
+  const markers = useRef(new Map<string, { marker: Marker; root: Root }>());
   /** The captions as they are now, for a handler bound to the map's events. */
-  const liveCaptions = useRef(captions)
-  liveCaptions.current = captions
+  const liveCaptions = useRef(captions);
+  liveCaptions.current = captions;
   /**
    * Put every anchor at its raster's height.
    *
@@ -194,55 +267,55 @@ export function OverlayCallouts({
    * surface and there is no elevated one to give it. Negative Y is up.
    */
   const liftAll = useCallback(() => {
-    if (!map) return
+    if (!map) return;
     for (const c of liveCaptions.current) {
-      const held = markers.current.get(c.key)
-      if (!held) continue
-      held.marker.setOffset([0, -riseInPixels(map, c.at, c.elevationM)])
+      const held = markers.current.get(c.key);
+      if (!held) continue;
+      held.marker.setOffset([0, -riseInPixels(map, c.at, c.elevationM)]);
     }
-  }, [map])
+  }, [map]);
 
   useEffect(() => {
-    if (!map || !ready) return
-    const live = new Set(captions.map((c) => c.key))
+    if (!map || !ready) return;
+    const live = new Set(captions.map((c) => c.key));
 
     for (const [key, held] of markers.current) {
-      if (live.has(key)) continue
-      held.marker.remove()
+      if (live.has(key)) continue;
+      held.marker.remove();
       // Unmounted on a later task: React refuses to unmount a root while it is
       // rendering, and this effect can run inside that window.
-      const root = held.root
-      queueMicrotask(() => root.unmount())
-      markers.current.delete(key)
+      const root = held.root;
+      queueMicrotask(() => root.unmount());
+      markers.current.delete(key);
     }
 
     for (const c of captions) {
-      let held = markers.current.get(c.key)
+      let held = markers.current.get(c.key);
       if (!held) {
-        const el = document.createElement("div")
+        const el = document.createElement("div");
         // The element is the ANCHOR POINT, not the box: the library places its
         // centre at the coordinate, so anything drawn here is positioned
         // relative to the dot rather than to a corner of a card.
-        el.style.width = "0"
-        el.style.height = "0"
+        el.style.width = "0";
+        el.style.height = "0";
         /*
           Not `draggable`. The library's drag moves the marker, and the marker
           IS the anchor: using it would move the dot off the raster, which is
           the one thing the dot is for. The box does its own dragging below, in
           screen pixels, and the anchor stays on the ground.
         */
-        const marker = new Marker({ element: el }).setLngLat(c.at).addTo(map)
-        held = { marker, root: createRoot(el) }
-        markers.current.set(c.key, held)
+        const marker = new Marker({ element: el }).setLngLat(c.at).addTo(map);
+        held = { marker, root: createRoot(el) };
+        markers.current.set(c.key, held);
       } else {
         // Follows its raster. The box's offset is the reader's and is held
         // inside the mounted body, which survives this re-render.
-        held.marker.setLngLat(c.at)
+        held.marker.setLngLat(c.at);
       }
-      held.root.render(<CalloutBody caption={c.caption} />)
+      held.root.render(<CalloutBody caption={c.caption} />);
     }
-    liftAll()
-  }, [map, ready, captions, liftAll])
+    liftAll();
+  }, [map, ready, captions, liftAll]);
 
   /*
     The lift is re-applied on every camera move, because it is a function of
@@ -254,26 +327,26 @@ export function OverlayCallouts({
     animation, and the work per marker is one project and two unprojects.
   */
   useEffect(() => {
-    if (!map || !ready) return
-    map.on("move", liftAll)
+    if (!map || !ready) return;
+    map.on("move", liftAll);
     return () => {
-      map.off("move", liftAll)
-    }
-  }, [map, ready, liftAll])
+      map.off("move", liftAll);
+    };
+  }, [map, ready, liftAll]);
 
   useEffect(
     () => () => {
       for (const [, held] of markers.current) {
-        held.marker.remove()
-        const root = held.root
-        queueMicrotask(() => root.unmount())
+        held.marker.remove();
+        const root = held.root;
+        queueMicrotask(() => root.unmount());
       }
-      markers.current.clear()
+      markers.current.clear();
     },
-    []
-  )
+    [],
+  );
 
-  return null
+  return null;
 }
 
 /**
@@ -301,29 +374,29 @@ export function OverlayCallouts({
  * the box rather than one coming out of it; much more and the arc has too
  * little room left to bend and the elbow comes back.
  */
-const STRAIGHT = 0.34
+const STRAIGHT = 0.34;
 
 function leaderPath(dx: number, dy: number, boxH: number): string {
   // The box's rectangle, in the anchor's own frame.
-  const left = dx
-  const right = dx + BOX_W
-  const top = dy
-  const bottom = dy + boxH
+  const left = dx;
+  const right = dx + BOX_W;
+  const top = dy;
+  const bottom = dy + boxH;
 
   // Horizontal where the box is clearly to one side, vertical otherwise: the
   // comparison is against the box's own measure, so a box offset by less than
   // its width still leaves from the top or bottom rather than sideways.
-  const horizontal = right < 0 || left > 0
+  const horizontal = right < 0 || left > 0;
   if (horizontal) {
-    const x = right < 0 ? right : left
-    const y = Math.min(Math.max(0, top + 12), bottom - 12)
-    const stub = right < 0 ? STUB : -STUB
-    return `M ${x} ${y} L ${x + stub * STRAIGHT} ${y} Q ${x + stub} ${y}, 0 0`
+    const x = right < 0 ? right : left;
+    const y = Math.min(Math.max(0, top + 12), bottom - 12);
+    const stub = right < 0 ? STUB : -STUB;
+    return `M ${x} ${y} L ${x + stub * STRAIGHT} ${y} Q ${x + stub} ${y}, 0 0`;
   }
-  const y = bottom < 0 ? bottom : top
-  const x = Math.min(Math.max(0, left + 24), right - 24)
-  const stub = bottom < 0 ? STUB : -STUB
-  return `M ${x} ${y} L ${x} ${y + stub * STRAIGHT} Q ${x} ${y + stub}, 0 0`
+  const y = bottom < 0 ? bottom : top;
+  const x = Math.min(Math.max(0, left + 24), right - 24);
+  const stub = bottom < 0 ? STUB : -STUB;
+  return `M ${x} ${y} L ${x} ${y + stub * STRAIGHT} Q ${x} ${y + stub}, 0 0`;
 }
 
 /** A gradient bar and the two ends it runs between. */
@@ -332,9 +405,9 @@ function Ramp({
   low,
   high,
 }: {
-  gradient: string
-  low: string
-  high: string
+  gradient: string;
+  low: string;
+  high: string;
 }) {
   return (
     <>
@@ -343,13 +416,15 @@ function Ramp({
         style={{ background: gradient }}
       />
       <div className="mt-1 flex items-baseline justify-between gap-2">
-        <span className="telemetry text-micro text-muted-foreground">{low}</span>
+        <span className="telemetry text-micro text-muted-foreground">
+          {low}
+        </span>
         <span className="telemetry text-micro text-muted-foreground">
           {high}
         </span>
       </div>
     </>
-  )
+  );
 }
 
 /**
@@ -369,13 +444,15 @@ function LegendBody({ legend }: { legend: NonNullable<LayerLegend> }) {
   if (legend.kind === "ramp") {
     return (
       <Ramp gradient={legend.gradient} low={legend.low} high={legend.high} />
-    )
+    );
   }
 
   if (legend.kind === "classes") {
-    const ordered = [...legend.entries].sort((a, b) => (b.pct ?? 0) - (a.pct ?? 0))
-    const shown = ordered.slice(0, MAX_ROWS)
-    const rest = ordered.length - shown.length
+    const ordered = [...legend.entries].sort(
+      (a, b) => (b.pct ?? 0) - (a.pct ?? 0),
+    );
+    const shown = ordered.slice(0, MAX_ROWS);
+    const rest = ordered.length - shown.length;
     return (
       <div className="mt-1.5 flex flex-col gap-0.5">
         {shown.map((c) => (
@@ -401,7 +478,7 @@ function LegendBody({ legend }: { legend: NonNullable<LayerLegend> }) {
           </p>
         )}
       </div>
-    )
+    );
   }
 
   if (legend.kind === "note") {
@@ -409,15 +486,18 @@ function LegendBody({ legend }: { legend: NonNullable<LayerLegend> }) {
       <p className="mt-1.5 text-micro leading-relaxed text-muted-foreground">
         {legend.note}
       </p>
-    )
+    );
   }
 
-  const shown = legend.rows.slice(0, MAX_ROWS)
-  const rest = legend.rows.length - shown.length
+  const shown = legend.rows.slice(0, MAX_ROWS);
+  const rest = legend.rows.length - shown.length;
   return (
     <div className="mt-1.5 flex flex-col gap-0.5">
       {shown.map((r) => (
-        <div key={r.label} className="flex items-baseline justify-between gap-2">
+        <div
+          key={r.label}
+          className="flex items-baseline justify-between gap-2"
+        >
           <span className="min-w-0 truncate text-micro text-muted-foreground">
             {r.label}
           </span>
@@ -439,7 +519,7 @@ function LegendBody({ legend }: { legend: NonNullable<LayerLegend> }) {
         />
       )}
     </div>
-  )
+  );
 }
 
 function CalloutBody({ caption }: { caption: OverlayCaption }) {
@@ -451,68 +531,51 @@ function CalloutBody({ caption }: { caption: OverlayCaption }) {
     without the parent having to keep a map of offsets in step with a map of
     markers.
   */
-  const [off, setOff] = useState({ x: START_X, y: START_Y })
-  const from = useRef<{ x: number; y: number } | null>(null)
+  const [off, setOff] = useState({ x: START_X, y: START_Y });
+  const from = useRef<{ x: number; y: number } | null>(null);
 
   /*
     The box's height, measured rather than declared. It changes with the
     caption -- a product with no acquisition window is a line shorter -- and
     the leader has to know which edge faces the dot.
   */
-  /*
-    Whether the parameter line is showing in full, and whether it has anything
-    to show. See the disclosure below.
-  */
-  const [openDetail, setOpenDetail] = useState(false)
-  const [clipped, setClipped] = useState(false)
-  const detailRef = useRef<HTMLSpanElement | null>(null)
+  const boxRef = useRef<HTMLDivElement | null>(null);
+  const [boxH, setBoxH] = useState(BOX_H_GUESS);
   useLayoutEffect(() => {
-    const el = detailRef.current
-    if (!el || openDetail) return
-    const read = () => setClipped(el.scrollWidth > el.clientWidth + 1)
-    read()
-    const ro = new ResizeObserver(read)
-    ro.observe(el)
-    return () => ro.disconnect()
-  }, [openDetail, clipped, caption.detail])
-
-  const boxRef = useRef<HTMLDivElement | null>(null)
-  const [boxH, setBoxH] = useState(BOX_H_GUESS)
-  useLayoutEffect(() => {
-    const el = boxRef.current
-    if (!el) return
-    const read = () => setBoxH(el.offsetHeight || BOX_H_GUESS)
-    read()
-    const ro = new ResizeObserver(read)
-    ro.observe(el)
-    return () => ro.disconnect()
-  }, [])
+    const el = boxRef.current;
+    if (!el) return;
+    const read = () => setBoxH(el.offsetHeight || BOX_H_GUESS);
+    read();
+    const ro = new ResizeObserver(read);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
 
   const onPointerDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       // Left button only, and the map must not also read this as a pan.
-      if (e.button !== 0) return
-      e.stopPropagation()
-      e.preventDefault()
-      from.current = { x: e.clientX - off.x, y: e.clientY - off.y }
-      e.currentTarget.setPointerCapture(e.pointerId)
+      if (e.button !== 0) return;
+      e.stopPropagation();
+      e.preventDefault();
+      from.current = { x: e.clientX - off.x, y: e.clientY - off.y };
+      e.currentTarget.setPointerCapture(e.pointerId);
     },
-    [off.x, off.y]
-  )
+    [off.x, off.y],
+  );
 
   const onPointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    const start = from.current
-    if (!start) return
-    e.stopPropagation()
-    setOff({ x: e.clientX - start.x, y: e.clientY - start.y })
-  }, [])
+    const start = from.current;
+    if (!start) return;
+    e.stopPropagation();
+    setOff({ x: e.clientX - start.x, y: e.clientY - start.y });
+  }, []);
 
   const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    from.current = null
+    from.current = null;
     if (e.currentTarget.hasPointerCapture(e.pointerId)) {
-      e.currentTarget.releasePointerCapture(e.pointerId)
+      e.currentTarget.releasePointerCapture(e.pointerId);
     }
-  }, [])
+  }, []);
 
   return (
     <div className="relative">
@@ -628,67 +691,28 @@ function CalloutBody({ caption }: { caption: OverlayCaption }) {
         <p className="eyebrow !text-[9px] truncate text-primary">
           {caption.legend.subject}
         </p>
-        <p className="mt-0.5 truncate text-emphasis italic text-foreground">
-          {caption.area}
-        </p>
-        {caption.detail &&
-          (clipped || openDetail ? (
-            /*
-              THE DISCLOSURE EXISTS ONLY WHERE THERE IS SOMETHING BEHIND IT.
+        {/*
+          THE NAME GETS THE SAME WAY OUT THE PARAMETER LINE HAS.
 
-              The parameter line is as long as the product has parameters --
-              "Annual · kWh/m2/year · Copernicus DEM GLO-30 · 10 yr · opacity
-              100%" in a box 216 wide -- so it clips, and a clipped line with
-              no way past it is a box that says it knows more than it will
-              tell. A reading's line can be short enough to fit, and there a
-              caret would be a control that expands nothing.
-
-              So it is measured rather than assumed: the span reports whether
-              its own content overflows it, and the caret appears for that
-              answer. Which is also why `clipped` is a dependency of the effect
-              that measures -- the node it observes is a different one once the
-              line becomes a button, and an observer left on the old node would
-              answer for a box that is no longer there.
-
-              `stopPropagation` on the press, because the box captures the
-              pointer to be dragged: without it the capture takes the pointerup
-              and the button's click never happens, which reads as a caret that
-              does nothing.
-            */
-            <button
-              type="button"
-              onPointerDown={(e) => e.stopPropagation()}
-              onClick={() => setOpenDetail((v) => !v)}
-              aria-expanded={openDetail}
-              title={openDetail ? "Show less" : caption.detail}
-              className="mt-0.5 flex w-full items-start gap-1 text-left text-muted-foreground transition-colors hover:text-foreground"
-            >
-              <CaretRight
-                aria-hidden
-                className={cn(
-                  "mt-[3px] size-2.5 shrink-0 transition-transform",
-                  openDetail && "rotate-90"
-                )}
-              />
-              <span
-                ref={detailRef}
-                className={cn(
-                  "telemetry min-w-0 flex-1 text-micro",
-                  openDetail ? "leading-relaxed" : "truncate"
-                )}
-              >
-                {caption.detail}
-              </span>
-            </button>
-          ) : (
-            <p className="telemetry text-micro text-muted-foreground">
-              <span ref={detailRef} className="block truncate">
-                {caption.detail}
-              </span>
-            </p>
-          ))}
+          A circuit is named "LT 500 kV SANTA LUZIA II / MILAGRES II C1" and
+          the box is 216 wide, so the name clipped and there was nothing to
+          press: the callout told the reader which line they had picked up to
+          the point where it stops telling them. The parameter line below it
+          had had a disclosure for exactly this since it was written; this one
+          did not, and the two lines clip for the same reason.
+        */}
+        <Disclosed
+          text={caption.area}
+          className="text-emphasis italic text-foreground"
+        />
+        {caption.detail && (
+          <Disclosed
+            text={caption.detail}
+            className="telemetry text-micro text-muted-foreground"
+          />
+        )}
         <LegendBody legend={caption.legend} />
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/src/lib/basemaps.ts
+++ b/frontend/src/lib/basemaps.ts
@@ -2,9 +2,9 @@
  * What each basemap requires to be shown, and where it comes from.
  *
  * The credit is a licensing obligation, not chrome: Esri's terms require the
- * source to be attributed, EOX's require the Copernicus notice, and OSM's ODbL
- * requires attribution with a link where the medium allows one. So the parts
- * are structured rather than an HTML string -- the title bar renders real
+ * source to be attributed and EOX's require the Copernicus notice, with a link
+ * where the medium allows one. So the parts are structured rather than an HTML
+ * string -- the title bar renders real
  * anchors from this, which keeps the links the obligation asks for without any
  * component having to inject markup it did not write.
  *
@@ -15,7 +15,7 @@
 
 import { MOSAIC_MIN_LEVEL, MOSAIC_TILES } from "@/lib/recentImagery"
 
-export type BasemapKind = "esri" | "eox" | "s2recent" | "osm"
+export type BasemapKind = "esri" | "eox" | "s2recent" | "street" | "topo"
 
 export interface CreditPart {
   label: string
@@ -105,17 +105,47 @@ export const BASEMAPS: readonly Basemap[] = [
       },
     ],
   },
+  /*
+    THE TWO THAT ARE NOT PHOTOGRAPHS, and the reason they are Esri's.
+
+    Every basemap above is imagery: the reader could choose between two
+    pictures of the ground and not between a picture and a drawing. A drawing
+    answers a question the photographs cannot -- what a place is CALLED, where
+    the road goes, which side of the river a town is on -- and on this
+    application's own products it is the one base a classification can be
+    checked against by name.
+
+    From the same provider as the imagery, deliberately. It is already
+    credited, its licence is already satisfied by that credit, and its tiles
+    are the same 256 px scheme, so nothing about the layer stack changes when
+    the base does.
+
+    THIS REPLACED A ROW FOR OSM WHICH NOTHING READ. It had been carried since
+    the Leaflet map, unreferenced outside this file, and its URL still held the
+    `{s}` subdomain placeholder that Leaflet expands and MapLibre does not --
+    so the one non-imagery base the table declared could not have drawn a tile
+    if it had been wired. Wiring it was the other option and is the one the
+    operator's own tile policy argues against: it asks applications not to use
+    those servers and to identify themselves when they do.
+
+    NEITHER HAS A HANDOVER. The imagery pair splits at level 12 because Esri's
+    World Imagery is a Landsat-derived composite below it; these two are one
+    product drawn at every level, so a reader on either sees the same map from
+    the planet down to a street.
+  */
   {
-    kind: "osm",
-    name: "Map (OSM)",
-    url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+    kind: "street",
+    name: "Streets (Esri)",
+    url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}",
     maxZoom: 19,
-    credit: [
-      {
-        label: "© OpenStreetMap",
-        href: "https://www.openstreetmap.org/copyright",
-      },
-    ],
+    credit: [{ label: "Tiles © Esri" }],
+  },
+  {
+    kind: "topo",
+    name: "Topographic (Esri)",
+    url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}",
+    maxZoom: 19,
+    credit: [{ label: "Tiles © Esri" }],
   },
 ]
 

--- a/frontend/src/lib/gridVoltage.ts
+++ b/frontend/src/lib/gridVoltage.ts
@@ -1,0 +1,56 @@
+/**
+ * What colour a circuit is, by the voltage it runs at.
+ *
+ * NOT CHOSEN HERE. These are the values ANEEL's own transmission map paints,
+ * read out of the renderer its service publishes -- PORTAL/Transmissão layer 1,
+ * field SymbolID, uniqueValue -- rather than sampled from a screenshot or
+ * matched by eye. A reader who works with the sector's maps recognises them
+ * without a legend, which is the whole reason for taking a convention instead
+ * of designing a ramp: the ramp would be better at saying which of two lines is
+ * higher, and worse at saying what either one IS.
+ *
+ * WHAT THE CONVENTION DOES NOT NAME. Its renderer has a sixth class holding
+ * 13.8, 34.5, 69, 88, 525, 600 and 765 kV together, painted black. Three of
+ * those are levels this register carries -- the store's own note names a 600 kV
+ * line -- so the class is not empty here, and black is not usable: the map's
+ * base is imagery as often as it is a street map, and a black circuit over
+ * either is a circuit that is read as a gap.
+ *
+ * So the class keeps its meaning and loses its colour. `UNNAMED` is a light
+ * neutral, which says what the convention says about these levels -- that it
+ * does not distinguish them -- rather than inventing five more hues and
+ * claiming an authority this table is here to borrow.
+ */
+import type { ExpressionSpecification } from "maplibre-gl"
+
+/** The levels ANEEL's renderer names, with the colour it gives each. */
+export const VOLTAGE_COLOUR: readonly { kv: number; colour: string }[] = [
+  { kv: 138, colour: "#F3C71F" },
+  { kv: 230, colour: "#1A9B43" },
+  { kv: 345, colour: "#00A2EC" },
+  { kv: 440, colour: "#B684A1" },
+  { kv: 500, colour: "#C90E16" },
+]
+
+/**
+ * Every other level, including the ones the convention lumps with the
+ * distribution voltages. See the note above for why this is not black.
+ */
+export const UNNAMED_VOLTAGE = "#C6D4E1"
+
+/**
+ * The table as a MapLibre expression over a feature's `kv`.
+ *
+ * `match` and not `step`, because these are named levels and not a range: a
+ * 525 kV circuit is not "somewhere above 500", it is a level the convention
+ * has an answer about, and that answer is the unnamed class. A step would
+ * paint it as though it were 500.
+ */
+export function voltageColourExpression(): ExpressionSpecification {
+  return [
+    "match",
+    ["get", "kv"],
+    ...VOLTAGE_COLOUR.flatMap(({ kv, colour }) => [kv, colour]),
+    UNNAMED_VOLTAGE,
+  ] as unknown as ExpressionSpecification
+}


### PR DESCRIPTION
Three corrections to the map screen. Each stands on its own and they are
independent of one another; they share a branch because they touch the same
four files.

## The base can be a drawing, not only a photograph

Every base this screen could show was imagery: Esri's footprints and a
Sentinel-2 mosaic, two pictures of the same ground. A drawing answers what a
photograph cannot -- what a place is called, where the road runs -- and on this
application's own products it is the one base a classification can be checked
against by name.

The table already declared an OSM row and nothing read it; its URL still held
the `{s}` subdomain placeholder that Leaflet expands and MapLibre does not, so
the single non-imagery base the table named could not have drawn a tile. Wiring
it was the alternative, and the operator's tile policy argues against it. Esri's
street and topographic maps instead, from the provider already credited for the
imagery, on the same 256 px scheme.

The rail button became a menu whose icon reports the base in force. It is
rendered through a portal: `MapBar` sets `overflow-hidden`, so a panel
positioned beside it was clipped away entirely.

## A circuit is coloured by the voltage it runs at

The network was drawn in three blue-greys interpolated across the voltage, so
colour said which of two circuits was higher and nothing about what either one
is. At a glance the 1,830 of them read as one mesh in two weights.

The colours are the sector's, read out of the ArcGIS renderer ANEEL publishes
for its own transmission map (PORTAL/Transmissao, layer 1, field SymbolID),
rather than sampled from a screenshot or matched by eye. The convention holds
13.8, 34.5, 69, 88, 525, 600 and 765 kV in one class painted black; three of
those are levels this register carries, and black over imagery reads as a gap,
so that class keeps its meaning and takes a light neutral instead. Inventing
five more hues would claim an authority this table exists to borrow.

Substations take the same table on their ring, so a 500 kV bus and the 500 kV
line arriving at it are one colour.

Also here: the metered plant's mark had the accent's literal written into the
style at construction and never repainted, so it stayed the colour the accent
used to be after the rotation to blue. It reads the token now, as the two AOI
paints beside it already did.

## A callout's name says the whole of itself

"LT 500 kV SANTA LUZIA II / MILAGRES II C1" in a 216 px callout clipped with
nothing to press. The disclosure it needed was already in the file, on the
parameter line underneath. Extracted rather than copied: the caret appears only
where the span reports its own content overflowing, and the press stops
propagation because the box captures the pointer to be dragged.

## Verification

`tsc`, 379 frontend tests, `check:contrast`, `gofmt`, `go vet` and
`go test ./...` all pass at the tip. Each commit was checked to build,
typecheck and test on its own in a separate worktree.

Rebased onto `main` after #75 and #76 merged.

Generated with [Claude Code](https://claude.com/claude-code)
