### PR TITLE
feat(studio): the application menu gains the rooms that had no door

### DIFF
--- a/frontend/src/components/SplashScreen.tsx
+++ b/frontend/src/components/SplashScreen.tsx
@@ -13,6 +13,17 @@ import { BRAND_TAGLINE, RELEASE_NAME } from "@/lib/brand"
 type SplashScreenProps = {
   /** When true, fade/scale out before the main window opens. */
   exiting?: boolean
+  /**
+   * Whether this is the real boot.
+   *
+   * The application menu shows this screen again on request, and at that
+   * moment nothing is booting: the boot events have long since stopped and the
+   * last line would read "booting…" over a window that has been open for an
+   * hour. A still shown deliberately says what it is instead -- the signature
+   * the brand carries everywhere else -- and does not subscribe to a stream
+   * that will never speak again.
+   */
+  live?: boolean
 }
 
 /**
@@ -24,7 +35,7 @@ type SplashScreenProps = {
  * holds a single still, so every launch is that one; the claim below is what
  * walks the manifest whenever it holds more.
  */
-export function SplashScreen({ exiting = false }: SplashScreenProps) {
+export function SplashScreen({ exiting = false, live = true }: SplashScreenProps) {
   const [logs, setLogs] = useState<string[]>(["booting…"])
   /*
     Claimed once, and never advanced.
@@ -90,6 +101,8 @@ export function SplashScreen({ exiting = false }: SplashScreenProps) {
   }, [])
 
   useEffect(() => {
+    // Nothing is booting when the menu asks for this; see `live`.
+    if (!live) return
     let cancelled = false
 
     GetBootLogs()
@@ -113,9 +126,9 @@ export function SplashScreen({ exiting = false }: SplashScreenProps) {
       cancelled = true
       EventsOff("boot:log")
     }
-  }, [])
+  }, [live])
 
-  const statusLine = logs[logs.length - 1] ?? "booting…"
+  const statusLine = live ? (logs[logs.length - 1] ?? "booting…") : BRAND_TAGLINE
   const activeImage = SPLASH_STILLS[slide]?.path ?? SPLASH_IMAGES[0]
 
   return (

--- a/frontend/src/components/studio/BoardSurface.tsx
+++ b/frontend/src/components/studio/BoardSurface.tsx
@@ -27,6 +27,11 @@ import {
   FolderSimple,
   Package,
   SlidersHorizontal,
+  HardDrive,
+  ImageSquare,
+  Info,
+  Sparkle,
+  Terminal,
 } from "@phosphor-icons/react"
 import type { RasterLayer } from "@/lib/mapLayers"
 import type { LayerPatch } from "@/components/studio/BoardSidebar"
@@ -175,6 +180,7 @@ import {
   tokenColor,
   type BoardStats,
 } from "@/components/studio/boardScene"
+import { useAppSurfaces } from "@/lib/appSurfaces"
 import { cn } from "@/lib/utils"
 import { remToPx } from "@/lib/boardPartition"
 import {
@@ -2997,6 +3003,11 @@ export function BoardSurface({
   surfaceRef2.current = surface
   const [appMenu, setAppMenu] = useState(false)
   /*
+    The rooms behind the application half of that menu. The hook holds their
+    state and the modals; this file draws the items and says where they go.
+  */
+  const app = useAppSurfaces()
+  /*
     WHICH GROUP'S MENU IS OPEN, by id rather than a boolean, because the bar
     carries one entrance per group and only one of them may be down at a time.
     A boolean per group would let two open together, which is the one thing a
@@ -5061,6 +5072,66 @@ export function BoardSurface({
               setAppMenu(false)
             }}
           />
+          {/*
+            AND THE THINGS THAT ARE ABOUT THE APPLICATION RATHER THAN THIS
+            BOARD, which is what the two above are.
+
+            They are here because this is already the application's menu -- the
+            note at the top of this block says so -- and because each of them
+            could otherwise be reached exactly once: the splash is shown while
+            the window boots and replaced, the release notes appear on the first
+            launch after an upgrade and mark themselves seen, and the storage
+            report and the interpreter live inside the account page, which is a
+            different screen from this one.
+
+            Below a rule rather than mixed in, since saving a studio and reading
+            the version are not the same kind of act. `useAppSurfaces` owns what
+            they open; this file only says where they are pressed.
+          */}
+          <StudioMenuRule />
+          <StudioMenuItem
+            icon={ImageSquare}
+            label={app.items.splash.label}
+            onSelect={() => {
+              app.items.splash.onSelect()
+              setAppMenu(false)
+            }}
+          />
+          <StudioMenuItem
+            icon={Sparkle}
+            label={app.items.releaseNotes.label}
+            onSelect={() => {
+              app.items.releaseNotes.onSelect()
+              setAppMenu(false)
+            }}
+          />
+          <StudioMenuRule />
+          <StudioMenuItem
+            icon={Terminal}
+            label={app.items.environment.label}
+            onSelect={() => {
+              app.items.environment.onSelect()
+              setAppMenu(false)
+            }}
+          />
+          <StudioMenuItem
+            icon={HardDrive}
+            label={app.items.storage.label}
+            disabled={app.items.storage.disabled}
+            onSelect={() => {
+              app.items.storage.onSelect()
+              setAppMenu(false)
+            }}
+          />
+          <StudioMenuRule />
+          <StudioMenuItem
+            icon={Info}
+            label={app.items.about.label}
+            onSelect={() => {
+              app.items.about.onSelect()
+              setAppMenu(false)
+            }}
+          />
         </StudioPopover>
 
         <span
@@ -5642,6 +5713,11 @@ export function BoardSurface({
       />
       </CanopyWorkflowProvider>
 
+      {/*
+        The rooms the application half of the Studio menu opens. Position does
+        not matter: every one of them is a modal or portals out of this tree.
+      */}
+      {app.surfaces}
     </motion.div>
   )
 }

--- a/frontend/src/lib/appSurfaces.tsx
+++ b/frontend/src/lib/appSurfaces.tsx
@@ -1,0 +1,245 @@
+/**
+ * The surfaces the application menu opens, and the state that keeps them.
+ *
+ * WHAT THEY HAVE IN COMMON. Four things here could be reached exactly once and
+ * then never again: the splash still is shown while the window boots and
+ * replaced, the release notes appear on the first launch after an upgrade and
+ * mark themselves seen, and the storage report and the Python environment live
+ * inside the account page, which is a different screen from wherever the reader
+ * is working. None is about what is on screen -- they are about the
+ * application -- so a per-screen home was never right for them.
+ *
+ * WHY A HOOK AND NOT A MENU. The application menu already exists: the studio
+ * bar opens one at its left end, where Blender puts File, and its own note
+ * says so. A second menu on the wordmark would have been a second answer to
+ * "where are this application's own commands", which is the question that menu
+ * was built to answer. So this module owns the rooms and the existing menu
+ * keeps the door.
+ *
+ * The caller renders the items with its own menu primitives -- one menu, one
+ * look -- and drops `surfaces` anywhere in its tree. Everything here portals
+ * or is a modal, so where it lands does not matter.
+ */
+import { useCallback, useEffect, useState } from "react"
+import { createPortal } from "react-dom"
+
+import { GetAppVersion } from "../../wailsjs/go/main/App"
+import { BRAND_TAGLINE, RELEASE_NAME } from "@/lib/brand"
+import { notesForVersion } from "@/lib/whatsNew"
+import { useStorageReport } from "@/lib/storageReport"
+import { EnvironmentPanel } from "@/components/EnvironmentPanel"
+import { SplashScreen } from "@/components/SplashScreen"
+import { StorageModal } from "@/components/StorageModal"
+import { WhatsNewModal } from "@/components/WhatsNewModal"
+import { ModalHeader, ModalShell } from "@/components/ui/ModalShell"
+
+/** Which surface the menu opened, or none. One at a time, by construction. */
+type Showing = "splash" | "whatsnew" | "environment" | "about" | null
+
+/** What the caller's menu needs to draw one item. */
+export interface AppSurfaceItem {
+  label: string
+  onSelect: () => void
+  disabled?: boolean
+}
+
+export interface AppSurfaces {
+  /** The items above the caller's own, in the order they should be drawn. */
+  items: {
+    splash: AppSurfaceItem
+    releaseNotes: AppSurfaceItem
+    environment: AppSurfaceItem
+    storage: AppSurfaceItem
+    about: AppSurfaceItem
+  }
+  /** Render this once, anywhere: every piece of it portals or is a modal. */
+  surfaces: React.ReactNode
+}
+
+export function useAppSurfaces(): AppSurfaces {
+  const [showing, setShowing] = useState<Showing>(null)
+  const storage = useStorageReport()
+  const close = useCallback(() => setShowing(null), [])
+
+  return {
+    items: {
+      splash: { label: "Splash screen", onSelect: () => setShowing("splash") },
+      releaseNotes: {
+        label: `What\u2019s new in ${RELEASE_NAME}`,
+        onSelect: () => setShowing("whatsnew"),
+      },
+      environment: {
+        label: "Python environment\u2026",
+        onSelect: () => setShowing("environment"),
+      },
+      /*
+        Measures before it opens, so the dialog never renders against a report
+        that has not arrived. The wait sits on this press, which is where the
+        reader is already looking -- and the caller closes its menu first, so
+        the delay reads as the dialog coming rather than as the menu having
+        ignored the click.
+      */
+      storage: {
+        label: "Storage\u2026",
+        disabled: storage.busy,
+        onSelect: () => void storage.measureAndOpen(),
+      },
+      about: { label: "About TERRA", onSelect: () => setShowing("about") },
+    },
+    surfaces: (
+      <>
+        {showing === "splash" && <SplashReplay onDone={close} />}
+        {showing === "whatsnew" && <ReleaseNotes onClose={close} />}
+        {showing === "environment" && (
+          <ModalShell
+            onDismiss={close}
+            labelledBy="app-environment-title"
+            className="h-[min(82vh,760px)] w-[min(94vw,780px)]"
+          >
+            <ModalHeader
+              eyebrow="System"
+              title="Python environment"
+              titleId="app-environment-title"
+              subtitle="The interpreter the analyses run in, and what is installed in it."
+              onClose={close}
+            />
+            <div className="min-h-0 flex-1 overflow-auto px-4 py-3">
+              <EnvironmentPanel />
+            </div>
+          </ModalShell>
+        )}
+        {showing === "about" && <About onClose={close} />}
+        {storage.open && storage.report && (
+          <StorageModal
+            report={storage.report}
+            busy={storage.busy}
+            note={storage.note}
+            problem={storage.problem}
+            onRefresh={() => void storage.refresh()}
+            onPurge={() => void storage.purge()}
+            onClose={storage.close}
+          />
+        )}
+      </>
+    ),
+  }
+}
+
+/**
+ * The splash, shown because it was asked for.
+ *
+ * Over everything and dismissed by anything: this is a still, not a dialog --
+ * there is nothing in it to decide, so any press or key puts it away. `live`
+ * is false, which is what stops it claiming to be booting something.
+ */
+function SplashReplay({ onDone }: { onDone: () => void }) {
+  useEffect(() => {
+    const done = () => onDone()
+    document.addEventListener("pointerdown", done)
+    document.addEventListener("keydown", done)
+    return () => {
+      document.removeEventListener("pointerdown", done)
+      document.removeEventListener("keydown", done)
+    }
+  }, [onDone])
+
+  return createPortal(
+    <div className="fixed inset-0 z-[500]">
+      <SplashScreen live={false} />
+    </div>,
+    document.body
+  )
+}
+
+/**
+ * The notes for the release that is running.
+ *
+ * The gate that shows these on an upgrade asks for everything since the
+ * version last seen. Asked for deliberately, that span is the wrong question:
+ * the reader wants to know what this release is, not what they have missed. So
+ * it is the running version's entry, and the newest one when the running
+ * version has none -- which is what a development build between tags is.
+ */
+function ReleaseNotes({ onClose }: { onClose: () => void }) {
+  const [version, setVersion] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    GetAppVersion()
+      .then((v) => {
+        if (!cancelled) setVersion(v?.trim() || "")
+      })
+      .catch(() => {
+        if (!cancelled) setVersion("")
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (version === null) return null
+
+  const entries = notesForVersion(version)
+  if (!entries.length) return null
+
+  return (
+    <WhatsNewModal
+      currentVersion={version || entries[0].version}
+      entries={entries}
+      onContinue={onClose}
+    />
+  )
+}
+
+/** Name, release, version. What the application is, and which one this is. */
+function About({ onClose }: { onClose: () => void }) {
+  const [version, setVersion] = useState("")
+
+  useEffect(() => {
+    let cancelled = false
+    GetAppVersion()
+      .then((v) => {
+        if (!cancelled) setVersion(v?.trim() ?? "")
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <ModalShell
+      onDismiss={onClose}
+      labelledBy="app-menu-about-title"
+      className="w-[min(92vw,26rem)]"
+    >
+      <ModalHeader
+        eyebrow="About"
+        title="TERRA"
+        titleId="app-menu-about-title"
+        subtitle={BRAND_TAGLINE}
+        onClose={onClose}
+      />
+      <div className="px-4 py-4">
+        <img
+          src="/terra-logo.png"
+          alt=""
+          className="mb-4 h-12 w-12 object-contain"
+        />
+        <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-meta">
+          <dt className="text-muted-foreground">Release</dt>
+          <dd className="text-foreground">{RELEASE_NAME}</dd>
+          <dt className="text-muted-foreground">Version</dt>
+          {/*
+            Read from the binary rather than from a constant in this bundle: a
+            number the frontend keeps is a number that can disagree with the
+            application it is describing, which is the whole reason to ask.
+          */}
+          <dd className="tabular-nums text-foreground">
+            {version || "unknown"}
+          </dd>
+        </dl>
+      </div>
+    </ModalShell>
+  )
+}

--- a/frontend/src/lib/storageReport.ts
+++ b/frontend/src/lib/storageReport.ts
@@ -1,0 +1,112 @@
+/**
+ * The data directory's size, and the one place that asks for it.
+ *
+ * Two surfaces want this: the account page, which has always had it, and the
+ * application menu, which is a second door onto the same dialog. Two copies of
+ * a measure-then-open sequence is two places for the busy flag to be forgotten
+ * and two places for the note to be cleared -- so it is one hook, and the
+ * dialog is handed the same shape either way.
+ *
+ * MEASURED ON DEMAND, NOT ON MOUNT. Walking the directory costs real time once
+ * there are hundreds of analyses, and neither surface is opened to look at disk
+ * usage in the common case. The reasoning was written on the page this was
+ * lifted from and belongs with the code rather than with one of its callers.
+ *
+ * AND MEASURED BEFORE THE DIALOG OPENS, not after. Opening first would render
+ * against no data, so every field in it would have to guard against a report
+ * that has not arrived. The control the reader pressed carries the wait, which
+ * is where they are already looking.
+ */
+import { useCallback, useState } from "react"
+
+import {
+  InspectStorage,
+  PurgeOrphanedRunAssets,
+} from "../../wailsjs/go/main/App"
+import type { store } from "../../wailsjs/go/models"
+import { formatBytes } from "@/lib/formatBytes"
+
+export interface StorageReportState {
+  report: store.StorageReport | null
+  busy: boolean
+  /** What the last purge freed, or null when nothing has been purged. */
+  note: string | null
+  /** Why the last attempt failed. Shown where the reader pressed. */
+  problem: string | null
+  open: boolean
+  /** Measure, then open. The wait is the caller's button, not an empty shell. */
+  measureAndOpen: () => Promise<void>
+  /** Measure again with the dialog already up. */
+  refresh: () => Promise<void>
+  /** Clear the folders no analysis points at, then measure again. */
+  purge: () => Promise<void>
+  close: () => void
+}
+
+export function useStorageReport(): StorageReportState {
+  const [report, setReport] = useState<store.StorageReport | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [note, setNote] = useState<string | null>(null)
+  const [problem, setProblem] = useState<string | null>(null)
+  const [open, setOpen] = useState(false)
+
+  const measure = useCallback(async (thenOpen: boolean) => {
+    setBusy(true)
+    setProblem(null)
+    setNote(null)
+    try {
+      setReport(await InspectStorage())
+      if (thenOpen) setOpen(true)
+    } catch (e) {
+      /*
+        The error stays where the reader pressed rather than opening a dialog
+        that exists only to say it could not measure anything -- a line under
+        the control is a better way to say that than a modal.
+      */
+      setProblem(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }, [])
+
+  const measureAndOpen = useCallback(() => measure(true), [measure])
+  const refresh = useCallback(() => measure(false), [measure])
+
+  /*
+    No confirmation, deliberately: nothing in the application can open these
+    files and no export includes them, so there is nothing for the reader to
+    weigh. A dialog asking them to approve deleting something they cannot see
+    or reach would be theatre.
+  */
+  const purge = useCallback(async () => {
+    setBusy(true)
+    setProblem(null)
+    try {
+      const result = await PurgeOrphanedRunAssets()
+      setNote(
+        `Cleared ${formatBytes(result.freed_bytes)} from ${result.removed} ${
+          result.removed === 1 ? "folder" : "folders"
+        }.`
+      )
+      setReport(await InspectStorage())
+    } catch (e) {
+      setProblem(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }, [])
+
+  const close = useCallback(() => setOpen(false), [])
+
+  return {
+    report,
+    busy,
+    note,
+    problem,
+    open,
+    measureAndOpen,
+    refresh,
+    purge,
+    close,
+  }
+}

--- a/frontend/src/lib/whatsNew.test.ts
+++ b/frontend/src/lib/whatsNew.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Which notes the menu shows, which is not the question the gate asks.
+ *
+ * The two callers want different spans out of one catalogue -- everything
+ * missed, versus what this release is -- and the difference is easy to lose in
+ * a refactor because both are "the release notes". So each is pinned against
+ * the same fixture, and the case that decides them apart is the reader who
+ * skipped a version.
+ */
+import { describe, expect, it } from "vitest"
+
+import { entriesSince, notesForVersion, type WhatsNewEntry } from "./whatsNew"
+
+const CATALOG: WhatsNewEntry[] = [
+  { version: "0.6.0", title: "six", items: [] },
+  { version: "0.5.0", title: "five", items: [] },
+  { version: "0.4.0", title: "four", items: [] },
+]
+
+describe("notesForVersion", () => {
+  it("is the running version's entry, not everything before it", () => {
+    expect(notesForVersion("0.5.0", CATALOG).map((e) => e.title)).toEqual([
+      "five",
+    ])
+  })
+
+  it("differs from the gate's span for a reader who skipped a version", () => {
+    /*
+      The reader last saw 0.4.0 and is running 0.6.0. The gate owes them both
+      releases; the menu owes them the one they are in. Same catalogue, same
+      version, two answers -- which is the whole reason the second function
+      exists.
+    */
+    expect(entriesSince("0.4.0", "0.6.0", CATALOG).map((e) => e.title)).toEqual([
+      "six",
+      "five",
+    ])
+    expect(notesForVersion("0.6.0", CATALOG).map((e) => e.title)).toEqual(["six"])
+  })
+
+  it("falls back to the newest for a build between tags", () => {
+    // A development version, or a patch folded into the minor above it.
+    expect(notesForVersion("0.6.1", CATALOG).map((e) => e.title)).toEqual(["six"])
+    expect(notesForVersion("", CATALOG).map((e) => e.title)).toEqual(["six"])
+  })
+
+  it("finds the newest by version rather than by position", () => {
+    const shuffled = [CATALOG[2], CATALOG[0], CATALOG[1]]
+    expect(notesForVersion("9.9.9", shuffled).map((e) => e.title)).toEqual(["six"])
+  })
+
+  it("answers nothing only when there is nothing to answer with", () => {
+    expect(notesForVersion("0.6.0", [])).toEqual([])
+  })
+})

--- a/frontend/src/lib/whatsNew.ts
+++ b/frontend/src/lib/whatsNew.ts
@@ -91,3 +91,28 @@ export function entriesSince(
     )
     .sort((x, y) => compareSemver(y.version, x.version))
 }
+
+/**
+ * The notes to show when a reader ASKS for them, which is a different question
+ * from the one the upgrade gate asks.
+ *
+ * The gate wants everything since the version last seen, because its subject
+ * is what the reader has missed. Someone opening this from the menu has missed
+ * nothing: they want to know what the release they are running IS. So it is
+ * that version's entry alone.
+ *
+ * A build between tags -- a development version, or a patch whose notes were
+ * folded into the minor above it -- matches no entry. Answering with nothing
+ * would make the menu item do nothing at all, which reads as broken rather
+ * than as empty, so the newest entry stands in: it is the release this build
+ * belongs to, which is the honest answer to what was asked.
+ */
+export function notesForVersion(
+  version: string,
+  catalog: WhatsNewEntry[] = WHATS_NEW
+): WhatsNewEntry[] {
+  if (!catalog.length) return []
+  const exact = catalog.filter((e) => e.version === version.trim())
+  if (exact.length) return exact
+  return [...catalog].sort((a, b) => compareSemver(b.version, a.version)).slice(0, 1)
+}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -17,8 +17,6 @@ import { BrowserOpenURL } from "../../wailsjs/runtime/runtime"
 import {
   ChooseBackupArchive,
   ExportBackup,
-  InspectStorage,
-  PurgeOrphanedRunAssets,
   RestoreBackup,
 } from "../../wailsjs/go/main/App"
 import type { store } from "../../wailsjs/go/models"
@@ -55,6 +53,7 @@ import {
 } from "@/lib/preferenceExtras"
 import { displayRunLabel } from "@/lib/aoiLabel"
 import { formatBytes } from "@/lib/formatBytes"
+import { useStorageReport } from "@/lib/storageReport"
 import { runRowLine } from "@/lib/runSummary"
 
 const MAX_AVATAR_BYTES = 2_000_000
@@ -145,11 +144,12 @@ export function ProfilePage({
     useState<store.RestorePreview | null>(null)
   const [restoreResult, setRestoreResult] = useState<string | null>(null)
   const [restoreError, setRestoreError] = useState<string | null>(null)
-  const [storage, setStorage] = useState<store.StorageReport | null>(null)
-  const [storageBusy, setStorageBusy] = useState(false)
-  const [storageNote, setStorageNote] = useState<string | null>(null)
-  const [storageError, setStorageError] = useState<string | null>(null)
-  const [storageOpen, setStorageOpen] = useState(false)
+  /*
+    The measure, the purge and the dialog's state, from the module that owns
+    them. The application menu opens the same dialog, and a second copy of this
+    sequence would be a second place for the busy flag to be forgotten.
+  */
+  const storage = useStorageReport()
   /*
     Account, always, unless something asks otherwise while this is open.
 
@@ -425,79 +425,6 @@ export function ProfilePage({
       setBackupError(e instanceof Error ? e.message : String(e))
     } finally {
       setBackupBusy(false)
-    }
-  }
-
-  /*
-    Measured on demand, not on mount.
-
-    Walking the data directory costs real time once there are hundreds of
-    analyses, and Account is opened to change a display name far more often
-    than to look at disk usage. Paying for it every visit would slow the common
-    case for the rare one.
-  */
-  const loadStorage = async () => {
-    setStorageBusy(true)
-    setStorageError(null)
-    setStorageNote(null)
-    try {
-      setStorage(await InspectStorage())
-    } catch (e) {
-      setStorageError(e instanceof Error ? e.message : String(e))
-    } finally {
-      setStorageBusy(false)
-    }
-  }
-
-  /*
-    Measured before the modal opens, not after.
-
-    Opening first would render the dialog against no data, so its first frame
-    would be an empty shell -- and every field in it would have to guard
-    against a report that is not there yet. The button carries the wait
-    instead, where the user already clicked.
-
-    The error stays on the settings row for the same reason: a modal that opens
-    only to say it could not measure anything is a worse way to say it than a
-    line under the button.
-  */
-  const openStorage = async () => {
-    setStorageBusy(true)
-    setStorageError(null)
-    setStorageNote(null)
-    try {
-      setStorage(await InspectStorage())
-      setStorageOpen(true)
-    } catch (e) {
-      setStorageError(e instanceof Error ? e.message : String(e))
-    } finally {
-      setStorageBusy(false)
-    }
-  }
-
-  /*
-    Clears only the folders no analysis points at.
-
-    No confirmation, deliberately: nothing in the application can open these
-    files and no export includes them, so there is nothing for the user to
-    weigh. A dialog asking them to approve deleting something they cannot see
-    or reach would be theatre.
-  */
-  const purgeOrphans = async () => {
-    setStorageBusy(true)
-    setStorageError(null)
-    try {
-      const result = await PurgeOrphanedRunAssets()
-      setStorageNote(
-        `Cleared ${formatBytes(result.freed_bytes)} from ${result.removed} ${
-          result.removed === 1 ? "folder" : "folders"
-        }.`
-      )
-      setStorage(await InspectStorage())
-    } catch (e) {
-      setStorageError(e instanceof Error ? e.message : String(e))
-    } finally {
-      setStorageBusy(false)
     }
   }
 
@@ -848,22 +775,22 @@ export function ProfilePage({
               >
                 <button
                   type="button"
-                  disabled={storageBusy}
-                  onClick={() => void openStorage()}
+                  disabled={storage.busy}
+                  onClick={() => void storage.measureAndOpen()}
                   className={btnGhost}
                 >
-                  {storageBusy ? (
+                  {storage.busy ? (
                     <CircleNotch className="h-3 w-3 animate-spin" />
                   ) : (
                     <HardDrive className="h-3 w-3" />
                   )}
-                  {storage
-                    ? `${formatBytes(storage.total_bytes)} used`
+                  {storage.report
+                    ? `${formatBytes(storage.report.total_bytes)} used`
                     : "Measure storage"}
                 </button>
-                {storageError && (
+                {storage.problem && (
                   <p className="mt-2 text-body text-destructive-quiet">
-                    {storageError}
+                    {storage.problem}
                   </p>
                 )}
               </SettingRow>
@@ -1205,15 +1132,15 @@ export function ProfilePage({
       {/* Rendered only with a report in hand: openStorage measures first, so
           the dialog never has to guard against data that has not arrived. */}
       <AnimatePresence>
-        {storageOpen && storage && (
+        {storage.open && storage.report && (
           <StorageModal
-            report={storage}
-            busy={storageBusy}
-            note={storageNote}
-            problem={storageError}
-            onRefresh={() => void loadStorage()}
-            onPurge={() => void purgeOrphans()}
-            onClose={() => setStorageOpen(false)}
+            report={storage.report}
+            busy={storage.busy}
+            note={storage.note}
+            problem={storage.problem}
+            onRefresh={() => void storage.refresh()}
+            onPurge={() => void storage.purge()}
+            onClose={storage.close}
           />
         )}
       </AnimatePresence>


### PR DESCRIPTION
Four surfaces in the application could be reached exactly once and then never
again:

- the **splash** is shown while the window boots and then replaced;
- the **release notes** appear on the first launch after an upgrade and mark
  themselves seen;
- the **storage report** and the **Python environment** live inside the
  account page, a different screen from wherever the reader is working.

None of them is about what is on screen, so a per-screen home was never right.

## Where they go

Into the menu that already exists. The studio bar opens one at its left end,
and its own comment says what it is: *"the application menu, at the left end
where Blender puts File/Edit."* A second menu elsewhere would have been a second
answer to the question that menu exists to answer. The items sit below a rule,
because saving a studio and reading the version are different kinds of act.

```
Save studio
Reset this workspace
-------------------------
Splash screen
What's new in Cumulus
-------------------------
Python environment...
Storage...
-------------------------
About TERRA
```

Theme, sign-out and quit are deliberately absent: each already has a home, and
a second copy of a control is a second place for its state to be wrong.

## What the implementation required

- **The splash learns it is not always booting.** Shown on request it would
  have read "booting..." over a window open for an hour, since its status line
  is the last boot event. `live={false}` shows the tagline and does not
  subscribe to a stream that will not speak again.
- **The notes answer a different question from the upgrade gate's.** The gate
  wants everything since the last version seen; a reader asking deliberately
  wants what the running release *is*. `notesForVersion` is its own function,
  falls back to the newest entry for a build between tags, and its test
  separates the two spans on the case of a reader who skipped a version.
- **The storage report is a hook, not a second copy.** Measure-then-open clears
  a busy flag, a note and an error in order, and the account page held the only
  copy. Both callers now share `useStorageReport`; the account page lost thirty
  lines.

`useAppSurfaces` owns the rooms; `BoardSurface` draws the items with the menu's
own primitives, so there is one menu and one look.

## Verification

`tsc` clean, 391 tests (5 new), `check:contrast` clean, verified alone on
`main`. Confirmed in the running application.

Generated with [Claude Code](https://claude.com/claude-code)
