### PR TITLE
feat(browser): a folder is a colour, and its glyph says what is filed there

### DIFF
--- a/frontend/src/components/studio/StudioBrowser.tsx
+++ b/frontend/src/components/studio/StudioBrowser.tsx
@@ -801,6 +801,7 @@ export function StudioBrowser({
                     key={f.id}
                     name={f.name}
                     count={f.count}
+                    kinds={folderKinds(f.id)}
                     onOpen={enter}
                     onContext={context}
                   />
@@ -1203,9 +1204,20 @@ function SourceNode({
         ) : Icon ? (
           <Icon className="size-3.5 shrink-0" />
         ) : open ? (
-          <FolderOpen className="size-3.5 shrink-0" />
+          /*
+            The same tone the grid's folders carry. A folder is one colour
+            wherever it is drawn, or the tree and the grid are two vocabularies
+            for one thing -- and this row is the same folder the tile is.
+          */
+          <FolderOpen
+            className="size-3.5 shrink-0"
+            style={{ color: tint("--p-folder") }}
+          />
         ) : (
-          <Folder className="size-3.5 shrink-0" />
+          <Folder
+            className="size-3.5 shrink-0"
+            style={{ color: tint("--p-folder") }}
+          />
         )}
         <span className="min-w-0 flex-1 truncate">{label}</span>
         {marked && (
@@ -1311,14 +1323,34 @@ function FolderBranch({
 function FolderTile({
   name,
   count,
+  kinds,
   onOpen,
   onContext,
 }: {
   name: string
   count: number
+  /** Which products are filed here, in the table's order. */
+  kinds: readonly KindId[]
   onOpen: () => void
   onContext: (at: { x: number; y: number }) => void
 }) {
+  /*
+    THE GLYPH APPEARS WHERE IT SAYS SOMETHING, AND NOWHERE ELSE.
+
+    Blender marks Desktop, Documents and Downloads and leaves every other
+    folder plain, which is the rule worth taking: a mark on all of them is a
+    mark that distinguishes none. So a folder holding one product wears that
+    product's glyph, and a mixed one wears nothing -- the same honesty the tree
+    already applies when it draws a single child for a folder with nothing to
+    choose between.
+
+    Not five small glyphs for a mixed folder. The tile is 68px of folder body
+    and the count under it already says how much is inside; a row of marks that
+    small is a texture, and the reader who wants the breakdown opens the tree,
+    where it is drawn at a size that can be read.
+  */
+  const only = kinds.length === 1 ? KIND_BY_ID.get(kinds[0]) : undefined
+  const Glyph = only?.icon
   return (
     <button
       type="button"
@@ -1327,7 +1359,11 @@ function FolderTile({
         e.preventDefault()
         onContext({ x: e.clientX, y: e.clientY })
       }}
-      title={`${name} — ${count} ${count === 1 ? "analysis" : "analyses"}. Double-click to open.`}
+      title={
+        `${name} — ${count} ${count === 1 ? "analysis" : "analyses"}` +
+        (only ? `, all ${only.label.toLowerCase()}` : "") +
+        ". Double-click to open."
+      }
       className={cn(
         `flex ${TILE_W} flex-col gap-1 rounded-sm border border-transparent p-1 text-left transition-colors`,
         "hover:bg-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
@@ -1349,15 +1385,38 @@ function FolderTile({
       */}
       <span className={cn(TILE_PLATE, "flex items-center justify-start")}>
         <span className="flex h-[3.25rem] w-[4.25rem] flex-col">
-          {/* The tab, a little over a third of the width. */}
+          {/* The tab, a little over a third of the width, and behind the body. */}
           <span
             className="h-[0.5rem] w-[42%] rounded-t-[3px]"
-            style={{ background: "rgb(var(--p-line) / 0.55)" }}
+            style={{ background: tint("--p-folder-tab") }}
           />
+          {/*
+            Lit at the top and shaded at the foot, with a hairline along the
+            edge between the two -- the front panel of a folder, catching the
+            light a flat fill cannot. One tone read as a swatch beside the
+            reference this was drawn from; see the note in index.css.
+          */}
           <span
-            className="flex-1 rounded-b-[3px] rounded-tr-[3px]"
-            style={{ background: "rgb(var(--p-line) / 0.34)" }}
-          />
+            className="flex flex-1 items-center justify-center rounded-b-[3px] rounded-tr-[3px]"
+            style={{
+              background: `linear-gradient(${tint("--p-folder")}, ${tint(
+                "--p-folder-shade"
+              )})`,
+              boxShadow: "inset 0 1px 0 rgb(255 255 255 / 0.10)",
+            }}
+          >
+            {Glyph ? (
+              /*
+                On the folder rather than on a plate of its own: the body IS
+                the plate, and a second one inside it would be a tile within a
+                tile. Ink rather than the product's tint, because the tint on
+                its own ground is what every run tile in this grid already
+                does, and two things that look alike would be saying different
+                sentences.
+              */
+              <Glyph className="size-4" style={{ color: tint("--p-folder-ink") }} aria-hidden />
+            ) : null}
+          </span>
         </span>
       </span>
       <span className="truncate text-emphasis text-foreground">{name}</span>
@@ -1395,7 +1454,10 @@ function FolderRow({
         "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
       )}
     >
-      <Folder className="size-4 shrink-0" />
+      <Folder
+        className="size-4 shrink-0"
+        style={{ color: tint("--p-folder") }}
+      />
       <span className="min-w-0 flex-1 truncate text-emphasis text-foreground">
         {name}
       </span>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -218,6 +218,51 @@
   --p-kind-wind: 162 147 209;
 
   /*
+    THE FOLDER, WHICH IS NOT A PRODUCT AND MUST NOT READ AS ONE.
+
+    A container holds the products above; it is not one of them, and giving it
+    a hue from that scale would say a folder of solar runs IS solar. So it sits
+    beside the scale rather than in it, and two measurements place it.
+
+    LOWER CHROMA THAN A PRODUCT, which is the same move the scale above made
+    against the semantic tokens: a status is C 0.149, a product is C 0.09, and
+    the thing that merely holds products is C 0.058. Three tiers, each asking
+    less of the reader's attention than the one above.
+
+    ONE STEP TOWARDS ITS OWN GROUND, not one step darker. A container should
+    recede, and receding is darker on graphite and lighter on paper -- so the
+    two blocks move in opposite directions and the folder ends up nearly the
+    same colour in both themes. That is the bands' property, for the bands'
+    reason: it is a colour rather than a relation to a ground.
+
+    FOUR VALUES, BECAUSE A FLAT SHAPE READ AS A RECTANGLE. The first pass was
+    one tone for the body and one for the tab, and against Blender's own icons
+    it looked like a swatch rather than like a folder. What the reference has
+    and it did not is depth: the body is lighter at its top edge than at its
+    bottom, so the front panel catches light and the shape reads as a thing
+    with a front. `--p-folder` is that lit top and `--p-folder-shade` the foot
+    of the same face; the tree and the list, which draw a folder as a glyph and
+    have no face to light, take the lit value alone.
+
+    The tab is below both, because it is the back of the folder seen over the
+    front. A literal rather than the body at a lower alpha: alpha is darker on
+    graphite and lighter on paper, so a translucent tab would light the folder
+    from opposite sides in the two themes.
+
+    AND THE GLYPH IS LIGHTER THAN THE FOLDER, which is the reference's choice
+    and reads at 16px where the first pass did not. One value across both
+    themes, for a reason stronger than symmetry: every ink token in this file
+    flips, and this ink's ground does not.
+
+    Not gated by check-contrast.ts, for the reason the scale above gives: these
+    are a shape's fill, never a ground for text.
+  */
+  --p-folder: 153 143 103;
+  --p-folder-shade: 137 127 87;
+  --p-folder-tab: 122 112 73;
+  --p-folder-ink: 215 209 187;
+
+  /*
     THE PARTS OF A REQUEST, AS COLOUR. A second scale of its own, on the same
     construction as the products above and not mixed with either that one or
     the semantic tokens.
@@ -578,6 +623,16 @@
   --p-kind-water: 19 130 130;
   --p-kind-flood: 64 119 163;
   --p-kind-wind: 117 103 161;
+
+  /* The folder, receding towards THIS ground rather than away from it. The
+     dark block carries the argument; these are the same four tones stepped the
+     other way, which is why they land so close to it. The ink is not stepped
+     at all -- it is the one value both themes share, because the surface it is
+     drawn on is also one value. */
+  --p-folder: 160 150 109;
+  --p-folder-shade: 144 134 94;
+  --p-folder-tab: 129 120 80;
+  --p-folder-ink: 215 209 187;
 
   /*
     THE SAME BLOCK FOR A LIGHT GROUND, and the same rule: every line is a hex


### PR DESCRIPTION
The browser drew folders in two greys off `--p-line`, so the only thing that
separated a folder from a run was its silhouette. Blender's file browser was
the reference: a warm folder, and a glyph inside the ones worth marking.

## Placement

Not a hue from the product scale. A folder holds products and is not one;
borrowing `--p-kind-solar` would say a folder of solar runs *is* solar. It sits
beside that scale, placed by two measurements:

- **Lower chroma.** The product scale already sits below the semantic tokens
  (C 0.09 against 0.149). The thing that merely holds products sits below that
  again, at C 0.058.
- **One step towards its own ground,** not one step darker: receding is darker
  on graphite and lighter on paper. The two theme blocks move in opposite
  directions, and the folder lands on nearly one colour in both.

## Two things that flip, caught by rendering both themes side by side

- The tab is a literal a step below the body, not the body at a lower alpha.
  Alpha is darker on graphite and lighter on paper, so a translucent tab lit
  the folder from opposite sides in the two themes.
- The glyph is one value across both themes. Every ink token in `index.css`
  flips, and this glyph's ground does not. It is lighter than the folder, which
  is the reference's choice and the one that reads at 16px.

The body is lit at its top and shaded at its foot; with one tone the shape read
as a swatch rather than as a folder.

## Glyph rule

A folder holding one product wears that product's glyph; a mixed one stays
plain. Blender marks Desktop, Documents and Downloads and leaves the rest
alone -- a mark on every folder distinguishes none. The tree and the list view
take the same tone, so a folder is one colour wherever it is drawn.

## Verification

`tsc` clean, 386 tests, `check:contrast` clean, verified alone on `main`. The
new tokens are ungated by `check-contrast.ts` on the rule `index.css` already
states for the product scale: a shape's fill, never a ground for text.
Confirmed in the running application.

Generated with [Claude Code](https://claude.com/claude-code)
