### PR TITLE
ci(release): a release cut by release-please gets its binaries

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,8 +12,13 @@
 # decision stops being "do the release procedure" and becomes "merge this or
 # not", which is a decision small enough to take on a Friday afternoon.
 #
-# Merging it tags the release, which is what release.yml already watches for.
-# Nothing about how binaries are built changes.
+# Merging it tags the release and creates the release page -- and then calls
+# release.yml to build and attach the binaries. It used to leave that to the
+# tag, on the reasoning that release.yml already watches for one. It does, and
+# it never sees this one: GitHub starts no workflow from an event made with the
+# repository's own token, which is the token this runs with. v0.5.0 was the
+# first release cut here and it went out with a page and no assets. The call
+# below runs inside this workflow's run, where that rule does not reach.
 
 name: Release please
 
@@ -29,8 +34,23 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  # Only on the run that merged the proposal. Every other push to main updates
+  # the proposal and cuts nothing, and release_created is false for it.
+  binaries:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,38 @@
 name: Release
 
+# Three ways in, one build.
+#
+# A TAG PUSHED BY A PERSON starts this directly, which is how v0.1.0 to v0.4.0
+# were built.
+#
+# A TAG CREATED BY release-please DOES NOT. GitHub does not start a workflow
+# from an event made with the repository's own GITHUB_TOKEN, which is the token
+# release-please runs with -- so merging the v0.5.0 proposal created the tag
+# and the release page and this workflow never ran. The page went out with no
+# assets at all, where v0.4.0 has six. release-please.yml therefore calls this
+# as a reusable workflow once it has cut a release, inside its own run, where
+# the token rule does not apply.
+#
+# BY HAND, for a tag that already exists: the way to put binaries on a release
+# that shipped without them. Nothing about the build depends on how it was
+# started; `inputs.tag` is empty only for the pushed tag, and every reference to
+# the tag below reads `inputs.tag || github.ref_name` for that reason.
 on:
   push:
     tags:
       - "v*"
+  workflow_call:
+    inputs:
+      tag:
+        description: The tag to build and publish, e.g. v0.6.0
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: The tag to build and publish, e.g. v0.5.0
+        required: true
+        type: string
 
 permissions:
   contents: write # needed to create the release and upload assets
@@ -60,7 +89,14 @@ jobs:
             arch: x86_64
 
     steps:
+      # The tag, not whatever the run was started from. Called from
+      # release-please the run belongs to main and a bare checkout would build
+      # main's tip -- the same commit today, but not a thing to rely on; started
+      # by hand it would build main for an older tag, which is the wrong binary
+      # under the right name.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -149,6 +185,7 @@ jobs:
       - name: Checkout for the code name
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.tag || github.ref }}
           sparse-checkout: frontend/src/lib/brand.ts
           sparse-checkout-cone-mode: false
 
@@ -169,16 +206,31 @@ jobs:
           path: dist
           merge-multiple: true
 
+      # APPENDED, NOT WRITTEN. When release-please cuts the release the page
+      # already carries its changelog -- the notes are taken from the proposal's
+      # body -- and this action's default is to replace a page's body with its
+      # own. Run after release-please, it would have swapped the changelog for
+      # an install table. So the table goes underneath, and GitHub's generated
+      # list is asked for only when nothing else wrote the page: a tag pushed by
+      # hand, where `inputs.tag` is empty.
+      #
+      # `make_latest: legacy` because this can now run for an older tag. Left
+      # to the API default, putting binaries on v0.5.0 after v0.6.0 is out
+      # would move "Latest" back to v0.5.0; legacy decides it by date and
+      # version, which is the question being asked.
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: dist/*
-          name: TERRA ${{ github.ref_name }} — ${{ steps.codename.outputs.name }}
-          generate_release_notes: true
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          name: TERRA ${{ inputs.tag || github.ref_name }} — ${{ steps.codename.outputs.name }}
+          append_body: true
+          generate_release_notes: ${{ inputs.tag == '' }}
+          make_latest: legacy
           draft: false
           prerelease: false
           body: |
-            ## TERRA ${{ github.ref_name }} — ${{ steps.codename.outputs.name }}
+            ## Installing
 
             Two install flavors per platform:
 


### PR DESCRIPTION
v0.5.0 was the first release cut by release-please, and its page has **no
assets**. v0.4.0 has six.

## Why

`release.yml` starts on a pushed `v*` tag. release-please creates its tag with
the repository's own `GITHUB_TOKEN`, and GitHub does not start a workflow from
an event made with that token. The four earlier tags were pushed by a person and
each has a `release.yml` run; v0.5.0 has none. That is also why its page is
titled `v0.5.0` rather than `TERRA v0.5.0 — Draugen`.

## What changes

- **`release-please.yml`** exposes `release_created` and `tag_name` and, on the
  run that merged the proposal, calls `release.yml` as a reusable workflow. The
  call happens inside the same run, so the token rule does not apply and no
  secret is needed. On every other push to main `release_created` is false and
  the build is skipped.
- **`release.yml`** keeps the pushed-tag trigger and adds `workflow_call` and
  `workflow_dispatch`, both taking a `tag`. Both checkouts use
  `inputs.tag || github.ref`, so a call from main builds the tag rather than
  main's tip, and a manual run for an older tag builds that tag.
- **The page is appended to, not overwritten.** `softprops/action-gh-release`
  replaces a release body by default, and release-please has already written the
  changelog there. `append_body: true` puts the install table underneath;
  GitHub's generated list is requested only for a pushed tag; `make_latest:
  legacy` keeps a later build of v0.5.0 from moving "Latest" back.

## Verification

`actionlint` 1.7.12 is clean on both files. The path this enables only runs
when a release is cut, so it is exercised for the first time by merging the
0.6.0 proposal (#71). The manual trigger can then put the missing binaries on
v0.5.0.

Generated with [Claude Code](https://claude.com/claude-code)
