### PR TITLE
fix(flood): the envelope's raster reaches the studio

### DIFF
--- a/frontend/src/components/studio/BoardSurface.tsx
+++ b/frontend/src/components/studio/BoardSurface.tsx
@@ -1749,6 +1749,8 @@ export function BoardSurface({
           composition: null,
           compositionGallery: [],
           water: r.result.water,
+          // A flood run's raster travels in its payload the same way.
+          flood: r.result.flood,
           solarTerrain: r.result.solar_terrain,
           solarSiting: r.result.solar_siting,
           showCompositionOverlay: false,
@@ -1784,6 +1786,7 @@ export function BoardSurface({
           in hand and the tree did not mention them.
         */
         water: result.water,
+        flood: result.flood,
         solarTerrain: result.solar_terrain,
         solarSiting: result.solar_siting,
         // A loaded run brings its own rasters and none of the map's state:

--- a/frontend/src/lib/runAssets.test.ts
+++ b/frontend/src/lib/runAssets.test.ts
@@ -12,7 +12,7 @@
 import { describe, expect, it } from "vitest"
 
 import { runAssets, type RunAssetInput } from "./runAssets"
-import type { CompositionOverlay } from "./types"
+import type { CompositionOverlay, FloodAnalysis } from "./types"
 
 const EXTENT = { lon_min: -48.47, lat_min: -10.74, lon_max: -48.45, lat_max: -10.71 }
 
@@ -86,5 +86,52 @@ describe("compositions listed under an area", () => {
     const a = comp("ndvi", { areaId: "area-a" })
     const b = comp("evi", { areaId: "area-a" })
     expect(listed({ composition: b, compositionGallery: [b, a] })).toEqual(["evi"])
+  })
+})
+
+describe("the flood envelope's raster", () => {
+  /*
+    The sidecar wrote it and the store kept it, and the board listed nothing:
+    this table had no flood row, so a finished flood run left a notification
+    and no raster to read. Pinned as a row with both exports.
+  */
+  const flood = {
+    agreement_uri: "data:image/png;base64,flood",
+    agreement_tif: "/data/runs/r1/flood_agreement.tif",
+    extent: EXTENT,
+    products: [{}, {}, {}, {}],
+    reference_threshold_m: 1,
+  } as unknown as FloodAnalysis
+
+  const base: RunAssetInput = {
+    result: null,
+    composition: null,
+    compositionGallery: [],
+    water: null,
+    showCompositionOverlay: false,
+    showWaterOverlay: false,
+    composeOpacity: 1,
+    waterOpacity: 1,
+  }
+
+  it("is listed under the layer name the map draws it by, with both exports", () => {
+    const a = runAssets({ ...base, flood, showFloodOverlay: true }).find(
+      (x) => x.id === "flood-agreement"
+    )
+    expect(a?.sceneId).toBe("flood")
+    expect(a?.params).toContain("4 DEMs")
+    expect(a?.onBoard).toBe(true)
+    expect(a?.exportTif).toEqual({
+      via: "file",
+      src: "/data/runs/r1/flood_agreement.tif",
+      filename: "terra_flood_agreement.tif",
+    })
+  })
+
+  it("is absent when the run carries no rendering to list", () => {
+    const bare = { ...flood, agreement_uri: "" } as FloodAnalysis
+    expect(runAssets({ ...base, flood: bare }).map((x) => x.id)).not.toContain(
+      "flood-agreement"
+    )
   })
 })

--- a/frontend/src/lib/runAssets.ts
+++ b/frontend/src/lib/runAssets.ts
@@ -33,6 +33,7 @@ import type {
   PredictResult,
   SolarSitingAnalysis,
   SolarTerrainAnalysis,
+  FloodAnalysis,
   WaterAnalysis,
 } from "@/lib/types"
 import { isZeroExtent, predictionSource } from "@/lib/mapLayers"
@@ -170,6 +171,14 @@ export interface RunAssetInput {
   showWaterOverlay: boolean
   composeOpacity: number
   waterOpacity: number
+  /**
+   * The flood envelope's agreement raster: how many elevation products call
+   * each cell flooded. Optional, like the solar pair, because most callers
+   * have no flood in hand.
+   */
+  flood?: FloodAnalysis | null
+  showFloodOverlay?: boolean
+  floodOpacity?: number
   /**
    * The two solar products that produce a raster.
    *
@@ -350,6 +359,45 @@ export function runAssets(i: RunAssetInput): RunAsset[] {
         filename: "terra_water_occurrence.png",
       },
       exportTif: null,
+    })
+  }
+
+  /*
+    THE FLOOD ENVELOPE'S RASTER, which this table did not list at all.
+
+    The sidecar writes it and the store keeps it -- flood_agreement.png beside
+    its GeoTIFF in every flood run's folder -- and lib/mapLayers.ts already
+    knew how to draw it. Nothing asked it to: this table had the
+    classification, water and the solar pair and no flood, so a flood run
+    finished with a notification and nothing on screen to read it by.
+
+    `sceneId` is `flood` because that is what lib/mapLayers.ts calls the layer.
+  */
+  const f = i.flood
+  if (f?.agreement_uri) {
+    out.push({
+      id: "flood-agreement",
+      sceneId: "flood",
+      title: "Flood agreement",
+      params: [
+        f.products?.length ? `${f.products.length} DEMs` : null,
+        `HAND ≤ ${f.reference_threshold_m} m`,
+        `opacity ${Math.round((i.floodOpacity ?? 1) * 100)}%`,
+      ]
+        .filter(Boolean)
+        .join(" · "),
+      previewUri: f.agreement_uri,
+      extent: placeable(f.extent),
+      // Counts of products, not a ramp between them: a blend of two counts
+      // names no count.
+      pixelated: true,
+      onBoard: i.showFloodOverlay ?? false,
+      selectId: null,
+      removeId: null,
+      exportPng: { src: f.agreement_uri, filename: "terra_flood_agreement.png" },
+      exportTif: f.agreement_tif
+        ? { via: "file", src: f.agreement_tif, filename: "terra_flood_agreement.tif" }
+        : null,
     })
   }
 

--- a/frontend/src/lib/studioWorkspaces.ts
+++ b/frontend/src/lib/studioWorkspaces.ts
@@ -23,7 +23,7 @@
  * 1000x700, so no preset is born with an area under its editor's own floor.
  */
 import type { Icon } from "@phosphor-icons/react"
-import { Cube, Database, Drop, GitDiff, Table, Tree, Waves } from "@phosphor-icons/react"
+import { Cube, Database, Drop, GitDiff, Mountains, Table, Tree, Waves } from "@phosphor-icons/react"
 
 import type { AreaNode } from "@/lib/boardAreas"
 import { type EditorId, type StudioGroup } from "@/lib/studioEditors"
@@ -213,6 +213,40 @@ export const STUDIO_WORKSPACES: readonly StudioWorkspace[] = [
           leaf("a-outliner", "outliner")
         ),
         col("w-data-right", 0.55, leaf("a-table", "table"), leaf("a-browser", "browser"))
+      ),
+  },
+  {
+    id: "envelope",
+    group: "water",
+    // Waves is Diagnose's and Drop is Routing's; HAND is read off terrain.
+    icon: Mountains,
+    label: "Flood envelope",
+    hint: "How far the elevation products disagree about what the area floods",
+    /*
+      THE ENVELOPE HAD A PANEL AND NO BOARD. The reading existed as an editor
+      type and no arrangement opened it -- the state the routing preset below
+      was written to end for its own product: a panel nobody can find without
+      already knowing it is there has not been added to the studio, only to
+      the type selector. A flood envelope run finished with a notification
+      and nothing on screen.
+
+      Routing's shape, for routing's reason: the agreement raster is an
+      overlay of the ground it was measured over, so the viewport takes the
+      width and the reading -- products, pairs, the envelope table -- stands in
+      a column. The column is 340x624 at the 1000x700 minimum, against the
+      320x256 the reading asks for.
+    */
+    build: () =>
+      row(
+        "w-envelope-split",
+        0.66,
+        col(
+          "w-envelope-left",
+          0.68,
+          leaf("a-viewport", "viewport"),
+          leaf("a-outliner", "outliner")
+        ),
+        leaf("a-flood", "floodReading")
       ),
   },
   {

--- a/frontend/src/pages/StudioScreen.tsx
+++ b/frontend/src/pages/StudioScreen.tsx
@@ -462,6 +462,15 @@ export function StudioScreen(props: StudioScreenProps) {
    * report figures, and the studio reads figures now: the Solar result editor
    * carries what the energy screen's reading column did.
    */
+  /*
+    The flood envelope's layer, held here because nothing above holds it.
+    Water and the solar pair answer to switches the map screen owns; flood
+    never had one, which is part of why its raster reached neither the board
+    nor the scene tree. Local rather than lifted: this is the only surface
+    that draws it.
+  */
+  const [showFloodOverlay, setShowFloodOverlay] = useState(true);
+  const [floodOpacity, setFloodOpacity] = useState(1);
   const [solarProduct, setSolarProduct] = useState<SolarProductId>("terrain");
   /*
     Which energy product the band is on, across all three families.
@@ -572,6 +581,10 @@ export function StudioScreen(props: StudioScreenProps) {
     water: props.water,
     showWaterOverlay: props.showWaterOverlay,
     waterOpacity: props.waterOpacity,
+    // The raster lib/mapLayers.ts could always draw and was never handed.
+    flood: props.floodResult,
+    showFloodOverlay,
+    floodOpacity,
     solarOverlays,
   });
 
@@ -646,6 +659,9 @@ export function StudioScreen(props: StudioScreenProps) {
     showSolarSiting: props.showSolarSiting,
     solarTerrainOpacity: props.solarTerrainOpacity,
     solarSitingOpacity: props.solarSitingOpacity,
+    flood: props.floodResult,
+    showFloodOverlay,
+    floodOpacity,
   });
 
   const changeBoardLayer = (
@@ -664,6 +680,12 @@ export function StudioScreen(props: StudioScreenProps) {
         props.onShowWaterOverlayChange(patch.visible);
       if (patch.opacity !== undefined)
         props.onWaterOpacityChange(patch.opacity);
+      return;
+    }
+    // Without this the flood row's eye would be a control that moves nothing.
+    if (id === "flood") {
+      if (patch.visible !== undefined) setShowFloodOverlay(patch.visible);
+      if (patch.opacity !== undefined) setFloodOpacity(patch.opacity);
       return;
     }
     if (id === "confidence") {


### PR DESCRIPTION
A flood envelope run finished with a notification and nothing else on screen.

The raster was made. Every flood run's folder holds `flood_agreement.png`
beside its GeoTIFF, and the store reads it back. What was missing was every
path the studio uses to show a result.

## What was missing, and what changed

- **Viewport.** `lib/mapLayers.ts` already knew how to draw the agreement
  raster, but the studio's call to `rasterLayers` passed the classification,
  the composition, water and solar, and not the flood. It now passes the flood,
  with its own visibility and opacity held in the studio, and
  `changeBoardLayer` has a flood case so the row's eye toggles the layer.
- **Scene tree.** `runAssets` listed the classification, water and the solar
  pair, and had no flood row. It now has one, named after the layer the map
  draws, with the PNG and the GeoTIFF as exports. Runs loaded from the store
  list their raster too, because it travels in the payload the same way water
  does.
- **Workspace.** The reading existed as a panel type, but no arrangement
  opened it. **Water → Flood envelope** now opens the viewport, the outliner
  and the reading, using Routing's layout for the same reason: the raster is
  an overlay of the ground it was measured over.

Only the default workspace is reached by position, and it is still the first,
so adding one before Routing does not shift anything bound to it.

## Verification

- `tsc` passes, 399 tests pass, and `check:contrast` passes.
- The listing test fails without the new row.
- Confirmed in the running application.
