### PR TITLE
fix(globe): a raster drawn over the ground, not against it

### DIFF
--- a/frontend/src/components/globe/GlobeSurface.tsx
+++ b/frontend/src/components/globe/GlobeSurface.tsx
@@ -252,10 +252,15 @@ const RAISED_LAYER = "raised-rasters"
 /**
  * How far the lowest raster sits above the ground, in metres.
  *
- * At zero it shares a depth with the imagery it is drawn over, and two
- * surfaces at one depth flicker against each other as the camera moves. A
- * metre is below the resolution of anything drawn here and above the depth
- * buffer's ability to confuse them.
+ * It is what separates the stack from the ground when the spread is zero, so
+ * the lowest raster and the legend tied to it are anchored a little above the
+ * surface rather than on it.
+ *
+ * It is NOT what keeps the two apart in the depth buffer, and it was written
+ * believing it was. A metre is one part in six million of the globe's radius,
+ * which no depth buffer resolves at that scale -- the overlay banded against
+ * the ground below zoom 12 for exactly that reason. What fixed it was the
+ * layer not testing depth at all; see the note in `raisedRasters`.
  */
 const BASE_LIFT_M = 1
 /**

--- a/frontend/src/components/globe/GlobeSurface.tsx
+++ b/frontend/src/components/globe/GlobeSurface.tsx
@@ -1048,12 +1048,27 @@ export function GlobeSurface({
               written globe raycast the outline and had to fall back on nearest
               centre within a tolerance, because a line has no area to strike.
               A fill has area, so the press lands on the shape a reader aimed at.
+
+              IT PAINTS NOTHING, AND IT IS STILL THE TARGET. The wash it used to
+              carry sat over whatever the area holds -- imagery, and any raster
+              sent to it -- and tinted all of it. Fourteen percent is little on
+              an empty field and a great deal over a reading whose whole subject
+              is its colour: the value under the tint is not the value in the
+              legend beside it, and there is no way for a reader to discount a
+              cast they cannot see the size of. So the boundary is the line, and
+              the ground inside it is the ground.
+
+              Zero opacity rather than `visibility: none`, because the two are
+              not the same to the press: MapLibre's query skips a hidden layer
+              and keeps an invisible one. Measured rather than assumed --
+              `queryRenderedFeatures` returns the polygon at `fill-opacity: 0`
+              and returns nothing at `visibility: "none"`.
             */
             {
               id: AREA_FILL,
               type: "fill",
               source: AREA_SOURCE,
-              paint: { "fill-color": "#ED8744", "fill-opacity": 0.14 },
+              paint: { "fill-opacity": 0 },
             },
             {
               id: AREA_LINE,
@@ -1236,7 +1251,7 @@ export function GlobeSurface({
     const paint = () => {
       if (!map.isStyleLoaded()) return
       const accent = token("--p-accent", "#ED8744")
-      map.setPaintProperty(AREA_FILL, "fill-color", accent)
+      // AREA_FILL is not repainted: it paints nothing. See its layer above.
       map.setPaintProperty(AREA_LINE, "line-color", accent)
       /*
         THE METERED PLANT FOLLOWS THE ACCENT TOO, and it did not. Its colour

--- a/frontend/src/components/globe/raisedRasters.test.ts
+++ b/frontend/src/components/globe/raisedRasters.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The unit each projection term is fed, pinned as text.
+ *
+ * A shader cannot be run here -- there is no GL context in this suite and
+ * standing one up would test the driver rather than the decision. What is
+ * worth pinning is not the arithmetic anyway: it is which of the two elevation
+ * uniforms reaches which matrix, because the defect this guards was exactly
+ * one identifier in one branch and it cost the overlay every pass through the
+ * crossfade.
+ *
+ * So the assertions read the generated source. They are deliberately about the
+ * pairing and nothing else: rewrite the projection however you like, and these
+ * still fail the moment metres are handed to the matrix that wants mercator
+ * units.
+ */
+import { describe, expect, it } from "vitest"
+
+import { vertexSource } from "./raisedRasters"
+
+/** Enough of the prelude's shape for the branches to be readable. */
+const PRELUDE = "uniform mat4 u_projection_matrix;"
+
+function branches(define: string) {
+  const src = vertexSource(PRELUDE, define)
+  const globe = src.slice(src.indexOf("#ifdef GLOBE"), src.indexOf("#else"))
+  const mercator = src.slice(src.indexOf("#else"), src.indexOf("#endif"))
+  return { src, globe, mercator }
+}
+
+describe("the raised raster's vertex source", () => {
+  const { globe, mercator } = branches("#define GLOBE")
+
+  it("raises the sphere by the metres, which is the unit a globe radius is in", () => {
+    expect(globe).toContain("u_elevation_m / GLOBE_RADIUS")
+  })
+
+  it("gives the fallback matrix mercator units, because its z is world-scaled", () => {
+    expect(globe).toMatch(
+      /u_projection_fallback_matrix \* vec4\(a_pos, u_elevation_mercator, 1\.0\)/
+    )
+  })
+
+  it("never spends the metres on the fallback matrix", () => {
+    /*
+      The whole failure, stated as the thing that must not happen: MapLibre
+      hands the mercator custom-layer matrix over as the globe's fallback, so a
+      metre passed there is read as a mercator unit -- forty thousand
+      kilometres, and the corner leaves the frame.
+    */
+    const fallback = globe.slice(globe.indexOf("u_projection_fallback_matrix"))
+    expect(fallback).not.toMatch(/u_elevation_m\b/)
+  })
+
+  it("mixes towards the sphere by the transition MapLibre reports", () => {
+    expect(globe).toContain("mix(onPlane, onSphere, u_projection_transition)")
+  })
+
+  it("takes the sphere alone once the transition has finished", () => {
+    expect(globe).toContain("u_projection_transition > 0.999")
+  })
+
+  it("feeds the flat projection mercator units and never metres", () => {
+    expect(mercator).toContain("projectTileFor3D(a_pos, u_elevation_mercator)")
+    expect(mercator).not.toMatch(/u_elevation_m\b/)
+  })
+
+  it("carries the prelude and the define it was compiled beside", () => {
+    const { src } = branches("#define GLOBE")
+    expect(src).toContain(PRELUDE)
+    expect(src).toContain("#define GLOBE")
+    expect(src.startsWith("#version 300 es")).toBe(true)
+  })
+})

--- a/frontend/src/components/globe/raisedRasters.ts
+++ b/frontend/src/components/globe/raisedRasters.ts
@@ -27,6 +27,22 @@
  * latitude, because a mercator unit is a different number of metres at the
  * equator than at sixty degrees.
  *
+ * AND BOTH ARE WANTED AT ONCE WHILE THE PROJECTION IS CHANGING, which is the
+ * thing `projectTileFor3D` cannot express and the reason the globe path below
+ * is written out instead of delegated. MapLibre hands a custom layer a globe
+ * matrix and a fallback matrix and crossfades between them as the sphere
+ * flattens; the fallback it hands is the MERCATOR custom-layer matrix, whose z
+ * is scaled by the world size. So inside one call the sphere wants metres and
+ * the fallback wants mercator units, and the helper takes one argument for
+ * both.
+ *
+ * Feeding it metres put the fallback corner an Earth's circumference up: for
+ * the width of the crossfade the quad was mixed between a position on the
+ * ground and one forty thousand kilometres above it. That is what smeared the
+ * overlay from 11.1 and had it gone by 11.5, and why nothing was ever wrong
+ * above 12 -- past the crossfade the transition is 1, the fallback drops out
+ * of the mix, and the sphere term is the only one left.
+ *
  * BACK TO FRONT, WITH DEPTH WRITES OFF. These quads are translucent and they
  * overlap; sorted by elevation and drawn without writing depth is the painter's
  * order, which is what lets the lower raster show through the upper one rather
@@ -82,7 +98,7 @@ function mercatorPerMetre(b: Bounds): number {
   ).meterInMercatorCoordinateUnits()
 }
 
-const VERT = (prelude: string, define: string) => `#version 300 es
+export const vertexSource = (prelude: string, define: string) => `#version 300 es
 ${prelude}
 ${define}
 in vec2 a_pos;
@@ -97,11 +113,29 @@ void main() {
     MapLibre's own, so the branch cannot fall out of step with the prelude it
     was compiled beside.
   */
-  #ifdef GLOBE
-  gl_Position = projectTileFor3D(a_pos, u_elevation_m);
-  #else
+#ifdef GLOBE
+  /*
+    What the prelude's own projectTileFor3D does, with one difference: the two
+    terms are given the two units they are each written in, rather than one
+    number spent on both. Everything used here is the prelude's -- the sphere,
+    the radius, the fallback matrix and the transition -- so this stays a
+    restatement of MapLibre's arithmetic and not a second projection.
+  */
+  v_projection_tile_x = a_pos.x;
+  vec3 spherePos = projectToSphere(a_pos, a_pos);
+  vec3 raised = spherePos * (1.0 + u_elevation_m / GLOBE_RADIUS);
+  vec4 onSphere = u_projection_matrix * vec4(raised, 1.0);
+  if (u_projection_transition > 0.999) {
+    // Wholly a sphere: the fallback is not mixed in, so it is not computed.
+    gl_Position = onSphere;
+  } else {
+    vec4 onPlane =
+      u_projection_fallback_matrix * vec4(a_pos, u_elevation_mercator, 1.0);
+    gl_Position = mix(onPlane, onSphere, u_projection_transition);
+  }
+#else
   gl_Position = projectTileFor3D(a_pos, u_elevation_mercator);
-  #endif
+#endif
 }`
 
 const FRAG = `#version 300 es
@@ -222,7 +256,7 @@ export function raisedRasterLayer(
     if (held) return held
     const vs = compile(
       ctx,
-      VERT(shader.vertexShaderPrelude, shader.define),
+      vertexSource(shader.vertexShaderPrelude, shader.define),
       ctx.VERTEX_SHADER
     )
     const fs = compile(ctx, FRAG, ctx.FRAGMENT_SHADER)

--- a/frontend/src/components/globe/raisedRasters.ts
+++ b/frontend/src/components/globe/raisedRasters.ts
@@ -43,10 +43,29 @@
  * above 12 -- past the crossfade the transition is 1, the fallback drops out
  * of the mix, and the sphere term is the only one left.
  *
- * BACK TO FRONT, WITH DEPTH WRITES OFF. These quads are translucent and they
- * overlap; sorted by elevation and drawn without writing depth is the painter's
- * order, which is what lets the lower raster show through the upper one rather
- * than being cut away by a depth test against a fragment that was never opaque.
+ * BACK TO FRONT, AND NOT DEPTH TESTED AT ALL. These quads are translucent and
+ * they overlap; sorted by elevation and drawn without writing depth is the
+ * painter's order, which is what lets the lower raster show through the upper
+ * one rather than being cut away by a fragment that was never opaque.
+ *
+ * The test went with the writes, and that took measuring rather than taste.
+ * MapLibre fills the depth buffer with the ground itself -- `painter` line
+ * `if (isRenderingGlobe && !map.terrain) this._renderTilesDepthBuffer()`, the
+ * tile meshes drawn at elevation zero. So on the sphere, with relief OFF, the
+ * ground is in the buffer and this quad is a metre above it: one part in six
+ * million of the globe's radius, far under what the buffer can separate at that
+ * scale. Two surfaces the depth test cannot tell apart is z-fighting, and
+ * z-fighting is banding -- which is what the overlay did below zoom 12, in
+ * stripes that moved when the camera turned and closed up when it flattened.
+ *
+ * AND THE TEST WAS NEVER BUYING WHAT IT CLAIMED. It was here so terrain could
+ * occlude a raster behind a ridge. It cannot: the quad is lifted from mercator
+ * ZERO, not from the ground, so with relief on it is not hidden behind the hill
+ * but buried under it -- and relief on is also the case where MapLibre skips
+ * the pre-pass, so the two states each defeated it in their own way. An overlay
+ * asked for over an area is drawn over that area; occluding one by relief is a
+ * thing to build from the terrain's own elevation, deliberately, and not to
+ * half-inherit from a shared buffer.
  */
 import { MercatorCoordinate } from "maplibre-gl"
 import type {
@@ -291,10 +310,10 @@ export function raisedRasterLayer(
     id,
     type: "custom",
     /*
-      3d, so the depth buffer is shared with the rest of the map and terrain
-      can occlude a raster that is behind a ridge. It is also what makes the
-      mercator variant's z conformal, which is what the elevation is expressed
-      against.
+      3d for the projection, not for the depth: it is what makes the mercator
+      variant's z conformal, which is the space the elevation is expressed in.
+      The depth buffer is shared with the rest of the map and this layer neither
+      reads nor writes it; the header says why.
     */
     renderingMode: "3d",
 
@@ -365,14 +384,16 @@ export function raisedRasterLayer(
 
       ctx.enable(ctx.BLEND)
       ctx.blendFunc(ctx.ONE, ctx.ONE_MINUS_SRC_ALPHA)
-      ctx.enable(ctx.DEPTH_TEST)
       /*
-        Tested but not written. These quads are translucent and stacked over
-        one another; writing depth would make the first one drawn cut away
-        every fragment of the ones behind it, whatever their alpha.
+        Neither tested nor written. Not written because these quads are
+        translucent and stacked, and the first one drawn would cut away every
+        fragment behind it whatever its alpha. Not tested because the only
+        thing in the buffer to test against is the ground this raster is drawn
+        over, a metre below it and indistinguishable from it on the sphere --
+        see the header. Disabling the test disables the write with it, so the
+        mask is the driver's business rather than ours.
       */
-      ctx.depthMask(false)
-      ctx.depthFunc(ctx.LEQUAL)
+      ctx.disable(ctx.DEPTH_TEST)
 
       ctx.bindBuffer(ctx.ARRAY_BUFFER, buffer)
       ctx.enableVertexAttribArray(prog.aPos)
@@ -398,8 +419,6 @@ export function raisedRasterLayer(
         )
         ctx.drawArrays(ctx.TRIANGLES, 0, 6)
       }
-
-      ctx.depthMask(true)
     },
   }
 }


### PR DESCRIPTION
Three faults on the globe, found while chasing one report: a raster that came
apart into bands below zoom 12 and closed up above it.

## The overlay stops fighting the ground for the same depth

This is the one that was reported. Bands that move when the camera turns are
not a texture fault and not an analysis fault -- the stored PNG is whole -- they
are two surfaces the depth buffer cannot separate.

MapLibre puts the ground in the depth buffer, and only in one case:
`_renderTilesDepthBuffer()` runs under
`if (isRenderingGlobe && !this.style.map.terrain)`, drawing the tile meshes at
elevation zero into depth alone. On the sphere with relief off -- the default,
and the state in every report -- the ground is in the buffer and this quad is a
metre above it. A metre is one part in six million of the globe's radius, far
below what the buffer resolves at that scale, so `LEQUAL` decided per fragment
and the decision moved with the camera. Above zoom 12 the projection is
mercator, the pre-pass does not run, and nothing ever looked wrong up there.

The test was not buying what it claimed. It was there so terrain could occlude
a raster behind a ridge, and it cannot: the quad is lifted from mercator zero
rather than from the ground, so with relief on it is buried under the hill
rather than hidden behind it -- and relief on is the case where MapLibre skips
the pre-pass. Each state defeated it differently. So the test goes, along with
the writes it was already refusing to make.

## A raised raster survives the flattening of the sphere

Found on the way, in the same crossfade. `drawCustom` hands a custom layer a
globe matrix and a fallback matrix and mixes between them by
`u_projection_transition`; the fallback it hands is the mercator custom-layer
matrix, whose z is scaled by the world size. So inside one call the sphere term
wants metres and the fallback term wants mercator units, and
`projectTileFor3D` takes one argument for both.

Passing the metres lifted the fallback corner by a whole mercator unit: at zoom
11.5 that is 1.48e6 world pixels where 0.037 was meant. The globe path is now
written out and each term is given the unit it is written in -- the sphere, the
radius, the fallback matrix and the transition are all the prelude's, and the
early return above 0.999 is too, so a mercator-only view still computes one
matrix product.

Both variants were compiled and linked against a real WebGL2 context rather
than read: the info logs are empty, the attributes bind, and every uniform the
layer feeds is live in the variant that uses it. The test pins which elevation
reaches which matrix, because that is what broke -- one identifier in one
branch.

## The area's boundary is a line, and the ground inside it is the ground

The fill under an area carried a fourteen percent wash of the accent. Over an
empty field that is a tint on grass; over a raster sent to that same area it is
a cast on the reading, and the value under the tint is not the value in the
legend beside it. Rotating the accent to blue is what made it visible as a cold
veil.

The layer stays and still takes the press -- it exists because the old globe
raycast the outline, could not strike a line, and fell back on nearest centre
within a tolerance. Zero opacity rather than `visibility: none`, because those
are not the same to the query: measured, `queryRenderedFeatures` returns the
polygon at `fill-opacity: 0` and returns nothing at `visibility: "none"`.

## Verification

`tsc`, 22 test files / 386 tests, `check:contrast`, `gofmt`, `go vet` and
`go test ./...` pass at the tip. The reported symptom was confirmed gone in the
running application at the zooms and bearings where it appeared.

Generated with [Claude Code](https://claude.com/claude-code)
