### PR TITLE
fix(studio): the card that chose the product stays on the board that follows

### DIFF
--- a/frontend/src/components/studio/runGraph.test.ts
+++ b/frontend/src/components/studio/runGraph.test.ts
@@ -135,6 +135,31 @@ describe("cards no edge reaches", () => {
     }
   })
 
+  /*
+    THE CARD THAT CHOSE THE FAMILY IS ON THE GRAPH THE CHOICE PRODUCES.
+
+    On the energy entry the product card draws the nine labels, so it is not
+    only a description of the run -- it is the only control that can change
+    which run is being described. A branch that leaves it out takes the choice
+    off the board the moment it is made, and the reader is held on whichever
+    product they last picked with nothing to press. Wind did exactly that.
+
+    Asserted across every energy graph rather than against wind alone, because
+    the fault was not that wind was wrong: it was that eight branches agreed
+    and nothing said they had to.
+  */
+  it("does not include the product card, which every energy graph carries", () => {
+    const energy = GRAPHS.filter(([name]) => isEnergy(name))
+    expect(energy.length).toBe(9)
+    for (const [name, graph] of energy) {
+      expect(
+        graph.nodes.map((n) => n.id),
+        name
+      ).toContain("product")
+      expect(graph.edges.flat(), name).toContain("product")
+    }
+  })
+
   it("is nothing at all on the graphs that are not energy", () => {
     const rest = GRAPHS.filter(([name]) => !isEnergy(name))
     expect(rest.length).toBe(5)

--- a/frontend/src/components/studio/runGraph.ts
+++ b/frontend/src/components/studio/runGraph.ts
@@ -444,12 +444,31 @@ function productGraph(
   */
   if (family === "wind") {
     return {
-      nodes: [at("area", 0), at("record", 0), at("turbine", 1), at("roughness", 1), at("run", 2)],
+      nodes: [
+        at("area", 0),
+        at("record", 0),
+        /*
+          THE PRODUCT CARD IS ON EVERY ENERGY GRAPH, INCLUDING THIS ONE.
+
+          It is not a parameter here -- wind has one product and the card shows
+          it rather than offering a choice within the family. It is on the
+          graph because it is the control that chose the family, and a control
+          that removes itself when used is a door that locks behind the reader:
+          picking wind took the nine labels off the board and left no way back
+          to solar or the grid. Every sibling branch carries it; this one was
+          the omission.
+        */
+        at("product", 1),
+        at("turbine", 1),
+        at("roughness", 1),
+        at("run", 2),
+      ],
       edges: [
         ["area", "run"],
         ["record", "run"],
         ["turbine", "run"],
         ["roughness", "run"],
+        ["product", "run"],
       ],
     }
   }


### PR DESCRIPTION
Choosing Wind on the energy board removed the product card from the graph, and
the product card is the control that draws the nine product labels. The choice
took away the only thing that could change it: the board came back as area,
record, turbine, roughness and run, with no way back to solar or the grid.

## Cause

All four solar branches and all four grid branches in `runGraph.ts` place
`at("product", 1)`. The wind branch did not. Read alone the omission looks
deliberate -- the comment above it explains, correctly, that wind has no
acquisition-window card -- but a window is a parameter and this card is the
door out of the family.

It is not a parameter for wind either: wind has one product, so the card shows
what was chosen rather than offering a choice within the family. That is reason
to draw it, not to drop it.

## Guard

The test asserts the product card on every energy graph rather than on wind,
because the fault was that eight branches agreed and nothing required it. It
was run against the unfixed file first and fails there by name:

```
AssertionError: wind: expected [ 'area', 'record', 'turbine', ... ] to include 'product'
```

## Verification

`tsc` clean, 387 tests, `check:contrast` clean, verified alone on `main`.
Confirmed in the running application.

Generated with [Claude Code](https://claude.com/claude-code)
