### PR TITLE
fix(compose): every composition made over an area stays in its list

### DIFF
--- a/app_projects.go
+++ b/app_projects.go
@@ -99,7 +99,10 @@ type SaveProjectOverlayRequest struct {
 		scenes on the map produces one -- and those belong to the project
 		rather than to a run.
 	*/
-	RunID      string `json:"run_id"`
+	RunID string `json:"run_id"`
+	// The area the composition was made over, which is what files one that
+	// has no run. See store.ProjectOverlay.AreaID.
+	AreaID     string `json:"area_id"`
 	Kind       string `json:"kind"`
 	Title      string `json:"title"`
 	MetaJSON   string `json:"meta_json"`
@@ -170,6 +173,7 @@ func (a *App) SaveProjectOverlay(req SaveProjectOverlayRequest) (*store.ProjectO
 		ID:         overlayID,
 		ProjectID:  projectID,
 		RunID:      strings.TrimSpace(req.RunID),
+		AreaID:     strings.TrimSpace(req.AreaID),
 		Kind:       kind,
 		Title:      title,
 		MetaJSON:   meta,

--- a/app_projects_test.go
+++ b/app_projects_test.go
@@ -872,3 +872,35 @@ func TestProjectBindingsWithoutAStoreReturnAnError(t *testing.T) {
 		}
 	}
 }
+
+// A composition made over an area comes back filed under it.
+//
+// The binding took a run and no area, so a composition made with no run open
+// was filed only under the project, and the board -- which lists a run-less
+// composition only when it is the one on the map, unless it knows the area --
+// showed one composition per area however many had been made there.
+func TestProjectOverlaySaveFilesTheCompositionUnderItsArea(t *testing.T) {
+	a := newTestApp(t)
+	p := mustCreateProject(t, a, "Composition project")
+	png := []byte("\x89PNG\r\n\x1a\nan index composite")
+
+	row := mustSaveOverlay(t, a, SaveProjectOverlayRequest{
+		ProjectID:  p.ID,
+		AreaID:     "  area-compos  ",
+		OverlayURI: dataURI("image/png", png),
+	})
+	if row.AreaID != "area-compos" {
+		t.Fatalf("saved under area %q, want the trimmed %q", row.AreaID, "area-compos")
+	}
+	if row.RunID != "" {
+		t.Fatalf("a composition made with no run open reports run %q", row.RunID)
+	}
+
+	listed, err := a.ListProjectOverlays(p.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 1 || listed[0].AreaID != "area-compos" {
+		t.Fatalf("the list does not carry the area: %+v", listed)
+	}
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1751,6 +1751,14 @@ function AppBody(props: {
         presetId: meta.presetId,
         sceneDate,
         raster_tif: res.raster_tif,
+        /*
+          Both, as the saved row carries them. The entry in hand used to carry
+          neither, so the board could not tell it from a composition of another
+          field until the project was reopened -- and a composition with no run
+          made over this area was listed only while it was the one on the map.
+        */
+        runId: currentRunId ?? undefined,
+        areaId: props.activeAreaId,
       }
       setComposition(entry)
       setCompositionGallery((prev) => [entry, ...prev].slice(0, 12))
@@ -1774,6 +1782,8 @@ function AppBody(props: {
             // The run on screen, so this composition surfaces with that run
             // and not with every other run in the project.
             run_id: currentRunId ?? "",
+            // And the ground, which is what files one made with no run open.
+            area_id: props.activeAreaId ?? "",
             kind: "composition",
             title: meta.title,
             meta_json: metaJson,

--- a/frontend/src/lib/projectOverlays.ts
+++ b/frontend/src/lib/projectOverlays.ts
@@ -74,6 +74,7 @@ export function projectOverlayToComposition(
     sceneDate: meta.sceneDate,
     raster_tif: o.raster_tif,
     runId: o.run_id || undefined,
+    areaId: o.area_id || undefined,
   }
 }
 

--- a/frontend/src/lib/runAssets.test.ts
+++ b/frontend/src/lib/runAssets.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Which compositions an area lists, which is not the same as which the project
+ * holds.
+ *
+ * The rule had one clause for a composition with no run: list it if it is the
+ * one on the map. An area worked only by composition has no run, so every
+ * composition made over it has none either, and the list showed exactly one --
+ * each new composition replaced the last, though every one of them was saved.
+ * The fix is the area each was made over. These cases pin both halves: an
+ * area's own compositions are all listed, and another area's still are not.
+ */
+import { describe, expect, it } from "vitest"
+
+import { runAssets, type RunAssetInput } from "./runAssets"
+import type { CompositionOverlay } from "./types"
+
+const EXTENT = { lon_min: -48.47, lat_min: -10.74, lon_max: -48.45, lat_max: -10.71 }
+
+function comp(id: string, extra: Partial<CompositionOverlay> = {}): CompositionOverlay {
+  return {
+    id,
+    overlay_uri: `data:image/png;base64,${id}`,
+    extent: EXTENT,
+    opacity: 0.85,
+    title: id.toUpperCase(),
+    kind: "index",
+    index: id as CompositionOverlay["index"],
+    ...extra,
+  }
+}
+
+function listed(input: Partial<RunAssetInput>): string[] {
+  return runAssets({
+    result: null,
+    composition: null,
+    compositionGallery: [],
+    water: null,
+    showCompositionOverlay: true,
+    showWaterOverlay: false,
+    composeOpacity: 0.85,
+    waterOpacity: 0.85,
+    ...input,
+  }).map((a) => a.id)
+}
+
+describe("compositions listed under an area", () => {
+  it("lists every composition made over the area, not only the one on the map", () => {
+    const ndvi = comp("ndvi", { areaId: "area-a" })
+    const evi = comp("evi", { areaId: "area-a" })
+    // The newest is on the map, as it is right after applying it.
+    const ids = listed({
+      areaId: "area-a",
+      composition: evi,
+      compositionGallery: [evi, ndvi],
+    })
+    expect(ids).toContain("evi")
+    expect(ids).toContain("ndvi")
+  })
+
+  it("does not list another area's composition just because it covers this one", () => {
+    const here = comp("evi", { areaId: "area-a" })
+    const there = comp("ndvi", { areaId: "area-b" })
+    const ids = listed({
+      areaId: "area-a",
+      composition: here,
+      compositionGallery: [here, there],
+    })
+    expect(ids).toEqual(["evi"])
+  })
+
+  it("keeps a composition saved before the area was carried to the one on the map", () => {
+    const legacy = comp("savi")
+    const onMap = comp("evi", { areaId: "area-a" })
+    expect(listed({ areaId: "area-a", composition: onMap, compositionGallery: [onMap, legacy] }))
+      .toEqual(["evi"])
+    expect(listed({ areaId: "area-a", composition: legacy, compositionGallery: [onMap, legacy] }))
+      .toEqual(expect.arrayContaining(["evi", "savi"]))
+  })
+
+  it("lists a composition made under a run, which the scoping has already matched", () => {
+    const underRun = comp("ndwi", { runId: "run-1" })
+    expect(listed({ areaId: "area-a", compositionGallery: [underRun] })).toEqual(["ndwi"])
+  })
+
+  it("claims nothing when the caller names no area", () => {
+    const a = comp("ndvi", { areaId: "area-a" })
+    const b = comp("evi", { areaId: "area-a" })
+    expect(listed({ composition: b, compositionGallery: [b, a] })).toEqual(["evi"])
+  })
+})

--- a/frontend/src/lib/runAssets.ts
+++ b/frontend/src/lib/runAssets.ts
@@ -159,6 +159,8 @@ export interface RunAssetInput {
   result: PredictResult | null
   composition: CompositionOverlay | null
   compositionGallery: CompositionOverlay[]
+  /** The area these assets are listed under, which claims its own compositions. */
+  areaId?: string
   water: WaterAnalysis | null | undefined
   areaLabel?: string
   modelKind?: ModelKind
@@ -441,11 +443,21 @@ export function runAssets(i: RunAssetInput): RunAsset[] {
       that never produced one.
 
       One with a `runId` has already been filtered to this run by the scoping.
-      One without is the project's, and it earns a place here only by being the
-      composition actually on the map, which is the case this list exists to
-      report.
+      One without earns a place here by being the composition actually on the
+      map, or by having been made over this area.
+
+      THE SECOND CASE WAS MISSING, and it is the common one. An area worked
+      only by composition has no run, so every composition made over it has
+      none either, and the rule above listed exactly one of them: the one on
+      the map. Each new composition replaced the last in the list, though all
+      of them were saved. What it needed was the area each was made over,
+      which nothing recorded. Now the saved row and the entry in hand both
+      carry it, and a match is as good as a run -- while a composition of
+      another area, or one written before the area was carried, still needs to
+      be the one on the map to be listed.
     */
-    if (!item.runId && item.id !== i.composition?.id) continue
+    const ownArea = !!item.areaId && !!i.areaId && item.areaId === i.areaId
+    if (!item.runId && !ownArea && item.id !== i.composition?.id) continue
     const title = item.title || item.label || "Composition"
     const bandOrIndex =
       item.kind === "index" && item.index

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -690,6 +690,8 @@ export interface ProjectOverlay {
    * by their recorded extent instead.
    */
   run_id?: string
+  /** The area it was made over; empty on rows written before it was carried. */
+  area_id?: string
   kind: string
   title: string
   meta_json?: string
@@ -703,6 +705,8 @@ export interface ProjectOverlay {
 export interface SaveProjectOverlayRequest {
   /** The run on screen when the composition was made, when there was one. */
   run_id?: string
+  /** The area it was made over, which files a composition that has no run. */
+  area_id?: string
   project_id: string
   kind: string
   title: string
@@ -782,6 +786,11 @@ export interface CompositionOverlay {
   raster_tif?: string
   /** The run this was made under; empty for a project-level composition. */
   runId?: string
+  /**
+   * The area it was made over. What lets the board list every composition of
+   * an area that has no run, instead of only the one on the map.
+   */
+  areaId?: string
 }
 
 export type WaterIndex = "NDWI" | "MNDWI" | "AWEI"

--- a/frontend/src/pages/StudioScreen.tsx
+++ b/frontend/src/pages/StudioScreen.tsx
@@ -629,6 +629,7 @@ export function StudioScreen(props: StudioScreenProps) {
     result: props.result,
     composition: props.composition,
     compositionGallery: props.compositionGallery ?? [],
+    areaId: props.activeAreaId,
     water: props.water,
     areaLabel: props.areaLabel,
     modelKind: props.modelKind,

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -6857,6 +6857,7 @@ export namespace main {
 	export class SaveProjectOverlayRequest {
 	    project_id: string;
 	    run_id: string;
+	    area_id: string;
 	    kind: string;
 	    title: string;
 	    meta_json: string;
@@ -6871,6 +6872,7 @@ export namespace main {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.project_id = source["project_id"];
 	        this.run_id = source["run_id"];
+	        this.area_id = source["area_id"];
 	        this.kind = source["kind"];
 	        this.title = source["title"];
 	        this.meta_json = source["meta_json"];
@@ -7196,6 +7198,7 @@ export namespace store {
 	    id: string;
 	    project_id: string;
 	    run_id?: string;
+	    area_id?: string;
 	    kind: string;
 	    title: string;
 	    meta_json?: string;
@@ -7214,6 +7217,7 @@ export namespace store {
 	        this.id = source["id"];
 	        this.project_id = source["project_id"];
 	        this.run_id = source["run_id"];
+	        this.area_id = source["area_id"];
 	        this.kind = source["kind"];
 	        this.title = source["title"];
 	        this.meta_json = source["meta_json"];

--- a/internal/store/overlay_run_test.go
+++ b/internal/store/overlay_run_test.go
@@ -42,3 +42,43 @@ func TestOverlayCarriesItsRun(t *testing.T) {
 		t.Errorf("a composition made without a run reports %q", got["no run"])
 	}
 }
+
+// TestOverlayCarriesItsArea covers the column that files a composition made
+// with no run open. Without it an area worked only by composition could list
+// only the composition on the map, so each new one replaced the last.
+func TestOverlayCarriesItsArea(t *testing.T) {
+	s := openStoreIn(t, filepath.Join(t.TempDir(), "data"))
+	p, err := s.CreateProject(Project{UserID: LocalUserID, Name: "P"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, o := range []ProjectOverlay{
+		{ProjectID: p.ID, AreaID: "area-a", Title: "ndvi"},
+		{ProjectID: p.ID, AreaID: "area-a", Title: "evi"},
+		// Written before the area was carried: must read back as empty, so
+		// readers keep scoping it by extent rather than guessing an area.
+		{ProjectID: p.ID, Title: "legacy"},
+	} {
+		if _, err := s.AddProjectOverlay(LocalUserID, o); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rows, err := s.ListProjectOverlays(LocalUserID, p.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]string{}
+	for _, r := range rows {
+		got[r.Title] = r.AreaID
+	}
+	for _, title := range []string{"ndvi", "evi"} {
+		if got[title] != "area-a" {
+			t.Errorf("%s: area did not survive the round trip: %q", title, got[title])
+		}
+	}
+	if got["legacy"] != "" {
+		t.Errorf("a composition saved without an area reports %q", got["legacy"])
+	}
+}

--- a/internal/store/projects.go
+++ b/internal/store/projects.go
@@ -363,9 +363,9 @@ func (s *Store) AddProjectOverlay(userID string, o ProjectOverlay) (*ProjectOver
 	}
 	_, err := s.db.Exec(
 		`INSERT INTO project_overlays
-		 (id, project_id, run_id, kind, title, meta_json, png_relpath, tif_relpath, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		o.ID, o.ProjectID, nullIfEmpty(o.RunID), o.Kind, o.Title, o.MetaJSON,
+		 (id, project_id, run_id, area_id, kind, title, meta_json, png_relpath, tif_relpath, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		o.ID, o.ProjectID, nullIfEmpty(o.RunID), o.AreaID, o.Kind, o.Title, o.MetaJSON,
 		nullIfEmpty(o.PNGRelPath), nullIfEmpty(o.TIFRelPath), o.CreatedAt,
 	)
 	if err != nil {
@@ -384,7 +384,7 @@ func (s *Store) ListProjectOverlays(userID, projectID string) ([]ProjectOverlay,
 		return nil, err
 	}
 	rows, err := s.db.Query(
-		`SELECT id, project_id, COALESCE(run_id,''), kind, title, meta_json,
+		`SELECT id, project_id, COALESCE(run_id,''), COALESCE(area_id,''), kind, title, meta_json,
 		        COALESCE(png_relpath,''), COALESCE(tif_relpath,''), created_at
 		 FROM project_overlays WHERE project_id = ?
 		 ORDER BY created_at DESC`,
@@ -398,7 +398,7 @@ func (s *Store) ListProjectOverlays(userID, projectID string) ([]ProjectOverlay,
 	for rows.Next() {
 		var o ProjectOverlay
 		if err := rows.Scan(
-			&o.ID, &o.ProjectID, &o.RunID, &o.Kind, &o.Title, &o.MetaJSON,
+			&o.ID, &o.ProjectID, &o.RunID, &o.AreaID, &o.Kind, &o.Title, &o.MetaJSON,
 			&o.PNGRelPath, &o.TIFRelPath, &o.CreatedAt,
 		); err != nil {
 			return nil, err

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -160,7 +160,22 @@ type ProjectOverlay struct {
 		existed. Empty means "belongs to the project", not "belongs to no
 		project", so readers scope those by the recorded extent instead.
 	*/
-	RunID      string `json:"run_id,omitempty"`
+	RunID string `json:"run_id,omitempty"`
+	/*
+		The ground this composition was made over.
+
+		A composition made with no run open has no run to be filed under, and
+		the board listed those by one rule only -- "is it the composition on the
+		map" -- because nothing said which area they belonged to. So each new
+		composition on an area replaced the previous one in its list. The column
+		was already in the schema, and DeleteArea already deletes by it; nothing
+		wrote it.
+
+		Empty for rows written before it was carried. Those keep the project-level
+		behaviour, scoped by extent, rather than being assigned to an area by a
+		guess.
+	*/
+	AreaID     string `json:"area_id,omitempty"`
 	Kind       string `json:"kind"`
 	Title      string `json:"title"`
 	MetaJSON   string `json:"meta_json,omitempty"`


### PR DESCRIPTION
Applying a composition removed the previous one from the area's list. For
example, an NDVI and then an EVI left only the EVI. Every composition was
saved, one `INSERT` each in `project_overlays`, so nothing was lost from the
store, only from the list.

## Cause

`runAssets` lists a composition that has no run only when it is the one on the
map. The rule exists for a sound reason: a project's compositions can cover
several fields, and one that overlapped the drawn area was being attributed to
a run that never made it.

An area worked only through compositions has no run, so none of its
compositions has one either. The rule therefore listed exactly one of them,
and each new composition became the one on the map and pushed the previous one
out.

The missing piece was the area each composition was made over. The
`area_id` column already exists, and `DeleteArea` already deletes by it, but
nothing wrote it:

- the binding did not accept an area;
- the store's `INSERT` did not write it;
- the entry built in the frontend carried neither the area nor the run.

## Fix

- **Go:** `SaveProjectOverlayRequest` and `ProjectOverlay` now carry the area,
  and the store writes and reads it.
- **Frontend:** a new composition is created with its area and run.
  `runAssets` lists a composition without a run when it was made over the area
  being listed. A composition from another area, or one saved before this
  change, still appears only when it is the one on the map.
- Rows saved before this keep an empty area. They are not assigned one from
  their extent, because that is the guess the rule exists to avoid.

## Verification

- Tests cover all three layers: the store round-trip, the binding, and the
  listing rule. The listing test fails against the old rule on the reported
  case.
- Go: `gofmt`, `go vet`, `golangci-lint` (0 issues) and `go test -race` pass.
- Frontend: `tsc` passes, 397 tests pass, and `check:contrast` passes.
- Confirmed in the running application.
